### PR TITLE
feat(v2): Gemini vision pipeline on Vertex AI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ draw = [
     "matplotlib>=3.8",
     "Pillow>=10.0",
 ]
+gemini = [
+    "google-cloud-aiplatform>=1.38",
+    "Pillow>=10.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
@@ -90,7 +94,7 @@ disallow_untyped_defs = false
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "matplotlib.*", "fpdf.*"]
+module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "matplotlib.*", "fpdf.*", "google.*", "vertexai.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/cad_dxf_agent/llm/gemini_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_provider.py
@@ -1,0 +1,186 @@
+"""Gemini planner provider — Vertex AI multimodal vision pipeline.
+
+Uses Gemini 1.5 Pro on Vertex AI for hybrid vision planning:
+  1. DXF entity JSON (precise coordinates, handles, layers)
+  2. PNG render of the drawing (visual layout context)
+  3. User prompt
+
+Gemini returns a ChangeSet JSON validated by Pydantic.
+Retries once on validation failure with error feedback.
+Falls back to MockProvider if Gemini is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..models.ops_schema import ChangeSet
+from ..otel import get_tracer
+from ..settings import settings
+from .prompt_templates import SYSTEM_PROMPT, format_planner_prompt
+from .providers import PlannerProvider
+from .response_parser import parse_planner_response
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+
+class GeminiProvider(PlannerProvider):
+    """Gemini 1.5 Pro on Vertex AI — multimodal CAD planner.
+
+    Sends drawing context (JSON + optional PNG) to Gemini and
+    parses the structured ChangeSet response.
+    """
+
+    def __init__(
+        self,
+        project: str | None = None,
+        location: str | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        self._project = project or settings.gcp_project
+        self._location = location or settings.gcp_location
+        self._model_name = model_name or settings.gemini_model
+        self._max_retries = settings.gemini_max_retries
+        self._model: Any = None  # lazy init
+
+    @property
+    def name(self) -> str:
+        return f"gemini ({self._model_name})"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False  # Uses GCP credentials, not API key
+
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        image_path: str | Path | None = None,
+    ) -> ChangeSet:
+        """Generate a ChangeSet from prompt + drawing context + optional image.
+
+        Args:
+            prompt: User's natural-language edit request.
+            drawing_context: JSON-serializable drawing context.
+            image_path: Optional path to a PNG render of the drawing.
+
+        Returns:
+            Validated ChangeSet with structured operations.
+        """
+        with tracer.start_as_current_span("cad.gemini_plan") as span:
+            span.set_attribute("cad.gemini.model", self._model_name)
+            span.set_attribute("cad.gemini.has_image", image_path is not None)
+
+            model = self._get_model()
+            contents = self._build_contents(prompt, drawing_context, image_path)
+
+            # First attempt
+            raw_response = self._call_gemini(model, contents)
+            span.set_attribute("cad.gemini.response_length", len(raw_response))
+
+            try:
+                changeset = parse_planner_response(raw_response, prompt)
+                span.set_attribute("cad.ops.count", changeset.op_count)
+                return changeset
+            except ValueError as e:
+                logger.warning("Gemini response validation failed: %s", e)
+
+                if self._max_retries < 1:
+                    raise
+
+                # Retry with error feedback
+                span.add_event("gemini_retry", {"error": str(e)})
+                retry_text = (
+                    f"\nYour previous response was invalid:\n"
+                    f"Response: {raw_response[:500]}\n"
+                    f"Error: {e}\n\n"
+                    f"Please fix and return valid JSON matching the operations schema."
+                )
+                retry_contents = contents + [retry_text]
+                raw_retry = self._call_gemini(model, retry_contents)
+
+                changeset = parse_planner_response(raw_retry, prompt)
+                span.set_attribute("cad.ops.count", changeset.op_count)
+                span.set_attribute("cad.gemini.retried", True)
+                return changeset
+
+    def _get_model(self):
+        """Lazy-initialize the Gemini model."""
+        if self._model is None:
+            try:
+                import vertexai  # type: ignore[import-untyped]
+                from vertexai.generative_models import (
+                    GenerativeModel,  # type: ignore[import-untyped]
+                )
+
+                vertexai.init(
+                    project=self._project,
+                    location=self._location,
+                )
+                self._model = GenerativeModel(
+                    self._model_name,
+                    system_instruction=SYSTEM_PROMPT,
+                )
+            except ImportError as err:
+                raise ImportError(
+                    "google-cloud-aiplatform not installed. "
+                    "Install with: pip install google-cloud-aiplatform"
+                ) from err
+            except Exception as e:
+                raise RuntimeError(f"Failed to initialize Gemini: {e}") from e
+
+        return self._model
+
+    def _build_contents(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        image_path: str | Path | None,
+    ) -> list:
+        """Build the content list for Gemini.
+
+        For real Gemini calls, content includes Part objects.
+        For mocked tests, content is simple strings.
+        """
+        parts: list = []
+
+        # Add drawing image if available (vision pipeline)
+        if image_path is not None:
+            img_path = Path(image_path)
+            if img_path.exists():
+                try:
+                    from vertexai.generative_models import (  # type: ignore[import-untyped]
+                        Image,
+                        Part,
+                    )
+
+                    image = Image.load_from_file(str(img_path))
+                    parts.append(Part.from_image(image))
+                    logger.info("Including drawing image: %s", img_path.name)
+                except ImportError:
+                    logger.warning("Cannot include image: vertexai not installed")
+
+        # Add the text prompt with drawing context
+        context_json = json.dumps(drawing_context, indent=2, default=str)
+        text_prompt = format_planner_prompt(prompt, context_json)
+        parts.append(text_prompt)
+
+        return parts
+
+    def _call_gemini(self, model, contents: list) -> str:
+        """Call Gemini and return the text response.
+
+        The model.generate_content() method accepts either Part objects
+        or plain strings, so this works with both real SDK and mocks.
+        """
+        response = model.generate_content(contents)
+
+        text = response.text if hasattr(response, "text") else str(response)
+        if not text:
+            raise ValueError("Gemini returned empty response")
+
+        return text

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -24,9 +24,17 @@ def get_provider(provider_name: str | None = None) -> PlannerProvider:
     if name == "mock":
         return MockProvider()
 
-    # Future: add real providers here
-    # elif name == "openai": return OpenAIProvider(...)
-    # elif name == "anthropic": return AnthropicProvider(...)
+    if name in ("gemini", "google", "vertex"):
+        try:
+            from .gemini_provider import GeminiProvider
+
+            return GeminiProvider()
+        except ImportError:
+            logger.warning(
+                "google-cloud-aiplatform not installed, falling back to mock. "
+                "Install with: pip install google-cloud-aiplatform"
+            )
+            return MockProvider()
 
     logger.warning("Unknown provider '%s', falling back to mock", name)
     return MockProvider()

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -48,6 +48,12 @@ class Settings:
         self.render_dpi: int = int(os.getenv("CAD_RENDER_DPI", "150"))
         self.render_background: str = os.getenv("CAD_RENDER_BACKGROUND", "white")
 
+        # Gemini / Vertex AI (V2)
+        self.gcp_project: str | None = os.getenv("CAD_GCP_PROJECT")
+        self.gcp_location: str = os.getenv("CAD_GCP_LOCATION", "us-central1")
+        self.gemini_model: str = os.getenv("CAD_GEMINI_MODEL", "gemini-1.5-pro")
+        self.gemini_max_retries: int = int(os.getenv("CAD_GEMINI_MAX_RETRIES", "1"))
+
         # Local API
         self.api_host: str = os.getenv("CAD_API_HOST", "127.0.0.1")
         self.api_port: int = int(os.getenv("CAD_API_PORT", "8321"))

--- a/tests/unit/test_gemini_provider.py
+++ b/tests/unit/test_gemini_provider.py
@@ -1,0 +1,232 @@
+"""Tests for the Gemini vision pipeline planner provider.
+
+All tests mock the Vertex AI SDK — no real API calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+from cad_dxf_agent.llm.planner import get_provider
+from cad_dxf_agent.models.ops_schema import OpType
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def valid_changeset_json():
+    """Valid ChangeSet JSON that Gemini would return."""
+    return json.dumps(
+        {
+            "operations": [
+                {
+                    "op_type": "move_entity",
+                    "target_handle": "ABC",
+                    "target_layer": "STRUCTURAL",
+                    "params": {"dx": 10.0, "dy": 5.0},
+                }
+            ],
+            "revision_label": "Moved column east by 10 units",
+        }
+    )
+
+
+@pytest.fixture
+def multi_op_changeset_json():
+    """ChangeSet JSON with multiple operations."""
+    return json.dumps(
+        {
+            "operations": [
+                {
+                    "op_type": "move_entity",
+                    "target_handle": "A1",
+                    "params": {"dx": 5.0, "dy": 0.0},
+                },
+                {
+                    "op_type": "edit_text",
+                    "target_handle": "B2",
+                    "params": {"new_text": "Updated Note"},
+                },
+                {
+                    "op_type": "delete_entity",
+                    "target_handle": "C3",
+                },
+            ],
+            "revision_label": "Multiple edits",
+        }
+    )
+
+
+@pytest.fixture
+def sample_drawing_context():
+    """Minimal drawing context dict."""
+    return {
+        "entities": [
+            {
+                "handle": "ABC",
+                "type": "LINE",
+                "layer": "STRUCTURAL",
+                "insert_point": {"x": 0, "y": 0},
+            },
+            {
+                "handle": "DEF",
+                "type": "TEXT",
+                "layer": "NOTES",
+                "insert_point": {"x": 10, "y": 10},
+                "text": "Column C-4",
+            },
+        ],
+        "layers": [
+            {"name": "STRUCTURAL", "protected": False},
+            {"name": "NOTES", "protected": False},
+            {"name": "TITLE", "protected": True},
+        ],
+        "blocks": ["COLUMN_MARK"],
+    }
+
+
+def _make_provider() -> GeminiProvider:
+    """Create a GeminiProvider with test settings (no real SDK init)."""
+    provider = GeminiProvider(
+        project="test-project",
+        location="us-central1",
+        model_name="gemini-1.5-pro",
+    )
+    # Set mock model to bypass _get_model() which needs real SDK
+    provider._model = MagicMock()
+    return provider
+
+
+def _mock_gemini_response(provider: GeminiProvider, response_text: str) -> None:
+    """Configure the mock model to return a specific text response."""
+    mock_response = MagicMock()
+    mock_response.text = response_text
+    provider._model.generate_content.return_value = mock_response
+
+
+# --- Provider Selection ---
+
+
+class TestProviderSelection:
+    """Test that the planner correctly selects Gemini provider."""
+
+    def test_get_provider_mock_default(self):
+        """Default provider is mock."""
+        provider = get_provider("mock")
+        assert provider.name == "mock"
+
+    @patch("cad_dxf_agent.llm.planner.settings")
+    def test_gemini_provider_name_wired(self, mock_settings):
+        """'gemini' name routes to GeminiProvider (or mock fallback)."""
+        mock_settings.llm_provider = "gemini"
+        # If google-cloud-aiplatform is installed, returns Gemini; otherwise mock
+        provider = get_provider("gemini")
+        assert provider is not None
+
+
+# --- Gemini Provider ---
+
+
+class TestGeminiProvider:
+    """Test GeminiProvider with mocked Vertex AI SDK."""
+
+    def test_plan_valid_response(self, valid_changeset_json, sample_drawing_context):
+        """Gemini returns valid JSON → parses to ChangeSet."""
+        provider = _make_provider()
+        _mock_gemini_response(provider, valid_changeset_json)
+
+        changeset = provider.plan("Move column east by 10", sample_drawing_context)
+
+        assert changeset.op_count == 1
+        assert changeset.operations[0].op_type == OpType.MOVE_ENTITY
+        assert changeset.operations[0].target_handle == "ABC"
+        assert changeset.operations[0].params["dx"] == 10.0
+
+    def test_plan_multi_op_response(self, multi_op_changeset_json, sample_drawing_context):
+        """Gemini returns multiple operations."""
+        provider = _make_provider()
+        _mock_gemini_response(provider, multi_op_changeset_json)
+
+        changeset = provider.plan("Multiple edits", sample_drawing_context)
+
+        assert changeset.op_count == 3
+        assert changeset.operations[0].op_type == OpType.MOVE_ENTITY
+        assert changeset.operations[1].op_type == OpType.EDIT_TEXT
+        assert changeset.operations[2].op_type == OpType.DELETE_ENTITY
+
+    def test_plan_retry_on_invalid_response(self, valid_changeset_json, sample_drawing_context):
+        """Gemini retries once if first response is invalid."""
+        provider = _make_provider()
+
+        invalid_response = MagicMock()
+        invalid_response.text = "not valid json {"
+        valid_response = MagicMock()
+        valid_response.text = valid_changeset_json
+        provider._model.generate_content.side_effect = [
+            invalid_response,
+            valid_response,
+        ]
+
+        changeset = provider.plan("Move column", sample_drawing_context)
+        assert changeset.op_count == 1
+        assert provider._model.generate_content.call_count == 2
+
+    def test_plan_raises_after_retry_exhausted(self, sample_drawing_context):
+        """Raises ValueError if both attempts fail."""
+        provider = _make_provider()
+
+        bad_response = MagicMock()
+        bad_response.text = "invalid json"
+        provider._model.generate_content.return_value = bad_response
+
+        with pytest.raises(ValueError):
+            provider.plan("Move column", sample_drawing_context)
+
+    def test_plan_empty_response(self, sample_drawing_context):
+        """Raises ValueError on empty Gemini response."""
+        provider = _make_provider()
+
+        empty_response = MagicMock()
+        empty_response.text = ""
+        provider._model.generate_content.return_value = empty_response
+
+        with pytest.raises(ValueError, match="empty response"):
+            provider.plan("Move column", sample_drawing_context)
+
+    def test_provider_name(self):
+        """Provider name includes model name."""
+        provider = _make_provider()
+        assert "gemini" in provider.name
+        assert "1.5-pro" in provider.name
+
+    def test_provider_no_api_key_required(self):
+        """Uses GCP credentials, not API key."""
+        provider = _make_provider()
+        assert provider.requires_api_key is False
+
+    def test_plan_with_code_fenced_response(self, sample_drawing_context):
+        """Gemini sometimes wraps JSON in code fences."""
+        provider = _make_provider()
+
+        fenced = (
+            '```json\n{"operations": [{"op_type": "delete_entity", "target_handle": "X1"}]}\n```'
+        )
+        _mock_gemini_response(provider, fenced)
+
+        changeset = provider.plan("Delete entity X1", sample_drawing_context)
+        assert changeset.op_count == 1
+        assert changeset.operations[0].op_type == OpType.DELETE_ENTITY
+
+    def test_plan_bare_array_response(self, sample_drawing_context):
+        """Gemini returns a bare array instead of object."""
+        provider = _make_provider()
+
+        bare = '[{"op_type": "move_entity", "target_handle": "A", "params": {"dx": 1, "dy": 2}}]'
+        _mock_gemini_response(provider, bare)
+
+        changeset = provider.plan("Move it", sample_drawing_context)
+        assert changeset.op_count == 1


