### PR TITLE
docs(spec): Phase 2 — schema, I/O contracts, fixture, and test plan specs

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -9,6 +9,8 @@
 | 005 | ADEC | [005-AT-ADEC-llm-plans-not-dxf.md](005-AT-ADEC-llm-plans-not-dxf.md) |
 | 006 | ADEC | [006-AT-ADEC-ai-revision-notes.md](006-AT-ADEC-ai-revision-notes.md) |
 | 007 | ARCH | [007-AT-ARCH-v1-blueprint.md](007-AT-ARCH-v1-blueprint.md) |
+| 014 | SPEC | [014-AT-SPEC-pydantic-schema-specification.md](014-AT-SPEC-pydantic-schema-specification.md) |
+| 015 | SPEC | [015-AT-SPEC-dxf-reader-contract.md](015-AT-SPEC-dxf-reader-contract.md) |
 
 ### PP — Product & Planning
 | # | Type | File |
@@ -60,8 +62,10 @@
 | 011 | AA | AACR | OTel instrumentation AAR |
 | 012 | PM | PLAN | V1 ten-phase roadmap |
 | 013 | PM | TASK | Phase 2 schemas, DXF I/O, and test plan |
+| 014 | AT | SPEC | Pydantic data schema specification |
+| 015 | AT | SPEC | DXF reader contract |
 
 ## Quick Reference
 
 - **CC codes:** AT=Architecture, PP=Product, PM=Project Mgmt, DR=Documentation, TQ=Testing, BL=Business, AA=After Action
-- **Type codes:** ADEC=Decision, ARCH=Architecture, PROD=Product, TASK=Task, GUID=Guide, SECU=Security, POLI=Policy, AACR=After Action Review, PLAN=Roadmap
+- **Type codes:** ADEC=Decision, ARCH=Architecture, SPEC=Specification, PROD=Product, TASK=Task, GUID=Guide, SECU=Security, POLI=Policy, AACR=After Action Review, PLAN=Roadmap

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -11,6 +11,8 @@
 | 007 | ARCH | [007-AT-ARCH-v1-blueprint.md](007-AT-ARCH-v1-blueprint.md) |
 | 014 | SPEC | [014-AT-SPEC-pydantic-schema-specification.md](014-AT-SPEC-pydantic-schema-specification.md) |
 | 015 | SPEC | [015-AT-SPEC-dxf-reader-contract.md](015-AT-SPEC-dxf-reader-contract.md) |
+| 016 | SPEC | [016-AT-SPEC-dxf-writer-contract.md](016-AT-SPEC-dxf-writer-contract.md) |
+| 017 | SPEC | [017-AT-SPEC-fixture-strategy.md](017-AT-SPEC-fixture-strategy.md) |
 
 ### PP — Product & Planning
 | # | Type | File |
@@ -33,6 +35,7 @@
 | # | Type | File |
 |---|------|------|
 | 002 | SECU | [002-TQ-SECU-security-policy.md](002-TQ-SECU-security-policy.md) |
+| 018 | SPEC | [018-TQ-SPEC-unit-roundtrip-test-plan.md](018-TQ-SPEC-unit-roundtrip-test-plan.md) |
 
 ### BL — Business & Legal
 | # | Type | File |
@@ -64,6 +67,9 @@
 | 013 | PM | TASK | Phase 2 schemas, DXF I/O, and test plan |
 | 014 | AT | SPEC | Pydantic data schema specification |
 | 015 | AT | SPEC | DXF reader contract |
+| 016 | AT | SPEC | DXF writer contract |
+| 017 | AT | SPEC | Test fixture strategy |
+| 018 | TQ | SPEC | Unit and roundtrip test plan |
 
 ## Quick Reference
 

--- a/000-docs/014-AT-SPEC-pydantic-schema-specification.md
+++ b/000-docs/014-AT-SPEC-pydantic-schema-specification.md
@@ -84,7 +84,7 @@ Describes a layer's state and protection status.
 | `frozen` | `bool` | no | `False` | Whether the layer is frozen |
 | `color` | `int \| None` | no | `None` | AutoCAD color index (ACI) |
 
-**Protection resolution:** A layer is marked `protected=True` when its name (case-insensitive) matches any entry in `RuleConfig.protected_layers`.
+**Protection resolution:** A layer is marked `protected=True` by the reader when its name (case-insensitive) matches any entry in `settings.protected_layers` (loaded from the `CAD_PROTECTED_LAYERS` environment variable). The validator separately checks against the `RuleConfig.protected_layers` list passed by the caller. Both default to `["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]`.
 
 ---
 

--- a/000-docs/014-AT-SPEC-pydantic-schema-specification.md
+++ b/000-docs/014-AT-SPEC-pydantic-schema-specification.md
@@ -1,0 +1,313 @@
+# 014-AT-SPEC — Pydantic Data Schema Specification
+
+**Date:** 2026-02-20
+**Category:** AT (Architecture & Technical)
+**Type:** SPEC (Specification)
+**Beads task:** `cad-xoh.1`
+
+---
+
+## Purpose
+
+This document is the authoritative field-level specification for every Pydantic model used in the cad-dxf-agent pipeline. Phase 3 implementation must conform to these definitions. No code is written here — only specifications and behavioral contracts.
+
+---
+
+## Domain Models (`models/cad_schema.py`)
+
+### EntityType (StrEnum)
+
+Enumerates the V1-supported DXF entity types. Any value not in this enum is rejected at parse time.
+
+| Member | Value | DXF Meaning |
+|--------|-------|-------------|
+| `LINE` | `"LINE"` | Straight line segment between two points |
+| `LWPOLYLINE` | `"LWPOLYLINE"` | Lightweight polyline (2D, vertex list) |
+| `TEXT` | `"TEXT"` | Single-line text entity |
+| `MTEXT` | `"MTEXT"` | Multi-line / rich text entity |
+| `INSERT` | `"INSERT"` | Block reference insertion |
+
+**Strictness:** StrEnum inherently rejects unknown values with `ValueError`.
+
+---
+
+### Point2D (BaseModel)
+
+Represents a 2D coordinate. Used for entity positions, insertion points, and anchor points.
+
+| Field | Type | Required | Default | Constraints |
+|-------|------|----------|---------|-------------|
+| `x` | `float` | yes | — | Finite (no NaN/Inf) |
+| `y` | `float` | yes | — | Finite (no NaN/Inf) |
+
+**Notes:**
+- All coordinates in drawing units (typically inches or millimeters, determined by the DXF file)
+- Z coordinate is always 0 in V1 (2D only) and is not stored
+
+---
+
+### EntityRef (BaseModel)
+
+Normalized reference to a single DXF entity extracted by the reader.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `handle` | `str` | yes | — | DXF entity handle (hex string, unique within drawing) |
+| `entity_type` | `EntityType` | yes | — | One of the V1 entity types |
+| `layer` | `str` | yes | — | Layer name the entity belongs to |
+| `insert_point` | `Point2D \| None` | no | `None` | Primary position (start point for LINE, first vertex for LWPOLYLINE, insert for TEXT/MTEXT/INSERT) |
+| `text_content` | `str \| None` | no | `None` | Text payload (TEXT: `dxf.text`, MTEXT: plain text extraction) |
+| `block_name` | `str \| None` | no | `None` | Referenced block definition name (INSERT only) |
+| `attributes` | `dict[str, Any]` | no | `{}` | Extensible bag for future entity-specific properties |
+
+**Field population by entity type:**
+
+| Entity Type | `insert_point` | `text_content` | `block_name` |
+|-------------|----------------|----------------|--------------|
+| LINE | start point (`dxf.start`) | — | — |
+| LWPOLYLINE | first vertex | — | — |
+| TEXT | insert point (`dxf.insert`) | `dxf.text` | — |
+| MTEXT | insert point (`dxf.insert`) | plain text via `.text` | — |
+| INSERT | insert point (`dxf.insert`) | — | `dxf.name` |
+
+---
+
+### LayerRule (BaseModel)
+
+Describes a layer's state and protection status.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | `str` | yes | — | Layer name as stored in the DXF layer table |
+| `protected` | `bool` | no | `False` | Whether edits to entities on this layer are blocked |
+| `visible` | `bool` | no | `True` | Whether the layer is on (not off) |
+| `frozen` | `bool` | no | `False` | Whether the layer is frozen |
+| `color` | `int \| None` | no | `None` | AutoCAD color index (ACI) |
+
+**Protection resolution:** A layer is marked `protected=True` when its name (case-insensitive) matches any entry in `RuleConfig.protected_layers`.
+
+---
+
+### DrawingContext (BaseModel)
+
+Top-level model representing a fully loaded DXF drawing. This is the only object the planner and validator see — they never touch raw DXF.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `file_path` | `str` | yes | — | Absolute or relative path to the source DXF |
+| `entities` | `list[EntityRef]` | no | `[]` | All V1 entities from model space |
+| `layers` | `list[LayerRule]` | no | `[]` | Layer table with protection flags |
+| `blocks` | `list[str]` | no | `[]` | Named block definitions (excluding `*`-prefixed internal blocks) |
+| `unsupported_entity_types` | `list[str]` | no | `[]` | DXF types encountered but skipped (sorted, deduplicated) |
+| `metadata` | `dict[str, Any]` | no | `{}` | Drawing-level metadata (dxf_version, encoding) |
+
+**Computed properties:**
+- `entity_count: int` — `len(self.entities)`
+
+**Methods:**
+- `get_entity_by_handle(handle: str) -> EntityRef | None` — linear scan lookup
+- `get_protected_layers() -> list[str]` — filters `layers` where `protected=True`
+
+---
+
+## Operation Models (`models/ops_schema.py`)
+
+### OpType (StrEnum)
+
+Enumerates the V1-supported edit operations. Any value not in this enum is rejected at parse time.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `MOVE_ENTITY` | `"move_entity"` | Translate an entity by (dx, dy) |
+| `EDIT_TEXT` | `"edit_text"` | Replace text content on TEXT/MTEXT |
+| `DELETE_ENTITY` | `"delete_entity"` | Remove an entity from model space |
+| `ADD_BLOCK` | `"add_block"` | Insert an existing block definition |
+
+**Strictness:** StrEnum rejects unknown values with `ValueError`.
+
+---
+
+### EditOperation (BaseModel)
+
+A single structured edit instruction. The LLM planner returns these — never raw DXF commands.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `op_type` | `OpType` | yes | — | The operation to perform |
+| `target_handle` | `str \| None` | no | `None` | DXF handle of target entity (required for move/edit/delete) |
+| `target_layer` | `str \| None` | no | `None` | Layer for add_block insertion |
+| `params` | `dict[str, Any]` | no | `{}` | Operation-specific parameters |
+
+**Params contract per operation:**
+
+| Op Type | Required Params | Optional Params |
+|---------|----------------|-----------------|
+| `move_entity` | `dx: float`, `dy: float` | — |
+| `edit_text` | `new_text: str` | — |
+| `delete_entity` | _(none)_ | — |
+| `add_block` | `block_name: str`, `insert_point: {x: float, y: float}` | `scale: float` (default 1.0), `rotation: float` (default 0.0) |
+
+---
+
+### ChangeSet (BaseModel)
+
+A batch of operations produced by a single planner invocation.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `operations` | `list[EditOperation]` | no | `[]` | Ordered list of edits to apply |
+| `prompt` | `str` | no | `""` | Original user prompt that produced these operations |
+| `revision_label` | `str \| None` | no | `None` | Human label for this batch (used in revision notes) |
+
+**Computed properties:**
+- `op_count: int` — `len(self.operations)`
+
+---
+
+### AppliedChange (BaseModel)
+
+Post-execution record of a single operation.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `operation` | `EditOperation` | yes | — | The operation that was applied |
+| `success` | `bool` | no | `True` | Whether the operation succeeded |
+| `entity_handle` | `str \| None` | no | `None` | Handle of the affected entity (may differ from target for add_block) |
+| `description` | `str` | no | `""` | Human-readable summary of what happened |
+
+---
+
+## Validation Models (`models/changes_schema.py`)
+
+### Severity (StrEnum)
+
+| Member | Value | Effect |
+|--------|-------|--------|
+| `WARNING` | `"warning"` | Informational; does not prevent apply |
+| `BLOCKER` | `"blocker"` | Prevents the entire changeset from being applied |
+
+---
+
+### ValidationIssue (BaseModel)
+
+A single problem found during changeset validation.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `severity` | `Severity` | yes | — | Warning or blocker |
+| `message` | `str` | yes | — | Human-readable description of the issue |
+| `operation_index` | `int \| None` | no | `None` | Zero-based index of the offending operation |
+| `field` | `str \| None` | no | `None` | Specific field that caused the issue (if applicable) |
+
+---
+
+### ValidationResult (BaseModel)
+
+Aggregate result of validating an entire changeset.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `valid` | `bool` | no | `True` | False if any blocker exists |
+| `issues` | `list[ValidationIssue]` | no | `[]` | All issues found |
+
+**Computed properties:**
+- `blockers: list[ValidationIssue]` — issues with severity BLOCKER
+- `warnings: list[ValidationIssue]` — issues with severity WARNING
+
+**Methods:**
+- `add_blocker(message, operation_index=None)` — appends blocker and sets `valid=False`
+- `add_warning(message, operation_index=None)` — appends warning (does not affect `valid`)
+
+---
+
+## Configuration Models (`models/config_schema.py`)
+
+### RuleConfig (BaseModel)
+
+Controls validation behavior and layer protection.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `protected_layers` | `list[str]` | no | `["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]` | Layer names blocked from editing (case-insensitive match) |
+| `protected_blocks` | `list[str]` | no | `[]` | Block names blocked from deletion (reserved for future use) |
+| `max_move_distance` | `float \| None` | no | `None` | If set, moves exceeding this distance emit a warning |
+| `coordinate_tolerance` | `float` | no | `1e-6` | Tolerance for coordinate comparison |
+
+---
+
+### RevisionNoteConfig (BaseModel)
+
+Controls the deterministic revision note insertion.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | `bool` | no | `True` | Whether to insert revision notes after edits |
+| `layer_name` | `str` | no | `"AI_REV_NOTES"` | Target layer for notes |
+| `anchor_point` | `Point2D` | no | `(0.0, -50.0)` | Where to place the note text |
+| `text_height` | `float` | no | `2.5` | Text height in drawing units |
+| `prefix` | `str` | no | `"REV"` | Prefix for revision labels |
+| `revision_number` | `int` | no | `1` | Current revision counter |
+
+---
+
+## Strictness Rules
+
+### Unknown field rejection
+
+All models use Pydantic's default behavior where unknown fields passed to the constructor are silently ignored. For V1, this is acceptable because:
+- The LLM response is parsed through `response_parser.py` which extracts only known fields
+- Schema-level validation catches type mismatches and missing required fields
+- The validator catches invalid op types and missing params
+
+If stricter rejection is needed in a future phase, models can add:
+```python
+model_config = ConfigDict(extra="forbid")
+```
+
+### Invalid operation type rejection
+
+`OpType` is a `StrEnum`. Constructing an `EditOperation` with an invalid `op_type` string raises `ValueError` at parse time. This is enforced by Pydantic's enum validation — no additional code is needed.
+
+### Invalid entity type rejection
+
+`EntityType` is a `StrEnum`. Constructing an `EntityRef` with an invalid `entity_type` string raises `ValueError` at parse time.
+
+---
+
+## Error Behavior
+
+### LLM returns invalid JSON
+
+The `response_parser.py` module wraps `json.loads()` and `ChangeSet.model_validate()`. If either fails, the entire response is rejected with a parse error. No partial changeset is created.
+
+### LLM returns unsupported operation type
+
+Pydantic rejects the `EditOperation` construction when `op_type` is not a valid `OpType` member. The entire changeset is rejected.
+
+### LLM returns valid ops targeting nonexistent entities
+
+Validation passes at the schema level (the operation is well-formed). The validator catches this during `validate_changeset()` and adds a BLOCKER. The changeset is not applied.
+
+### LLM returns ops targeting protected layers
+
+The validator checks entity layers against `RuleConfig.protected_layers` (case-insensitive). A BLOCKER is added and the changeset is not applied.
+
+### Changeset has mixed valid and invalid ops
+
+If any operation produces a BLOCKER, the entire changeset is rejected. Partial application never occurs. This is the atomic batch guarantee.
+
+---
+
+## Entity Index (`core/entity_index.py`)
+
+The `EntityIndex` is not a Pydantic model but is a critical data structure built from `DrawingContext`:
+
+| Lookup | Method | Return |
+|--------|--------|--------|
+| By handle | `get_by_handle(handle: str)` | `EntityRef \| None` |
+| By layer | `get_by_layer(layer: str)` | `list[EntityRef]` (case-insensitive) |
+| By type | `get_by_type(entity_type: EntityType)` | `list[EntityRef]` |
+| All handles | `handles()` | `list[str]` |
+| Total count | `count` (property) | `int` |
+
+The index is built once per `DrawingContext` and used by the validator for O(1) handle lookups.