### PR DESCRIPTION
## Summary

- Add `GeminiProvider` extending `PlannerProvider` ABC for hybrid vision planning on Vertex AI
- Sends DXF entity JSON + optional PNG render to Gemini 1.5 Pro, receives validated ChangeSet JSON
- Lazy SDK imports — module works without `google-cloud-aiplatform` installed, falls back to MockProvider
- Retry logic: on first validation failure, appends error feedback and retries once
- Wire `"gemini"` / `"google"` / `"vertex"` provider names in `planner.get_provider()`
- Add Gemini settings: `CAD_GCP_PROJECT`, `CAD_GCP_LOCATION`, `CAD_GEMINI_MODEL`, `CAD_GEMINI_MAX_RETRIES`
- Add `gemini` optional dependency group (`google-cloud-aiplatform>=1.38`, `Pillow>=10.0`)

## Files Changed

| File | Change |
|------|--------|
| `src/cad_dxf_agent/llm/gemini_provider.py` | New — GeminiProvider with multimodal content building |
| `src/cad_dxf_agent/llm/planner.py` | Wire GeminiProvider into get_provider() |
| `src/cad_dxf_agent/settings.py` | Add Gemini/Vertex AI settings |
| `pyproject.toml` | Add gemini dep group, mypy overrides for google/vertexai |
| `tests/unit/test_gemini_provider.py` | 11 new tests (all mock SDK, no real API calls) |

## Test plan

- [x] 11 new Gemini provider tests pass (valid response, multi-op, retry, empty, code-fenced, bare array)
- [x] 148 total tests pass locally
- [ ] CI matrix: ubuntu+windows, Python 3.11+3.12
- [x] ruff lint + format clean
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 1.5 Pro as an AI provider for CAD planning with multimodal capabilities, including image analysis support.
  * New configuration settings for Google Cloud Project, region, and model selection, configurable via environment variables.

* **Chores**
  * Added optional dependency group for Google Cloud AI Platform and image processing libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->