--- a/000-docs/015-AT-SPEC-dxf-reader-contract.md
+++ b/000-docs/015-AT-SPEC-dxf-reader-contract.md
@@ -1,0 +1,215 @@
+# 015-AT-SPEC — DXF Reader Contract
+
+**Date:** 2026-02-20
+**Category:** AT (Architecture & Technical)
+**Type:** SPEC (Specification)
+**Beads task:** `cad-xoh.2`
+**Depends on:** `cad-xoh.1` (schema specification, doc 014)
+
+---
+
+## Purpose
+
+This document defines the complete I/O contract for `core/dxf_reader.py`. It specifies what the reader accepts, what it returns, how it handles each V1 entity type, how entities are identified, and what happens when the DXF contains content outside V1 scope.
+
+---
+
+## Module Interface
+
+### `load_dxf(file_path: str | Path) -> DrawingContext`
+
+The sole public function. Loads a DXF file from disk and returns a fully populated `DrawingContext`.
+
+---
+
+## I/O Contract
+
+### Input
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `file_path` | `str \| Path` | Path to a DXF file on disk. Converted to `Path` internally. |
+
+**Preconditions:**
+- The file must exist on disk
+- The file must be a valid DXF readable by ezdxf
+- No specific DXF version requirement (ezdxf handles R12 through R2018+)
+
+### Output
+
+| Return | Type | Description |
+|--------|------|-------------|
+| context | `DrawingContext` | Fully populated context with entities, layers, blocks, metadata |
+
+**Postconditions:**
+- `context.file_path` is the string representation of the input path
+- `context.entities` contains one `EntityRef` for every model-space entity of a V1 type
+- `context.layers` contains one `LayerRule` for every layer in the DXF layer table
+- `context.blocks` contains the names of all user-defined blocks (excluding `*`-prefixed internal blocks)
+- `context.unsupported_entity_types` lists any non-V1 entity types found (sorted, deduplicated)
+- `context.metadata` contains `dxf_version` and `encoding`
+
+### Errors
+
+| Condition | Exception | Message Pattern |
+|-----------|-----------|-----------------|
+| File does not exist | `FileNotFoundError` | `"DXF file not found: {path}"` |
+| File is corrupt / not valid DXF | `ezdxf.DXFError` (or subclass) | Propagated from ezdxf — not caught by the reader |
+
+The reader does not catch ezdxf parse errors. A corrupt DXF propagates naturally and the caller (planner or UI) handles the exception.
+
+---
+
+## Entity Extraction
+
+### Scope
+
+Only model-space entities are processed. Paper space, layout tabs, and entities inside block definitions are ignored.
+
+### V1 Entity Types and Extracted Fields
+
+#### LINE
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `handle` | `entity.dxf.handle` | Hex string, unique within drawing |
+| `entity_type` | `EntityType.LINE` | — |
+| `layer` | `entity.dxf.layer` | Layer name |
+| `insert_point` | `entity.dxf.start` → `Point2D(x, y)` | Start point of the line |
+| `text_content` | — | Always `None` |
+| `block_name` | — | Always `None` |
+
+#### LWPOLYLINE
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `handle` | `entity.dxf.handle` | Hex string |
+| `entity_type` | `EntityType.LWPOLYLINE` | — |
+| `layer` | `entity.dxf.layer` | Layer name |
+| `insert_point` | `entity.get_points("xy")[0]` → `Point2D(x, y)` | First vertex of the polyline |
+| `text_content` | — | Always `None` |
+| `block_name` | — | Always `None` |
+
+**Edge case:** If the polyline has zero vertices, `insert_point` is `None`.
+
+#### TEXT
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `handle` | `entity.dxf.handle` | Hex string |
+| `entity_type` | `EntityType.TEXT` | — |
+| `layer` | `entity.dxf.layer` | Layer name |
+| `insert_point` | `entity.dxf.insert` → `Point2D(x, y)` | Insertion point |
+| `text_content` | `entity.dxf.text` | Single-line text content |
+| `block_name` | — | Always `None` |
+
+#### MTEXT
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `handle` | `entity.dxf.handle` | Hex string |
+| `entity_type` | `EntityType.MTEXT` | — |
+| `layer` | `entity.dxf.layer` | Layer name |
+| `insert_point` | `entity.dxf.insert` → `Point2D(x, y)` | Insertion point |
+| `text_content` | `entity.text` (property) | Plain text with formatting stripped by ezdxf |
+| `block_name` | — | Always `None` |
+
+**Note:** `entity.text` on MTEXT returns plain text. `entity.dxf.text` would return raw MTEXT formatting codes. The reader uses the plain-text property.
+
+#### INSERT
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `handle` | `entity.dxf.handle` | Hex string |
+| `entity_type` | `EntityType.INSERT` | — |
+| `layer` | `entity.dxf.layer` | Layer name |
+| `insert_point` | `entity.dxf.insert` → `Point2D(x, y)` | Block insertion point |
+| `text_content` | — | Always `None` |
+| `block_name` | `entity.dxf.name` | Name of the referenced block definition |
+
+---
+
+## ID Strategy
+
+### DXF Handles
+
+Entities are identified by their DXF handle (`entity.dxf.handle`), which is:
+
+- A hexadecimal string (e.g., `"1A"`, `"2F5"`)
+- Unique within a single DXF file
+- Assigned by ezdxf during file creation or load
+- Stable across read/write cycles (ezdxf preserves handles on save)
+- Not reused within the same document after deletion
+
+### Why not custom IDs?
+
+DXF handles are the native identity mechanism. Custom UUIDs or sequential IDs would add a mapping layer with no benefit. The handle is the canonical reference throughout the pipeline: the planner returns handles, the validator looks up handles, and the edit engine resolves handles.
+
+---
+
+## Layer Resolution
+
+The reader builds `LayerRule` objects from the DXF layer table:
+
+| Field | Source | Logic |
+|-------|--------|-------|
+| `name` | `layer.dxf.name` | Raw layer name from the table |
+| `protected` | settings comparison | `True` if `name.upper()` matches any `settings.protected_layers` entry (case-insensitive) |
+| `visible` | `layer.is_off()` | `True` if the layer is not off |
+| `frozen` | `layer.is_frozen()` | Direct boolean |
+| `color` | `layer.color` | AutoCAD color index |
+
+**Protected layer matching:** The comparison is case-insensitive. Both `"Title"` and `"TITLE"` match the protected layer `"TITLE"`.
+
+---
+
+## Block Discovery
+
+The reader collects block names from `doc.blocks`, filtering out internal blocks:
+
+```
+blocks = [block.name for block in doc.blocks if not block.name.startswith("*")]
+```
+
+Internal blocks (like `*Model_Space`, `*Paper_Space`) are excluded. Only user-defined block definitions are listed. The block geometry itself is not extracted — only the name is recorded for reference by INSERT entities.
+
+---
+
+## Unsupported Entity Handling
+
+When the reader encounters an entity whose `dxftype()` is not in the `SUPPORTED_TYPES` set:
+
+1. The entity type string is added to a `set` (deduplicated)
+2. The entity is skipped — no `EntityRef` is created
+3. After iteration, the set is sorted and stored in `context.unsupported_entity_types`
+4. A log message is emitted at INFO level: `"Skipped unsupported entity types: CIRCLE, DIMENSION"`
+
+**Guarantees:**
+- No exception is raised for unsupported entities
+- The reader never fails due to unknown entity types
+- The caller can inspect `unsupported_entity_types` to understand what was skipped
+
+---
+
+## Metadata
+
+The reader populates `context.metadata` with:
+
+| Key | Source | Example |
+|-----|--------|---------|
+| `dxf_version` | `doc.dxfversion` | `"AC1032"` (R2018) |
+| `encoding` | `doc.encoding` | `"utf-8"` |
+
+---
+
+## Observability
+
+The reader emits an OpenTelemetry span `cad.load_dxf` with attributes:
+
+| Attribute | Value |
+|-----------|-------|
+| `cad.file.name` | Basename of the input file (no directory path for privacy) |
+| `cad.entities.count` | Number of extracted entities |
+| `cad.layers.count` | Number of layers |
+
+When OTel is disabled (default), these calls are no-ops via `_NoOpSpan`.

--- a/000-docs/015-AT-SPEC-dxf-reader-contract.md
+++ b/000-docs/015-AT-SPEC-dxf-reader-contract.md
@@ -86,7 +86,7 @@ Only model-space entities are processed. Paper space, layout tabs, and entities 
 | `handle` | `entity.dxf.handle` | Hex string |
 | `entity_type` | `EntityType.LWPOLYLINE` | — |
 | `layer` | `entity.dxf.layer` | Layer name |
-| `insert_point` | `entity.get_points("xy")[0]` → `Point2D(x, y)` | First vertex of the polyline |
+| `insert_point` | `entity.get_points(format="xy")[0]` → `Point2D(x, y)` | First vertex of the polyline |
 | `text_content` | — | Always `None` |
 | `block_name` | — | Always `None` |
 

--- a/000-docs/016-AT-SPEC-dxf-writer-contract.md
+++ b/000-docs/016-AT-SPEC-dxf-writer-contract.md
@@ -1,0 +1,233 @@
+# 016-AT-SPEC — DXF Writer Contract
+
+**Date:** 2026-02-20
+**Category:** AT (Architecture & Technical)
+**Type:** SPEC (Specification)
+**Beads task:** `cad-xoh.3`
+**Depends on:** `cad-xoh.2` (reader contract, doc 015)
+
+---
+
+## Purpose
+
+This document defines the complete I/O contract for `core/dxf_writer.py` and the save path in `core/edit_engine.py`. It specifies what the writer accepts, what it produces, its safety guarantees, and the precise definition of "roundtrip success."
+
+---
+
+## Module Interface
+
+### `save_as_new_dxf(source_path, output_path) -> Path`
+
+Standalone save function. Reads a DXF from `source_path`, writes it to `output_path`. Used for copy-without-edits scenarios.
+
+### `copy_dxf_for_editing(source_path, work_path) -> Path`
+
+Copies a DXF file to a working location via `shutil.copy2`. Used internally to stage a file before in-memory editing.
+
+### `EditEngine.save(output_path) -> Path`
+
+Saves the in-memory ezdxf document (after operations have been applied) to `output_path`. This is the primary save path for the editing pipeline.
+
+---
+
+## I/O Contract — `save_as_new_dxf`
+
+### Input
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_path` | `str \| Path` | Path to the source DXF file on disk |
+| `output_path` | `str \| Path` | Path where the new DXF will be written |
+
+**Preconditions:**
+- `source_path` must exist and be a valid DXF readable by ezdxf
+- `output_path` must differ from `source_path` (resolved absolute comparison)
+
+### Output
+
+| Return | Type | Description |
+|--------|------|-------------|
+| path | `Path` | The resolved output path where the file was written |
+
+### Errors
+
+| Condition | Exception | Message Pattern |
+|-----------|-----------|-----------------|
+| Output path equals source path | `ValueError` | `"Output path must differ from source path (save-as workflow)."` |
+| Source file does not exist | `FileNotFoundError` | Propagated from ezdxf |
+| Source file is corrupt DXF | `ezdxf.DXFError` | Propagated from ezdxf |
+
+### Side Effects
+
+- Creates parent directories for `output_path` if they do not exist (`mkdir(parents=True, exist_ok=True)`)
+- Writes a new DXF file to disk at `output_path`
+- Logs the output path at INFO level
+
+---
+
+## I/O Contract — `copy_dxf_for_editing`
+
+### Input
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_path` | `str \| Path` | Path to the source DXF file |
+| `work_path` | `str \| Path` | Path for the working copy |
+
+### Output
+
+| Return | Type | Description |
+|--------|------|-------------|
+| path | `Path` | The resolved work path |
+
+### Errors
+
+| Condition | Exception | Message Pattern |
+|-----------|-----------|-----------------|
+| Work path equals source path | `ValueError` | `"Work path must differ from source path."` |
+| Source file does not exist | `FileNotFoundError` | Propagated from `shutil.copy2` |
+
+### Side Effects
+
+- Creates parent directories for `work_path`
+- Copies the file via `shutil.copy2` (preserves metadata)
+
+---
+
+## I/O Contract — `EditEngine.save`
+
+### Input
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `output_path` | `str \| Path` | Path where the edited DXF will be saved |
+
+### Output
+
+| Return | Type | Description |
+|--------|------|-------------|
+| path | `Path` | The resolved output path |
+
+### Behavior
+
+- Creates parent directories if needed
+- Calls `ezdxf.document.Drawing.saveas()` on the in-memory document
+- Emits an OTel span `cad.save` with attribute `cad.save.output_basename`
+- Logs the output path at INFO level
+
+### Relationship to `save_as_new_dxf`
+
+| Function | When to Use |
+|----------|-------------|
+| `EditEngine.save()` | After applying operations through the pipeline (primary path) |
+| `save_as_new_dxf()` | Copying a DXF without modifications (utility path) |
+
+Both paths enforce the save-as guarantee: the original file is never overwritten.
+
+---
+
+## Save-As Behavior
+
+### Path constraint
+
+The output path must differ from the input/source path. This is enforced by:
+- `save_as_new_dxf`: explicit `ValueError` if `output_path.resolve() == source_path.resolve()`
+- `EditEngine.save`: not enforced at the method level (caller is responsible), but the pipeline convention is that output is always a new path
+
+### Directory creation
+
+Both `save_as_new_dxf` and `EditEngine.save` create parent directories automatically:
+
+```python
+output_path.parent.mkdir(parents=True, exist_ok=True)
+```
+
+This means the caller does not need to pre-create output directories.
+
+### File naming convention
+
+No specific naming convention is enforced. The caller provides the full output path. The smoke test uses the pattern `{stem}_edited.dxf`. The UI or API layer is responsible for generating user-friendly output names.
+
+---
+
+## Preservation Guarantees
+
+### Original file integrity
+
+The source DXF file is never modified by any writer function. Evidence:
+
+1. `save_as_new_dxf` reads the source via `ezdxf.readfile()` (read-only), then writes to a different path
+2. `copy_dxf_for_editing` uses `shutil.copy2` (read-only on source)
+3. `EditEngine.__init__` reads via `ezdxf.readfile()` (read-only), all mutations happen in memory, `save()` writes to a new path
+
+**Testable assertion:** After the full pipeline runs (load → edit → save), the source file must be byte-identical to its state before the pipeline started.
+
+### Non-targeted entity preservation
+
+Entities that are not targeted by any operation in the changeset remain unchanged in the output DXF. The edit engine only modifies entities explicitly referenced by handle in the operations. ezdxf preserves all other entities, layers, blocks, and metadata during `saveas()`.
+
+**Testable assertion:** Load the output DXF, iterate all entities not targeted by operations, and verify their handles, positions, text content, and layer assignments are identical to the original.
+
+### Layer table preservation
+
+The layer table (names, colors, frozen/off states) is preserved in its entirety. The edit engine does not add, remove, or modify layers. The revision notes module may create the `AI_REV_NOTES` layer if it does not exist, but all other layers remain untouched.
+
+### Block definitions preservation
+
+All block definitions present in the source DXF are preserved in the output. The edit engine does not modify block definitions. `add_block` operations insert block references but do not alter the definitions themselves.
+
+---
+
+## Roundtrip Definition
+
+### What "roundtrip" means
+
+A roundtrip test verifies that loading a DXF and immediately saving it (with no edits) produces an output that, when reloaded, yields an identical `DrawingContext`.
+
+### Formal definition
+
+Given:
+1. `ctx_a = load_dxf(source_path)` — load the original
+2. `save_as_new_dxf(source_path, output_path)` — save without edits
+3. `ctx_b = load_dxf(output_path)` — reload the output
+
+Then:
+- `len(ctx_a.entities) == len(ctx_b.entities)` — entity count preserved
+- For each entity `a` in `ctx_a.entities`, there exists an entity `b` in `ctx_b.entities` where:
+  - `a.handle == b.handle` — handle preserved
+  - `a.entity_type == b.entity_type` — type preserved
+  - `a.layer == b.layer` — layer preserved
+  - `a.insert_point == b.insert_point` (within coordinate tolerance) — position preserved
+  - `a.text_content == b.text_content` — text preserved
+  - `a.block_name == b.block_name` — block reference preserved
+- `set(ctx_a.blocks) == set(ctx_b.blocks)` — block definitions preserved
+- `len(ctx_a.layers) == len(ctx_b.layers)` — layer count preserved
+- For each layer `la` in `ctx_a.layers`, there exists a layer `lb` in `ctx_b.layers` where:
+  - `la.name == lb.name`
+  - `la.protected == lb.protected`
+  - `la.visible == lb.visible`
+  - `la.frozen == lb.frozen`
+  - `la.color == lb.color`
+- `ctx_a.metadata["dxf_version"] == ctx_b.metadata["dxf_version"]` — version preserved
+
+### What roundtrip does NOT guarantee
+
+- **Byte-identical output:** The output DXF is not guaranteed to be byte-identical to the source. ezdxf may reorder internal structures, normalize whitespace, or update header fields. The roundtrip guarantee is at the `DrawingContext` semantic level, not the byte level.
+- **Unsupported entity types:** Entities of non-V1 types (CIRCLE, ARC, DIMENSION, etc.) are preserved in the DXF file by ezdxf, but they are not tracked in `DrawingContext`. The roundtrip test only verifies V1 entities.
+- **`file_path` field:** This will differ between `ctx_a` and `ctx_b` because they were loaded from different files. It is excluded from comparison.
+
+---
+
+## Observability
+
+### `EditEngine.save`
+
+Emits an OTel span `cad.save` with:
+
+| Attribute | Value |
+|-----------|-------|
+| `cad.save.output_basename` | Filename only (no directory path) |
+
+### `save_as_new_dxf`
+
+No OTel span currently emitted. If tracing is added in a future phase, use span name `cad.save_as_copy`.

--- a/000-docs/017-AT-SPEC-fixture-strategy.md
+++ b/000-docs/017-AT-SPEC-fixture-strategy.md
@@ -1,0 +1,166 @@
+# 017-AT-SPEC — Test Fixture Strategy
+
+**Date:** 2026-02-20
+**Category:** AT (Architecture & Technical)
+**Type:** SPEC (Specification)
+**Beads task:** `cad-xoh.4`
+**Depends on:** `cad-xoh.1` (schema specification, doc 014)
+
+---
+
+## Purpose
+
+This document specifies how test fixtures are created, what they contain, where they live, and what determinism guarantees they provide. All DXF fixtures are generated programmatically at test time — no binary DXF files are committed to the repository.
+
+---
+
+## Fixture Creation Approach
+
+### Programmatic generation
+
+All DXF fixtures are created in-process using `ezdxf.new()`. This avoids:
+- Binary files in version control (DXF files are opaque to git diff)
+- Stale fixtures that drift from the schema specification
+- Platform-specific line ending issues
+
+### DXF version
+
+All fixtures use `ezdxf.new(dxfversion="R2018")`. R2018 (AC1032) is the target version for V1. Pinning the version eliminates variation across runs and ensures consistent handle assignment.
+
+### Fixture lifecycle
+
+1. Pytest calls the fixture function
+2. The function creates an ezdxf document in memory
+3. Entities, layers, and blocks are added programmatically
+4. The document is saved to a `tmp_path` directory (pytest-managed, auto-cleaned)
+5. The file path is returned to the test
+
+No fixture files persist after the test session.
+
+---
+
+## Required Fixture Content
+
+### Primary fixture: `sample_dxf`
+
+The main fixture creates a DXF with comprehensive coverage of all V1 entity types, layers, and blocks.
+
+#### Layers
+
+| Layer Name | Color | Protected | Purpose |
+|------------|-------|-----------|---------|
+| `0` | — | no | Default layer (created by ezdxf automatically) |
+| `STRUCTURAL` | 1 (red) | no | Editable geometry layer |
+| `NOTES` | 3 (green) | no | Editable text layer |
+| `TITLE` | 7 (white) | yes | Protected — title text |
+| `TITLEBLOCK` | 7 (white) | yes | Protected — title block geometry |
+| `SEAL` | 7 (white) | yes | Protected — seal/stamp area |
+| `REVISION` | 7 (white) | yes | Protected — revision history |
+
+#### Entities
+
+| # | Type | Layer | Key Properties | Purpose |
+|---|------|-------|----------------|---------|
+| 1 | LINE | STRUCTURAL | start=(0,0), end=(100,0) | Basic geometry, move/delete target |
+| 2 | LWPOLYLINE | STRUCTURAL | 4 vertices, closed rectangle | Multi-vertex geometry |
+| 3 | TEXT | NOTES | text="Column C-4", insert=(10,10) | Editable text, edit_text target |
+| 4 | MTEXT | NOTES | text="Footing detail note", insert=(20,20) | Multi-line text target |
+| 5 | TEXT | TITLE | text="PROJECT TITLE", insert=(0,-20) | Protected layer entity — validator must block |
+| 6 | INSERT | STRUCTURAL | block="COLUMN_MARK", insert=(25,25) | Block reference |
+
+#### Block Definitions
+
+| Block Name | Content | Purpose |
+|------------|---------|---------|
+| `COLUMN_MARK` | Circle at origin, radius=2 | Minimal block for INSERT testing |
+
+### Entity count expectations
+
+The `sample_dxf` fixture produces exactly **6 entities** of V1 types in model space. Tests that assert entity counts must use this number.
+
+### Handle stability
+
+ezdxf assigns handles sequentially starting from a deterministic base when creating a new document. As long as entities are added in the same order with the same parameters, handles are identical across runs. Tests may assert specific handle values if needed, but testing by entity type and layer is preferred for resilience.
+
+---
+
+## Derived Fixtures
+
+### `sample_context`
+
+Loads `sample_dxf` through `load_dxf()` and returns the resulting `DrawingContext`. This fixture depends on `sample_dxf` and exercises the reader contract (doc 015).
+
+**Expected postconditions:**
+- `context.entity_count == 6`
+- Entity types present: LINE, LWPOLYLINE, TEXT (x2), MTEXT, INSERT
+- Layers present: 0, STRUCTURAL, NOTES, TITLE, TITLEBLOCK, SEAL, REVISION
+- Protected layers: TITLE, TITLEBLOCK, SEAL, REVISION
+- Blocks: `COLUMN_MARK`
+- `unsupported_entity_types` is empty (only V1 types in the fixture)
+- `metadata["dxf_version"]` is `"AC1032"` (R2018)
+
+### `rule_config`
+
+Returns a default `RuleConfig()` with factory defaults:
+- `protected_layers`: `["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]`
+- `protected_blocks`: `[]`
+- `max_move_distance`: `None`
+- `coordinate_tolerance`: `1e-6`
+
+---
+
+## Fixture Location
+
+| Fixture | Location | Scope |
+|---------|----------|-------|
+| `sample_dxf` | `tests/conftest.py` | Session or function (currently function) |
+| `sample_context` | `tests/conftest.py` | Function (depends on `sample_dxf`) |
+| `rule_config` | `tests/conftest.py` | Function |
+
+All shared fixtures live in `tests/conftest.py`. If test-specific fixtures become necessary (e.g., a DXF with only protected-layer entities, or a DXF with unsupported entity types), they should be defined in the relevant test module, not in conftest.
+
+Helper functions for DXF generation (if they grow complex) may be extracted to `tests/helpers.py`, imported by both conftest and individual test modules.
+
+---
+
+## Determinism Requirements
+
+### Entity count
+
+The primary fixture must produce the same number of entities every time. This is guaranteed by the programmatic creation approach — no external data sources, no randomness, no conditional entity creation.
+
+### Handle assignment
+
+ezdxf assigns handles deterministically within a new document. The sequence depends on:
+1. The order entities are added to model space
+2. The order blocks and layers are created
+
+As long as the fixture code does not change, handles are stable. Tests should prefer looking up entities by type or layer rather than by exact handle value, to tolerate minor fixture refactors.
+
+### Coordinate precision
+
+All coordinates in fixtures use integer or simple float values (e.g., `0`, `100`, `10.0`, `25.0`). This avoids floating-point representation issues and ensures exact equality in assertions.
+
+### No random data
+
+Fixtures must not use `random`, `uuid`, timestamps, or any non-deterministic source. Every property of every entity is explicitly specified.
+
+### DXF version pinned
+
+Always `ezdxf.new(dxfversion="R2018")`. Never use `ezdxf.new()` without specifying the version, as the default may change across ezdxf releases.
+
+---
+
+## Future Fixture Needs
+
+As Phases 3-10 are implemented, additional fixtures may be needed:
+
+| Scenario | Phase | Notes |
+|----------|-------|-------|
+| DXF with unsupported entity types (CIRCLE, ARC) | 3 | Test reader skipping behavior |
+| DXF with zero entities | 3 | Edge case for empty model space |
+| DXF with entities on default layer (0) only | 4 | Validator edge case |
+| DXF with duplicate block names | 6 | Edit engine edge case |
+| DXF from older DXF versions (R12, R2000) | 3 | Compatibility testing |
+
+These are documented here for awareness but are not part of the Phase 2 deliverable. They should be added as test needs arise.

--- a/000-docs/018-TQ-SPEC-unit-roundtrip-test-plan.md
+++ b/000-docs/018-TQ-SPEC-unit-roundtrip-test-plan.md
@@ -1,0 +1,233 @@
+# 018-TQ-SPEC — Unit and Roundtrip Test Plan
+
+**Date:** 2026-02-20
+**Category:** TQ (Testing & Quality)
+**Type:** SPEC (Specification)
+**Beads task:** `cad-xoh.5`
+**Depends on:** `cad-xoh.2` (reader, doc 015), `cad-xoh.3` (writer, doc 016), `cad-xoh.4` (fixtures, doc 017)
+
+---
+
+## Purpose
+
+This document defines the complete test matrix, CI expectations, and coverage targets for Phases 3-4. Every test scenario is listed with its inputs, expected outcome, and the spec it validates. Implementation of these tests happens in Phase 3 (reader/schema tests) and Phase 4 (validator tests).
+
+---
+
+## Test Matrix
+
+### 1. Schema Tests
+
+Target module: `models/cad_schema.py`, `models/ops_schema.py`, `models/config_schema.py`, `models/changes_schema.py`
+Spec reference: doc 014
+
+| ID | Scenario | Input | Expected Outcome |
+|----|----------|-------|------------------|
+| S-01 | Valid EntityRef construction | All required fields with valid EntityType | Model created successfully |
+| S-02 | Invalid entity type rejected | `entity_type="CIRCLE"` | `ValueError` raised by StrEnum |
+| S-03 | Valid OpType construction | Each of the 4 valid op types | Model created successfully |
+| S-04 | Invalid op type rejected | `op_type="rotate_entity"` | `ValueError` raised by StrEnum |
+| S-05 | Missing required field (handle) | `EntityRef(entity_type="LINE", layer="0")` | `ValidationError` — handle is required |
+| S-06 | Optional fields default correctly | `EntityRef(handle="1A", entity_type="LINE", layer="0")` | `insert_point=None`, `text_content=None`, `block_name=None`, `attributes={}` |
+| S-07 | Point2D construction | `Point2D(x=10.0, y=20.0)` | Model created with correct values |
+| S-08 | DrawingContext entity_count | Context with 3 entities | `entity_count == 3` |
+| S-09 | DrawingContext get_entity_by_handle | Known handle | Returns correct EntityRef |
+| S-10 | DrawingContext get_entity_by_handle miss | Unknown handle | Returns `None` |
+| S-11 | DrawingContext get_protected_layers | Layers with mixed protected flags | Returns only protected layer names |
+| S-12 | ValidationResult add_blocker | Call `add_blocker("msg", 0)` | `valid=False`, blocker in issues |
+| S-13 | ValidationResult add_warning | Call `add_warning("msg", 0)` | `valid=True` (unchanged), warning in issues |
+| S-14 | ValidationResult blockers/warnings separation | Mix of blockers and warnings | `.blockers` returns only blockers, `.warnings` returns only warnings |
+| S-15 | ChangeSet op_count | ChangeSet with 3 operations | `op_count == 3` |
+| S-16 | RuleConfig defaults | `RuleConfig()` | Protected layers are TITLE, TITLEBLOCK, SEAL, REVISION |
+| S-17 | Severity enum values | `Severity.WARNING`, `Severity.BLOCKER` | Values are `"warning"`, `"blocker"` |
+
+### 2. Reader Tests
+
+Target module: `core/dxf_reader.py`
+Spec reference: doc 015
+Fixture: `sample_dxf`, `sample_context`
+
+| ID | Scenario | Input | Expected Outcome |
+|----|----------|-------|------------------|
+| R-01 | Load succeeds on valid DXF | `sample_dxf` path | Returns `DrawingContext` without error |
+| R-02 | Entity count matches fixture | `sample_context` | `entity_count == 6` |
+| R-03 | All V1 entity types present | `sample_context` | LINE, LWPOLYLINE, TEXT, MTEXT, INSERT all found |
+| R-04 | Correct layer assignments | `sample_context` | LINE on STRUCTURAL, TEXT on NOTES and TITLE |
+| R-05 | Protected layers marked | `sample_context` | TITLE, TITLEBLOCK, SEAL, REVISION have `protected=True` |
+| R-06 | Editable layers not protected | `sample_context` | STRUCTURAL, NOTES have `protected=False` |
+| R-07 | Blocks discovered | `sample_context` | `"COLUMN_MARK"` in `context.blocks` |
+| R-08 | Internal blocks excluded | `sample_context` | No `*`-prefixed block names in `context.blocks` |
+| R-09 | Metadata populated | `sample_context` | `metadata["dxf_version"]` is `"AC1032"`, `metadata["encoding"]` is `"utf-8"` |
+| R-10 | FileNotFoundError for missing file | Non-existent path | `FileNotFoundError` raised |
+| R-11 | Unsupported entities skipped | DXF with a CIRCLE added | CIRCLE not in entities, `"CIRCLE"` in `unsupported_entity_types` |
+| R-12 | TEXT entity fields extracted | TEXT entity from `sample_context` | `text_content == "Column C-4"`, `insert_point` is `(10, 10)` |
+| R-13 | MTEXT entity fields extracted | MTEXT entity from `sample_context` | `text_content == "Footing detail note"`, `insert_point` is `(20, 20)` |
+| R-14 | INSERT entity fields extracted | INSERT entity from `sample_context` | `block_name == "COLUMN_MARK"`, `insert_point` is `(25, 25)` |
+| R-15 | LINE entity fields extracted | LINE entity from `sample_context` | `insert_point` is `(0, 0)` (start point) |
+| R-16 | LWPOLYLINE entity fields extracted | LWPOLYLINE entity from `sample_context` | `insert_point` is `(0, 0)` (first vertex) |
+
+### 3. Writer Tests
+
+Target module: `core/dxf_writer.py`, `core/edit_engine.py`
+Spec reference: doc 016
+Fixture: `sample_dxf`
+
+| ID | Scenario | Input | Expected Outcome |
+|----|----------|-------|------------------|
+| W-01 | Save produces valid DXF | `sample_dxf` → `save_as_new_dxf` | Output file loadable by `ezdxf.readfile()` |
+| W-02 | Roundtrip preserves entity count | Load → save → reload | Entity count identical |
+| W-03 | Roundtrip preserves entity handles | Load → save → reload | All handles present in reloaded context |
+| W-04 | Roundtrip preserves layer table | Load → save → reload | Layer names, protected flags, colors identical |
+| W-05 | Roundtrip preserves blocks | Load → save → reload | Block names identical |
+| W-06 | Roundtrip preserves text content | Load → save → reload | TEXT and MTEXT content identical |
+| W-07 | Roundtrip preserves metadata | Load → save → reload | `dxf_version` identical |
+| W-08 | Original file untouched after save | Read source bytes → save_as → re-read source bytes | Bytes identical |
+| W-09 | Same path rejected | `save_as_new_dxf(path, path)` | `ValueError` raised |
+| W-10 | Parent directory created | Output path with non-existent parent | Directory created, file written |
+
+### 4. Entity Index Tests
+
+Target module: `core/entity_index.py`
+Spec reference: doc 014 (entity index section)
+Fixture: `sample_context`
+
+| ID | Scenario | Input | Expected Outcome |
+|----|----------|-------|------------------|
+| I-01 | Lookup by handle succeeds | Known handle from `sample_context` | Returns correct `EntityRef` |
+| I-02 | Lookup by handle miss | Handle `"FFFFF"` | Returns `None` |
+| I-03 | Lookup by layer returns correct subset | Layer `"STRUCTURAL"` | Returns LINE, LWPOLYLINE, INSERT |
+| I-04 | Lookup by layer case-insensitive | Layer `"structural"` | Returns same entities as `"STRUCTURAL"` |
+| I-05 | Lookup by type | `EntityType.TEXT` | Returns both TEXT entities |
+| I-06 | Handles list complete | `sample_context` | Length matches entity count |
+| I-07 | Count property | `sample_context` | `count == 6` |
+
+### 5. Validator Tests (Phase 4)
+
+Target module: `core/validators.py`
+Spec reference: doc 014 (error behavior section)
+Fixture: `sample_context`, `rule_config`
+
+| ID | Scenario | Input | Expected Outcome |
+|----|----------|-------|------------------|
+| V-01 | Valid move operation passes | move_entity on STRUCTURAL entity | `valid=True`, no blockers |
+| V-02 | Protected layer blocked | move_entity targeting TITLE entity | `valid=False`, blocker message |
+| V-03 | Missing target_handle blocked | move_entity with no handle | `valid=False`, blocker |
+| V-04 | Nonexistent entity blocked | move_entity targeting handle `"FFFFF"` | `valid=False`, blocker |
+| V-05 | move_entity missing dx/dy blocked | move with empty params | `valid=False`, blocker |
+| V-06 | move_entity NaN dx blocked | `dx=float('nan')` | `valid=False`, blocker |
+| V-07 | move_entity Inf dy blocked | `dy=float('inf')` | `valid=False`, blocker |
+| V-08 | move_entity non-numeric dx blocked | `dx="ten"` | `valid=False`, blocker |
+| V-09 | Max move distance warning | Move exceeding `max_move_distance` | `valid=True`, warning present |
+| V-10 | edit_text missing new_text blocked | edit_text with empty params | `valid=False`, blocker |
+| V-11 | edit_text non-string blocked | `new_text=42` | `valid=False`, blocker |
+| V-12 | add_block missing block_name blocked | add_block with no block_name | `valid=False`, blocker |
+| V-13 | add_block missing insert_point blocked | add_block with no insert_point | `valid=False`, blocker |
+| V-14 | add_block on protected layer blocked | `target_layer="TITLE"` | `valid=False`, blocker |
+| V-15 | Valid delete passes | delete_entity on editable entity | `valid=True` |
+| V-16 | Mixed valid/invalid ops | Batch with one valid, one blocked | `valid=False` (entire batch rejected) |
+
+---
+
+## CI Expectations
+
+### Environment constraints
+
+| Constraint | Requirement |
+|------------|-------------|
+| API keys | No API keys required — all tests use mock planner |
+| Network | No network calls — no OTLP exporter, no external APIs |
+| File system | Tests use `tmp_path` (auto-cleaned by pytest) |
+| Platform | Must pass on Ubuntu and Windows |
+| Python versions | Must pass on 3.11 and 3.12 |
+
+### CI matrix (from `.github/workflows/ci.yml`)
+
+```
+os: [ubuntu-latest, windows-latest]
+python-version: ["3.11", "3.12"]
+```
+
+Total: 4 combinations. All must pass for a PR to merge.
+
+### Test duration
+
+Target: total test suite completes in under 30 seconds on CI runners. Individual tests should complete in under 1 second. The `@pytest.mark.slow` marker is available for tests that legitimately take longer (e.g., large DXF generation).
+
+### Test isolation
+
+Each test function must be independent. No shared mutable state between tests. Fixtures that create DXF files use `tmp_path` (function-scoped by default) for isolation.
+
+---
+
+## Coverage Targets
+
+| Phase | Target | Rationale |
+|-------|--------|-----------|
+| Phase 3 | 50% line coverage | `fail_under = 50` in `pyproject.toml`. Covers schemas + reader + writer + entity index |
+| Phase 4 | 65% line coverage | Adding validator tests significantly increases coverage |
+| Post-Phase 4 | 100% path coverage on `validators.py` | Validators are safety-critical — every code path must be tested |
+
+### What counts toward coverage
+
+- All files under `src/cad_dxf_agent/` are measured
+- Test files themselves are excluded from coverage measurement
+- The `otel.py` module's graceful-degradation branches (import errors) are difficult to cover in the same process — these are excluded from the 100% path target
+
+### Coverage enforcement
+
+```bash
+make test-cov   # pytest --cov=cad_dxf_agent --cov-report=term-missing -v
+```
+
+CI runs `pytest -v` (without coverage) for speed. Coverage is checked locally and in the `make check` workflow.
+
+---
+
+## Roundtrip Test — Concrete Definition
+
+This test directly implements the roundtrip definition from doc 016.
+
+### Test procedure
+
+```
+1. Create DXF via sample_dxf fixture → source_path
+2. ctx_a = load_dxf(source_path)
+3. save_as_new_dxf(source_path, output_path)
+4. ctx_b = load_dxf(output_path)
+5. Assert ctx_a and ctx_b are semantically equal
+```
+
+### Assertions (in order)
+
+1. `ctx_a.entity_count == ctx_b.entity_count`
+2. For each entity pair (matched by handle):
+   - `a.entity_type == b.entity_type`
+   - `a.layer == b.layer`
+   - `a.insert_point.x ≈ b.insert_point.x` (within `1e-6`)
+   - `a.insert_point.y ≈ b.insert_point.y` (within `1e-6`)
+   - `a.text_content == b.text_content`
+   - `a.block_name == b.block_name`
+3. `set(ctx_a.blocks) == set(ctx_b.blocks)`
+4. Layer table match (name, protected, visible, frozen, color)
+5. `ctx_a.metadata["dxf_version"] == ctx_b.metadata["dxf_version"]`
+
+### Excluded from comparison
+
+- `file_path` (different files by definition)
+- `encoding` (ezdxf may normalize)
+- `unsupported_entity_types` (fixture has none, but this is informational)
+
+---
+
+## Test File Organization
+
+| File | Contents | Phase |
+|------|----------|-------|
+| `tests/conftest.py` | Shared fixtures: `sample_dxf`, `sample_context`, `rule_config` | 1 (exists) |
+| `tests/unit/test_schemas.py` | S-01 through S-17 | 3 |
+| `tests/unit/test_reader.py` | R-01 through R-16 | 3 |
+| `tests/unit/test_writer.py` | W-01 through W-10 | 3 |
+| `tests/unit/test_entity_index.py` | I-01 through I-07 | 3 |
+| `tests/unit/test_validators.py` | V-01 through V-16 | 4 |
+| `tests/smoke/test_e2e_mock.py` | Full pipeline smoke test | 1 (exists) |
+| `tests/unit/test_otel.py` | OTel span emission tests | 1 (exists) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/cad_dxf_agent/
 ### Data Models (Pydantic)
 
 - `DrawingContext` — normalized view of a loaded DXF (entities, layers, blocks, metadata)
-- `EntityRef` — single entity with handle, type, layer, position, text content
+- `EntityRef` — single entity with handle, type, layer, position, text content, block name, attributes
 - `EditOperation` — one op with `OpType`, target handle, layer, params dict
 - `ChangeSet` — batch of operations from a single prompt
 - `ValidationResult` — blockers (prevent apply) and warnings (informational)


### PR DESCRIPTION
## Summary

- Pydantic schema specification (014) — field-level spec for all 14 domain models with strictness rules and error behavior
- DXF reader contract (015) — I/O contract, per-entity extraction tables, ID strategy, unsupported entity handling
- DXF writer contract (016) — save-as guarantees, preservation guarantees, formal roundtrip definition
- Test fixture strategy (017) — programmatic DXF generation, determinism requirements, fixture content spec
- Unit and roundtrip test plan (018) — 56 test scenarios, CI expectations, coverage targets
- Consistency fixes from systems engineer + architect review agents (index, spec accuracy, CLAUDE.md)

Closes Phase 2 epic `cad-xoh` with all 5 child tasks delivered.

## Test plan

- No code changes — all deliverables are specification documents
- Existing CI (lint, typecheck, tests) unaffected
- `make check` passes (no source files modified except CLAUDE.md description fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for DXF reader and writer operations, including contract details, error handling, and observability requirements.
  * Expanded data model documentation with additional fields for entity references.
  * Introduced test fixture strategy and unit/roundtrip testing plans.
  * Updated documentation index with new specification entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->