### PR TITLE
feat: MVP v1 for Tony — tool-use agent, undo/redo, UI, proxy, packaging

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,60 @@
+name: Build Windows Installer
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[gui,convert,draw]"
+          pip install pyinstaller
+
+      - name: Run tests
+        run: |
+          pip install -e ".[dev]"
+          pytest tests/unit/ -q
+
+      - name: Build with PyInstaller
+        run: |
+          pyinstaller installer/cad-dxf-agent.spec --noconfirm
+
+      - name: Verify build output
+        run: |
+          dir dist\cad-dxf-agent\
+          dist\cad-dxf-agent\cad-dxf-agent.exe --help || echo "GUI app, no --help"
+
+      - name: Build Inno Setup installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.4
+        with:
+          path: installer/setup.iss
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/cad-dxf-agent-setup-*.exe
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/cad-dxf-agent-setup-*.exe
+          draft: true

--- a/installer/cad-dxf-agent.spec
+++ b/installer/cad-dxf-agent.spec
@@ -1,0 +1,113 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for cad-dxf-agent Windows desktop application.
+
+Build with:
+    pyinstaller installer/cad-dxf-agent.spec --noconfirm
+
+Produces a one-dir bundle (~80-120 MB) in dist/cad-dxf-agent/
+"""
+
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+# Project root (one level up from installer/)
+ROOT = Path(SPECPATH).parent
+SRC = ROOT / "src"
+
+a = Analysis(
+    [str(SRC / "cad_dxf_agent" / "app.py")],
+    pathex=[str(SRC)],
+    binaries=[],
+    datas=[
+        # Include sample files for testing
+        (str(ROOT / "samples"), "samples"),
+    ],
+    hiddenimports=[
+        "cad_dxf_agent",
+        "cad_dxf_agent.app",
+        "cad_dxf_agent.settings",
+        "cad_dxf_agent.otel",
+        "cad_dxf_agent.core",
+        "cad_dxf_agent.core.dxf_reader",
+        "cad_dxf_agent.core.dxf_writer",
+        "cad_dxf_agent.core.edit_engine",
+        "cad_dxf_agent.core.edit_history",
+        "cad_dxf_agent.core.entity_index",
+        "cad_dxf_agent.core.semantic_model",
+        "cad_dxf_agent.core.validators",
+        "cad_dxf_agent.core.preview_model",
+        "cad_dxf_agent.core.revision_notes",
+        "cad_dxf_agent.models",
+        "cad_dxf_agent.models.cad_schema",
+        "cad_dxf_agent.models.ops_schema",
+        "cad_dxf_agent.models.config_schema",
+        "cad_dxf_agent.models.changes_schema",
+        "cad_dxf_agent.llm",
+        "cad_dxf_agent.llm.planner",
+        "cad_dxf_agent.llm.providers",
+        "cad_dxf_agent.llm.mock_provider",
+        "cad_dxf_agent.llm.agent_provider",
+        "cad_dxf_agent.llm.proxy_client",
+        "cad_dxf_agent.llm.tool_definitions",
+        "cad_dxf_agent.llm.tool_executor",
+        "cad_dxf_agent.llm.vision_describer",
+        "cad_dxf_agent.llm.prompt_templates",
+        "cad_dxf_agent.llm.response_parser",
+        "cad_dxf_agent.ui",
+        "cad_dxf_agent.ui.main_window",
+        "ezdxf",
+        "pydantic",
+        "numpy",
+        "dotenv",
+        "PySide6",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "tkinter",
+        "test",
+        "unittest",
+        "pytest",
+        "mypy",
+        "ruff",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="cad-dxf-agent",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,  # No console window — PySide6 GUI
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,  # TODO: add icon when design is ready
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="cad-dxf-agent",
+)

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,0 +1,63 @@
+; Inno Setup script for cad-dxf-agent Windows installer
+; Requires Inno Setup 6.x (https://jrsoftware.org/isinfo.php)
+;
+; Build with:
+;   iscc installer/setup.iss
+
+#define AppName "CAD DXF Agent"
+#define AppVersion "1.0.0"
+#define AppPublisher "Intent Solutions"
+#define AppURL "https://github.com/your-org/cad-dxf-agent"
+#define AppExeName "cad-dxf-agent.exe"
+
+[Setup]
+AppId={{F3A2B1C0-D4E5-4F6A-8B9C-0D1E2F3A4B5C}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}
+AppUpdatesURL={#AppURL}
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+AllowNoIcons=yes
+LicenseFile=..\LICENSE
+OutputDir=..\dist
+OutputBaseFilename=cad-dxf-agent-setup-{#AppVersion}
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "fileassoc_dxf"; Description: "Associate .dxf files"; GroupDescription: "File Associations:"
+Name: "fileassoc_dwg"; Description: "Associate .dwg files"; GroupDescription: "File Associations:"
+
+[Files]
+Source: "..\dist\cad-dxf-agent\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Registry]
+; DXF file association
+Root: HKA; Subkey: "Software\Classes\.dxf\OpenWithProgids"; ValueType: string; ValueName: "CADDXFAgent.dxf"; ValueData: ""; Flags: uninsdeletevalue; Tasks: fileassoc_dxf
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dxf"; ValueType: string; ValueName: ""; ValueData: "DXF Drawing File"; Flags: uninsdeletekey; Tasks: fileassoc_dxf
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dxf\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},0"; Tasks: fileassoc_dxf
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dxf\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#AppExeName}"" ""%1"""; Tasks: fileassoc_dxf
+
+; DWG file association
+Root: HKA; Subkey: "Software\Classes\.dwg\OpenWithProgids"; ValueType: string; ValueName: "CADDXFAgent.dwg"; ValueData: ""; Flags: uninsdeletevalue; Tasks: fileassoc_dwg
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dwg"; ValueType: string; ValueName: ""; ValueData: "DWG Drawing File"; Flags: uninsdeletekey; Tasks: fileassoc_dwg
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dwg\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#AppExeName},0"; Tasks: fileassoc_dwg
+Root: HKA; Subkey: "Software\Classes\CADDXFAgent.dwg\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#AppExeName}"" ""%1"""; Tasks: fileassoc_dwg
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(AppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/proxy/cloudbuild.yaml
+++ b/proxy/cloudbuild.yaml
@@ -1,0 +1,39 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/cad-dxf-proxy:$SHORT_SHA'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/cad-dxf-proxy:latest'
+      - './proxy'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/cad-dxf-proxy:$SHORT_SHA']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/cad-dxf-proxy:latest']
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'cad-dxf-proxy'
+      - '--image'
+      - 'gcr.io/$PROJECT_ID/cad-dxf-proxy:$SHORT_SHA'
+      - '--platform'
+      - 'managed'
+      - '--region'
+      - 'us-central1'
+      - '--allow-unauthenticated'
+      - '--set-env-vars'
+      - 'CAD_GCP_PROJECT=$PROJECT_ID,CAD_GCP_LOCATION=us-central1'
+      - '--memory'
+      - '512Mi'
+      - '--timeout'
+      - '120s'
+
+images:
+  - 'gcr.io/$PROJECT_ID/cad-dxf-proxy:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/cad-dxf-proxy:latest'

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -1,0 +1,219 @@
+"""Cloud Run Gemini proxy — shields desktop users from GCP credentials.
+
+Desktop app sends requests with a license key. Proxy validates the key,
+forwards the request to Vertex AI, and streams the response back. Users
+never need GCP credentials or a billing account.
+
+Routes:
+    POST /v1/generate   — Forward a generate request to Gemini
+    GET  /health        — Health check
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import defaultdict
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------
+
+ALLOWED_LICENSE_KEYS: set[str] = set()
+_raw = os.getenv("CAD_ALLOWED_LICENSE_KEYS", "")
+if _raw:
+    ALLOWED_LICENSE_KEYS = {k.strip() for k in _raw.split(",") if k.strip()}
+
+GCP_PROJECT = os.getenv("CAD_GCP_PROJECT", "")
+GCP_LOCATION = os.getenv("CAD_GCP_LOCATION", "us-central1")
+DEFAULT_MODEL = os.getenv("CAD_GEMINI_MODEL", "gemini-2.5-flash")
+
+# Rate limiting (per-key, in-memory — good enough for MVP)
+MAX_REQUESTS_PER_MINUTE = int(os.getenv("CAD_RATE_LIMIT_RPM", "30"))
+
+app = FastAPI(title="CAD DXF Agent Proxy", version="1.0.0")
+
+
+# ------------------------------------------------------------------
+# Request / response models
+# ------------------------------------------------------------------
+
+
+class GenerateRequest(BaseModel):
+    """Proxied Gemini generate request."""
+
+    model: str = Field(default="", description="Model name override")
+    contents: list[dict[str, Any]] = Field(description="Gemini contents array")
+    system_instruction: str | None = None
+    tools: list[dict[str, Any]] | None = None
+    generation_config: dict[str, Any] | None = None
+
+
+# ------------------------------------------------------------------
+# In-memory rate limiter
+# ------------------------------------------------------------------
+
+_rate_buckets: dict[str, list[float]] = defaultdict(list)
+
+
+def _check_rate_limit(key: str) -> bool:
+    """Return True if the key is within the rate limit."""
+    now = time.time()
+    window = 60.0
+    _rate_buckets[key] = [t for t in _rate_buckets[key] if now - t < window]
+    if len(_rate_buckets[key]) >= MAX_REQUESTS_PER_MINUTE:
+        return False
+    _rate_buckets[key].append(now)
+    return True
+
+
+# ------------------------------------------------------------------
+# Auth middleware
+# ------------------------------------------------------------------
+
+
+def _validate_license(request: Request) -> str:
+    """Extract and validate the license key from the request."""
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+    key = auth[7:].strip()
+
+    if ALLOWED_LICENSE_KEYS and key not in ALLOWED_LICENSE_KEYS:
+        raise HTTPException(status_code=403, detail="Invalid license key")
+
+    if not _check_rate_limit(key):
+        raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+    return key
+
+
+# ------------------------------------------------------------------
+# Routes
+# ------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "project": GCP_PROJECT}
+
+
+@app.post("/v1/generate")
+async def generate(body: GenerateRequest, request: Request):
+    """Forward generate request to Vertex AI Gemini."""
+    _validate_license(request)
+
+    try:
+        import vertexai
+        from vertexai.generative_models import (
+            Content,
+            FunctionDeclaration,
+            GenerativeModel,
+            Part,
+            Tool,
+        )
+
+        vertexai.init(project=GCP_PROJECT, location=GCP_LOCATION)
+
+        model_name = body.model or DEFAULT_MODEL
+
+        # Rebuild tools if provided
+        gemini_tools = None
+        if body.tools:
+            declarations = []
+            for tool_group in body.tools:
+                for fd in tool_group.get("function_declarations", []):
+                    declarations.append(
+                        FunctionDeclaration(
+                            name=fd["name"],
+                            description=fd.get("description", ""),
+                            parameters=fd.get("parameters", {}),
+                        )
+                    )
+            if declarations:
+                gemini_tools = [Tool(function_declarations=declarations)]
+
+        model = GenerativeModel(
+            model_name,
+            system_instruction=body.system_instruction,
+            tools=gemini_tools,
+        )
+
+        # Convert contents to Gemini format
+        gemini_contents = []
+        for msg in body.contents:
+            role = msg.get("role", "user")
+            parts_raw = msg.get("parts", [])
+            parts = []
+            for p in parts_raw:
+                if isinstance(p, str):
+                    parts.append(Part.from_text(p))
+                elif isinstance(p, dict) and "text" in p:
+                    parts.append(Part.from_text(p["text"]))
+                elif isinstance(p, dict) and "function_call" in p:
+                    fc = p["function_call"]
+                    parts.append(Part.from_dict({"function_call": fc}))
+                elif isinstance(p, dict) and "function_response" in p:
+                    fr = p["function_response"]
+                    parts.append(
+                        Part.from_function_response(
+                            name=fr["name"],
+                            response=fr["response"],
+                        )
+                    )
+            gemini_contents.append(Content(role=role, parts=parts))
+
+        response = model.generate_content(
+            gemini_contents,
+            generation_config=body.generation_config,
+        )
+
+        # Serialize response
+        result = _serialize_response(response)
+        return JSONResponse(content=result)
+
+    except ImportError as err:
+        raise HTTPException(
+            status_code=500,
+            detail="google-cloud-aiplatform not installed on proxy",
+        ) from err
+    except Exception as e:
+        logger.error("Gemini proxy error: %s", e, exc_info=True)
+        raise HTTPException(status_code=502, detail=f"Upstream error: {e}") from e
+
+
+def _serialize_response(response) -> dict[str, Any]:
+    """Convert Gemini response to JSON-serializable dict."""
+    candidates = []
+    for candidate in response.candidates:
+        parts = []
+        for part in candidate.content.parts:
+            if hasattr(part, "function_call") and part.function_call:
+                fc = part.function_call
+                parts.append(
+                    {
+                        "function_call": {
+                            "name": fc.name,
+                            "args": dict(fc.args) if fc.args else {},
+                        }
+                    }
+                )
+            elif hasattr(part, "text") and part.text:
+                parts.append({"text": part.text})
+        candidates.append(
+            {
+                "content": {
+                    "role": candidate.content.role,
+                    "parts": parts,
+                }
+            }
+        )
+    return {"candidates": candidates}

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -17,9 +17,17 @@ import time
 from collections import defaultdict
 from typing import Any
 
+import vertexai
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+from vertexai.generative_models import (
+    Content,
+    FunctionDeclaration,
+    GenerativeModel,
+    Part,
+    Tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +46,9 @@ DEFAULT_MODEL = os.getenv("CAD_GEMINI_MODEL", "gemini-2.5-flash")
 
 # Rate limiting (per-key, in-memory — good enough for MVP)
 MAX_REQUESTS_PER_MINUTE = int(os.getenv("CAD_RATE_LIMIT_RPM", "30"))
+
+# Initialize Vertex AI once at startup
+vertexai.init(project=GCP_PROJECT, location=GCP_LOCATION)
 
 app = FastAPI(title="CAD DXF Agent Proxy", version="1.0.0")
 
@@ -87,7 +98,12 @@ def _validate_license(request: Request) -> str:
         raise HTTPException(status_code=401, detail="Missing Authorization header")
     key = auth[7:].strip()
 
-    if ALLOWED_LICENSE_KEYS and key not in ALLOWED_LICENSE_KEYS:
+    if not ALLOWED_LICENSE_KEYS:
+        raise HTTPException(
+            status_code=500,
+            detail="Server misconfigured: CAD_ALLOWED_LICENSE_KEYS not set",
+        )
+    if key not in ALLOWED_LICENSE_KEYS:
         raise HTTPException(status_code=403, detail="Invalid license key")
 
     if not _check_rate_limit(key):
@@ -112,17 +128,6 @@ async def generate(body: GenerateRequest, request: Request):
     _validate_license(request)
 
     try:
-        import vertexai
-        from vertexai.generative_models import (
-            Content,
-            FunctionDeclaration,
-            GenerativeModel,
-            Part,
-            Tool,
-        )
-
-        vertexai.init(project=GCP_PROJECT, location=GCP_LOCATION)
-
         model_name = body.model or DEFAULT_MODEL
 
         # Rebuild tools if provided
@@ -180,11 +185,6 @@ async def generate(body: GenerateRequest, request: Request):
         result = _serialize_response(response)
         return JSONResponse(content=result)
 
-    except ImportError as err:
-        raise HTTPException(
-            status_code=500,
-            detail="google-cloud-aiplatform not installed on proxy",
-        ) from err
     except Exception as e:
         logger.error("Gemini proxy error: %s", e, exc_info=True)
         raise HTTPException(status_code=502, detail=f"Upstream error: {e}") from e

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.34.0
+google-cloud-aiplatform>=1.74.0
+pydantic>=2.0.0

--- a/src/cad_dxf_agent/core/dxf_reader.py
+++ b/src/cad_dxf_agent/core/dxf_reader.py
@@ -1,4 +1,4 @@
-"""DXF file reader — loads model space entities into DrawingContext."""
+"""DXF file reader — loads model space and layout entities into DrawingContext."""
 
 from __future__ import annotations
 
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import ezdxf
 
-from ..models.cad_schema import DrawingContext, EntityRef, EntityType, LayerRule, Point2D
+from ..models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    LayoutInfo,
+    Point2D,
+)
 from ..otel import get_tracer
 from ..settings import settings
 
@@ -20,7 +27,8 @@ SUPPORTED_TYPES = {t.value for t in EntityType}
 def load_dxf(file_path: str | Path) -> DrawingContext:
     """Load a DXF file and build a normalized DrawingContext.
 
-    Only model space entities of supported V1 types are indexed.
+    Loads model space and all named layouts (paper spaces).
+    Only supported V1 entity types are indexed.
     Unsupported entity types are recorded but skipped.
     """
     with tracer.start_as_current_span("cad.load_dxf") as span:
@@ -31,32 +39,59 @@ def load_dxf(file_path: str | Path) -> DrawingContext:
         span.set_attribute("cad.file.name", file_path.name)
 
         doc = ezdxf.readfile(str(file_path))
-        msp = doc.modelspace()
 
         entities: list[EntityRef] = []
         unsupported: set[str] = set()
         blocks: list[str] = [block.name for block in doc.blocks if not block.name.startswith("*")]
 
+        # Parse model space
+        msp = doc.modelspace()
         for entity in msp:
             dxf_type = entity.dxftype()
             if dxf_type not in SUPPORTED_TYPES:
                 unsupported.add(dxf_type)
                 continue
-
-            ref = _parse_entity(entity, dxf_type)
+            ref = _parse_entity(entity, dxf_type, space="Model")
             if ref is not None:
                 entities.append(ref)
+
+        model_count = len(entities)
+
+        # Parse paper space layouts
+        layout_infos: list[LayoutInfo] = [
+            LayoutInfo(name="Model", entity_count=model_count),
+        ]
+
+        for layout in doc.layouts:
+            name = layout.name
+            if name == "Model":
+                continue
+            layout_entity_count = 0
+            for entity in layout:
+                dxf_type = entity.dxftype()
+                if dxf_type not in SUPPORTED_TYPES:
+                    unsupported.add(dxf_type)
+                    continue
+                ref = _parse_entity(entity, dxf_type, space=name)
+                if ref is not None:
+                    entities.append(ref)
+                    layout_entity_count += 1
+            layout_infos.append(LayoutInfo(name=name, entity_count=layout_entity_count))
 
         layers = _build_layer_rules(doc)
 
         if unsupported:
-            logger.info("Skipped unsupported entity types: %s", ", ".join(sorted(unsupported)))
+            logger.info(
+                "Skipped unsupported entity types: %s",
+                ", ".join(sorted(unsupported)),
+            )
 
         ctx = DrawingContext(
             file_path=str(file_path),
             entities=entities,
             layers=layers,
             blocks=blocks,
+            layouts=layout_infos,
             unsupported_entity_types=sorted(unsupported),
             metadata={
                 "dxf_version": doc.dxfversion,
@@ -66,11 +101,16 @@ def load_dxf(file_path: str | Path) -> DrawingContext:
 
         span.set_attribute("cad.entities.count", len(entities))
         span.set_attribute("cad.layers.count", len(layers))
+        span.set_attribute("cad.layouts.count", len(layout_infos))
 
         return ctx
 
 
-def _parse_entity(entity: ezdxf.entities.DXFGraphic, dxf_type: str) -> EntityRef | None:
+def _parse_entity(
+    entity: ezdxf.entities.DXFGraphic,
+    dxf_type: str,
+    space: str = "Model",
+) -> EntityRef | None:
     """Parse a single DXF entity into an EntityRef."""
     handle = entity.dxf.handle
     layer = entity.dxf.layer
@@ -103,6 +143,7 @@ def _parse_entity(entity: ezdxf.entities.DXFGraphic, dxf_type: str) -> EntityRef
         handle=handle,
         entity_type=EntityType(dxf_type),
         layer=layer,
+        space=space,
         insert_point=insert_point,
         text_content=text_content,
         block_name=block_name,

--- a/src/cad_dxf_agent/core/edit_history.py
+++ b/src/cad_dxf_agent/core/edit_history.py
@@ -1,0 +1,124 @@
+"""Edit history — snapshot-based undo/redo for DXF editing.
+
+Maintains a stack of DXF document snapshots. Each applied operation
+creates a snapshot that can be reverted (undo) or re-applied (redo).
+Uses ezdxf's stream I/O for efficient serialization.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+import ezdxf
+
+logger = logging.getLogger(__name__)
+
+
+class EditHistory:
+    """Snapshot-based undo/redo for a DXF document.
+
+    Each call to push() captures the current document state.
+    undo()/redo() navigate the snapshot stack and return the
+    restored document.
+    """
+
+    def __init__(self, initial_path: str | Path) -> None:
+        self._initial_path = Path(initial_path)
+        self._snapshots: list[bytes] = []
+        self._cursor: int = -1  # Points to current snapshot; -1 = initial
+        self._labels: list[str] = []
+
+        # Capture the initial state
+        doc = ezdxf.readfile(str(self._initial_path))
+        self._initial_snapshot = _serialize(doc)
+
+    def push(self, doc: ezdxf.document.Drawing, label: str = "") -> None:
+        """Capture current document state as a new snapshot.
+
+        Discards any redo history beyond the current cursor position.
+        """
+        # Truncate redo stack
+        self._snapshots = self._snapshots[: self._cursor + 1]
+        self._labels = self._labels[: self._cursor + 1]
+
+        snapshot = _serialize(doc)
+        self._snapshots.append(snapshot)
+        self._labels.append(label)
+        self._cursor = len(self._snapshots) - 1
+
+        logger.debug(
+            "Snapshot pushed [%d]: %s (%d bytes)",
+            self._cursor,
+            label,
+            len(snapshot),
+        )
+
+    def undo(self) -> ezdxf.document.Drawing | None:
+        """Undo: move cursor back one step and return the restored document.
+
+        Returns None if already at initial state.
+        """
+        if self._cursor < 0:
+            return None  # Already at initial state
+
+        if self._cursor == 0:
+            # Restore to initial state
+            self._cursor = -1
+            return _deserialize(self._initial_snapshot)
+
+        self._cursor -= 1
+        logger.debug("Undo to snapshot [%d]", self._cursor)
+        return _deserialize(self._snapshots[self._cursor])
+
+    def redo(self) -> ezdxf.document.Drawing | None:
+        """Redo: move cursor forward one step and return the restored document.
+
+        Returns None if already at the latest state.
+        """
+        if self._cursor >= len(self._snapshots) - 1:
+            return None  # Already at latest
+
+        self._cursor += 1
+        logger.debug("Redo to snapshot [%d]", self._cursor)
+        return _deserialize(self._snapshots[self._cursor])
+
+    @property
+    def can_undo(self) -> bool:
+        return self._cursor >= 0
+
+    @property
+    def can_redo(self) -> bool:
+        return self._cursor < len(self._snapshots) - 1
+
+    @property
+    def depth(self) -> int:
+        """Total number of snapshots (not counting initial)."""
+        return len(self._snapshots)
+
+    @property
+    def current_label(self) -> str:
+        """Label of the current snapshot, or 'initial' if at base state."""
+        if self._cursor < 0:
+            return "initial"
+        return self._labels[self._cursor]
+
+    def get_current_doc(self) -> ezdxf.document.Drawing:
+        """Return the document at the current cursor position."""
+        if self._cursor < 0:
+            return _deserialize(self._initial_snapshot)
+        return _deserialize(self._snapshots[self._cursor])
+
+
+def _serialize(doc: ezdxf.document.Drawing) -> bytes:
+    """Serialize a DXF document to bytes."""
+    stream = io.StringIO()
+    doc.write(stream)
+    return stream.getvalue().encode(doc.encoding)
+
+
+def _deserialize(data: bytes) -> ezdxf.document.Drawing:
+    """Deserialize a DXF document from bytes."""
+    stream = io.StringIO(data.decode("utf-8"))
+    return ezdxf.read(stream)

--- a/src/cad_dxf_agent/core/edit_history.py
+++ b/src/cad_dxf_agent/core/edit_history.py
@@ -115,7 +115,7 @@ def _serialize(doc: ezdxf.document.Drawing) -> bytes:
     """Serialize a DXF document to bytes."""
     stream = io.StringIO()
     doc.write(stream)
-    return stream.getvalue().encode(doc.encoding)
+    return stream.getvalue().encode("utf-8")
 
 
 def _deserialize(data: bytes) -> ezdxf.document.Drawing:

--- a/src/cad_dxf_agent/core/semantic_model.py
+++ b/src/cad_dxf_agent/core/semantic_model.py
@@ -12,7 +12,7 @@ def build_planner_context(context: DrawingContext) -> dict:
     """Build a JSON-serializable summary of the drawing for the LLM planner.
 
     This is the information the planner sees to make targeting decisions.
-    It does NOT include raw DXF data.
+    It does NOT include raw DXF data. Includes all spaces (model + layouts).
     """
     with tracer.start_as_current_span("cad.build_context") as span:
         span.set_attribute("cad.entities.count", context.entity_count)
@@ -33,6 +33,7 @@ def build_planner_context(context: DrawingContext) -> dict:
                 "handle": e.handle,
                 "type": e.entity_type.value,
                 "layer": e.layer,
+                "space": e.space,
                 "insert_point": (
                     {"x": e.insert_point.x, "y": e.insert_point.y} if e.insert_point else None
                 ),
@@ -42,11 +43,16 @@ def build_planner_context(context: DrawingContext) -> dict:
             for e in context.entities
         ]
 
+        layout_summary = [
+            {"name": layout.name, "entity_count": layout.entity_count} for layout in context.layouts
+        ]
+
         return {
             "file_path": context.file_path,
             "entity_count": context.entity_count,
             "layers": layer_summary,
             "entities": entity_summary,
             "blocks": context.blocks,
+            "layouts": layout_summary,
             "unsupported_types": context.unsupported_entity_types,
         }

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -1,0 +1,415 @@
+"""Agent provider — tool-use loop for Gemini function calling.
+
+Replaces the one-shot GeminiProvider with an iterative agent that:
+  1. Sends the user prompt + drawing context + tool definitions to Gemini
+  2. Gemini returns function calls (find_entities, move_entity, etc.)
+  3. Host executes each call via ToolExecutor
+  4. Results sent back to Gemini for the next turn
+  5. Repeats until Gemini stops calling tools
+  6. Accumulated EditOperations are returned as a ChangeSet
+
+The LLM never touches DXF — it only calls tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..models.ops_schema import ChangeSet
+from ..otel import get_tracer
+from ..settings import settings
+from .prompt_templates import AGENT_SYSTEM_PROMPT
+from .providers import PlannerProvider
+from .tool_definitions import ALL_TOOLS
+from .tool_executor import ToolExecutor
+from .vision_describer import describe_drawing
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+# Safety limit on agent turns to prevent infinite loops
+MAX_AGENT_TURNS = 10
+
+
+class AgentProvider(PlannerProvider):
+    """Gemini tool-use agent for CAD editing.
+
+    Uses Gemini function calling to iteratively query and edit the
+    drawing. More reliable than one-shot JSON generation because the
+    LLM can search for entities before acting on them.
+    """
+
+    def __init__(
+        self,
+        project: str | None = None,
+        location: str | None = None,
+        model_name: str | None = None,
+        image_path: str | Path | None = None,
+    ) -> None:
+        self._project = project or settings.gcp_project
+        self._location = location or settings.gcp_location
+        self._model_name = model_name or settings.gemini_model
+        self._image_path = image_path
+        self._model: Any = None  # lazy init
+
+    @property
+    def name(self) -> str:
+        return f"agent ({self._model_name})"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False  # Uses GCP credentials
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        """Run the tool-use agent loop to produce a ChangeSet."""
+        with tracer.start_as_current_span("cad.agent_plan") as span:
+            span.set_attribute("cad.agent.model", self._model_name)
+
+            context = self._reconstruct_context(drawing_context)
+            executor = ToolExecutor(context, settings.protected_layers)
+
+            # Build initial prompt with vision description if available
+            initial_prompt = self._build_initial_prompt(prompt, drawing_context)
+
+            # Run the agent loop
+            model = self._get_model()
+            chat = model.start_chat()
+
+            # Send initial message
+            response = chat.send_message(initial_prompt)
+            turns = 0
+
+            while turns < MAX_AGENT_TURNS:
+                # Check if Gemini wants to call tools
+                function_calls = _extract_function_calls(response)
+                if not function_calls:
+                    # No more tool calls — agent is done
+                    break
+
+                turns += 1
+                span.add_event(
+                    f"agent_turn_{turns}",
+                    {
+                        "tool_count": len(function_calls),
+                    },
+                )
+
+                # Execute each tool call and collect results
+                tool_results = []
+                for fc in function_calls:
+                    tool_name = fc["name"]
+                    tool_args = fc["args"]
+                    logger.info("Agent tool call [%d]: %s(%s)", turns, tool_name, tool_args)
+
+                    try:
+                        result = executor.execute(tool_name, tool_args)
+                    except KeyError:
+                        result = {"error": f"Unknown tool: {tool_name}"}
+                    except Exception as e:
+                        result = {"error": f"Tool execution failed: {e}"}
+
+                    tool_results.append(
+                        {
+                            "name": tool_name,
+                            "response": result,
+                        }
+                    )
+
+                # Send results back to Gemini
+                response = self._send_tool_results(chat, tool_results)
+
+            span.set_attribute("cad.agent.turns", turns)
+            span.set_attribute("cad.agent.ops_count", len(executor.operations))
+
+            ops = executor.operations
+            logger.info(
+                "Agent completed in %d turns, produced %d operations",
+                turns,
+                len(ops),
+            )
+
+            return ChangeSet(
+                prompt=prompt,
+                operations=ops,
+                revision_label=f"Agent edit ({turns} turns): {prompt[:50]}",
+            )
+
+    def _get_model(self):
+        """Lazy-initialize the Gemini model with tool declarations."""
+        if self._model is None:
+            try:
+                import vertexai
+                from vertexai.generative_models import (
+                    FunctionDeclaration,
+                    GenerativeModel,
+                    Tool,
+                )
+
+                vertexai.init(
+                    project=self._project,
+                    location=self._location,
+                )
+
+                # Convert tool dicts to FunctionDeclaration objects
+                declarations = []
+                for tool_def in ALL_TOOLS:
+                    declarations.append(
+                        FunctionDeclaration(
+                            name=str(tool_def["name"]),
+                            description=str(tool_def["description"]),
+                            parameters=dict(tool_def["parameters"]),  # type: ignore[arg-type]
+                        )
+                    )
+                tools = [Tool(function_declarations=declarations)]
+
+                self._model = GenerativeModel(
+                    self._model_name,
+                    system_instruction=AGENT_SYSTEM_PROMPT,
+                    tools=tools,
+                )
+            except ImportError as err:
+                raise ImportError(
+                    "google-cloud-aiplatform not installed. "
+                    "Install with: pip install google-cloud-aiplatform"
+                ) from err
+
+        return self._model
+
+    def _build_initial_prompt(self, prompt: str, drawing_context: dict) -> str:
+        """Build the initial message with drawing context and optional vision."""
+        parts = []
+
+        # Vision description (Stage 1)
+        if self._image_path:
+            try:
+                description = describe_drawing(self._image_path)
+                parts.append(f"DRAWING VISUAL DESCRIPTION:\n{description}\n")
+            except Exception as e:
+                logger.warning("Vision description failed, continuing without: %s", e)
+
+        # Entity summary (always included)
+        entity_summary = json.dumps(drawing_context, indent=2, default=str)
+        parts.append(f"DRAWING ENTITIES (JSON):\n{entity_summary}\n")
+
+        # User prompt
+        parts.append(f"USER REQUEST:\n{prompt}")
+
+        return "\n".join(parts)
+
+    def _send_tool_results(self, chat, tool_results: list[dict]) -> Any:
+        """Send tool execution results back to Gemini."""
+        from vertexai.generative_models import Content, Part
+
+        parts = []
+        for tr in tool_results:
+            part = Part.from_function_response(
+                name=tr["name"],
+                response=tr["response"],
+            )
+            parts.append(part)
+
+        return chat.send_message(Content(role="function", parts=parts))
+
+    def _reconstruct_context(self, drawing_context: dict) -> Any:
+        """Reconstruct a DrawingContext from the planner context dict.
+
+        The planner receives a simplified dict from semantic_model.
+        We reconstruct enough of a DrawingContext to feed the EntityIndex.
+        """
+        from ..models.cad_schema import (
+            DrawingContext,
+            EntityRef,
+            EntityType,
+            LayerRule,
+            Point2D,
+        )
+
+        entities = []
+        for e in drawing_context.get("entities", []):
+            try:
+                point = None
+                if e.get("insert_point"):
+                    point = Point2D(
+                        x=e["insert_point"]["x"],
+                        y=e["insert_point"]["y"],
+                    )
+                entities.append(
+                    EntityRef(
+                        handle=e["handle"],
+                        entity_type=EntityType(e["type"]),
+                        layer=e["layer"],
+                        insert_point=point,
+                        text_content=e.get("text"),
+                        block_name=e.get("block_name"),
+                    )
+                )
+            except (KeyError, ValueError) as exc:
+                logger.warning("Skipping malformed entity: %s", exc)
+
+        layers = []
+        for lyr in drawing_context.get("layers", []):
+            layers.append(
+                LayerRule(
+                    name=lyr["name"],
+                    protected=lyr.get("protected", False),
+                )
+            )
+
+        return DrawingContext(
+            file_path=drawing_context.get("file_path", ""),
+            entities=entities,
+            layers=layers,
+            blocks=drawing_context.get("blocks", []),
+        )
+
+
+class MockAgentProvider(PlannerProvider):
+    """Mock agent provider for testing the tool-use flow without Gemini.
+
+    Simulates a two-turn agent: first searches for an entity, then
+    performs the requested edit operation.
+    """
+
+    @property
+    def name(self) -> str:
+        return "mock-agent"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        """Simulate agent tool-use with deterministic tool calls."""
+        from ..models.cad_schema import (
+            DrawingContext,
+            EntityRef,
+            EntityType,
+            LayerRule,
+            Point2D,
+        )
+
+        # Reconstruct context for executor
+        entities = []
+        for e in drawing_context.get("entities", []):
+            try:
+                point = None
+                if e.get("insert_point"):
+                    point = Point2D(x=e["insert_point"]["x"], y=e["insert_point"]["y"])
+                entities.append(
+                    EntityRef(
+                        handle=e["handle"],
+                        entity_type=EntityType(e["type"]),
+                        layer=e["layer"],
+                        insert_point=point,
+                        text_content=e.get("text"),
+                        block_name=e.get("block_name"),
+                    )
+                )
+            except (KeyError, ValueError):
+                continue
+
+        layers = [
+            LayerRule(name=lyr["name"], protected=lyr.get("protected", False))
+            for lyr in drawing_context.get("layers", [])
+        ]
+
+        context = DrawingContext(
+            file_path=drawing_context.get("file_path", ""),
+            entities=entities,
+            layers=layers,
+            blocks=drawing_context.get("blocks", []),
+        )
+
+        executor = ToolExecutor(context, settings.protected_layers)
+        prompt_lower = prompt.lower()
+
+        # Turn 1: Search for entities
+        if "move" in prompt_lower:
+            executor.execute("find_entities", {"layer": "STRUCTURAL"})
+            # Turn 2: Move first editable entity
+            for e in drawing_context.get("entities", []):
+                protected = {
+                    lyr["name"].upper()
+                    for lyr in drawing_context.get("layers", [])
+                    if lyr.get("protected")
+                }
+                if e.get("layer", "").upper() not in protected:
+                    executor.execute(
+                        "move_entity",
+                        {
+                            "handle": e["handle"],
+                            "dx": 24.0,
+                            "dy": 0.0,
+                        },
+                    )
+                    break
+
+        elif "delete" in prompt_lower or "remove" in prompt_lower:
+            for e in drawing_context.get("entities", []):
+                protected = {
+                    lyr["name"].upper()
+                    for lyr in drawing_context.get("layers", [])
+                    if lyr.get("protected")
+                }
+                if e.get("layer", "").upper() not in protected:
+                    executor.execute("delete_entity", {"handle": e["handle"]})
+                    break
+
+        elif "text" in prompt_lower or "label" in prompt_lower:
+            for e in drawing_context.get("entities", []):
+                if e.get("type") in ("TEXT", "MTEXT") and e.get("text"):
+                    executor.execute(
+                        "edit_text",
+                        {
+                            "handle": e["handle"],
+                            "new_text": "UPDATED BY CAD-DXF-AGENT",
+                        },
+                    )
+                    break
+
+        else:
+            # Default: move first editable entity
+            for e in drawing_context.get("entities", []):
+                protected = {
+                    lyr["name"].upper()
+                    for lyr in drawing_context.get("layers", [])
+                    if lyr.get("protected")
+                }
+                if e.get("layer", "").upper() not in protected:
+                    executor.execute(
+                        "move_entity",
+                        {
+                            "handle": e["handle"],
+                            "dx": 12.0,
+                            "dy": 12.0,
+                        },
+                    )
+                    break
+
+        return ChangeSet(
+            prompt=prompt,
+            operations=executor.operations,
+            revision_label=f"Mock agent edit: {prompt[:50]}",
+        )
+
+
+def _extract_function_calls(response) -> list[dict[str, Any]]:
+    """Extract function call name/args pairs from a Gemini response."""
+    calls = []
+    try:
+        for candidate in response.candidates:
+            for part in candidate.content.parts:
+                if hasattr(part, "function_call") and part.function_call:
+                    fc = part.function_call
+                    calls.append(
+                        {
+                            "name": fc.name,
+                            "args": dict(fc.args) if fc.args else {},
+                        }
+                    )
+    except (AttributeError, TypeError):
+        pass
+    return calls

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -55,6 +55,17 @@ def get_provider(provider_name: str | None = None) -> PlannerProvider:
 
         return MockAgentProvider()
 
+    if name in ("proxy", "proxy-agent"):
+        try:
+            from .proxy_client import ProxyAgentProvider
+
+            return ProxyAgentProvider()
+        except ValueError as e:
+            logger.warning("Proxy provider misconfigured (%s), falling back to mock-agent", e)
+            from .agent_provider import MockAgentProvider
+
+            return MockAgentProvider()
+
     logger.warning("Unknown provider '%s', falling back to mock", name)
     return MockProvider()
 

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -36,6 +36,25 @@ def get_provider(provider_name: str | None = None) -> PlannerProvider:
             )
             return MockProvider()
 
+    if name == "agent":
+        try:
+            from .agent_provider import AgentProvider
+
+            return AgentProvider()
+        except ImportError:
+            logger.warning(
+                "google-cloud-aiplatform not installed, falling back to mock-agent. "
+                "Install with: pip install google-cloud-aiplatform"
+            )
+            from .agent_provider import MockAgentProvider
+
+            return MockAgentProvider()
+
+    if name == "mock-agent":
+        from .agent_provider import MockAgentProvider
+
+        return MockAgentProvider()
+
     logger.warning("Unknown provider '%s', falling back to mock", name)
     return MockProvider()
 

--- a/src/cad_dxf_agent/llm/prompt_templates.py
+++ b/src/cad_dxf_agent/llm/prompt_templates.py
@@ -33,6 +33,38 @@ PARAMS BY OP TYPE:
   "scale": n, "rotation": n}}
 """
 
+AGENT_SYSTEM_PROMPT = """You are a structural engineering CAD editing assistant. You help
+engineers edit 2D foundation and framing plans by calling tools to query and modify the drawing.
+
+COORDINATE SYSTEM:
+- X increases to the right, Y increases upward
+- Units are in the drawing's native units (typically inches or feet)
+- Grid lines are labeled with letters (A, B, C...) for one direction
+  and numbers (1, 2, 3...) for the other
+
+WORKFLOW:
+1. ALWAYS start by calling list_layers to understand the drawing structure
+2. Use find_entities or find_nearest to locate the specific entities the user mentions
+3. Verify entity handles and positions before making edits
+4. Call edit tools (move_entity, edit_text, delete_entity, add_block) with confirmed handles
+5. If the user mentions a grid intersection (like "C-4"), find entities near that location
+
+RULES:
+- NEVER edit entities on protected layers (TITLE, TITLEBLOCK, SEAL, REVISION)
+- Always check is_protected before editing a layer you haven't verified
+- Use find_entities with text_contains to locate labeled elements
+- When moving entities, calculate displacement in drawing units
+  - "two feet east" = dx=24 (if units are inches) or dx=2 (if units are feet)
+- Prefer precise targeting: search for the entity, verify its handle, then edit
+
+STRUCTURAL DOMAIN KNOWLEDGE:
+- Footings: spread footings (isolated pads) or strip footings (continuous walls)
+- Grid lines: reference framework, usually lettered one way and numbered the other
+- Column marks: typically circles or block references at grid intersections
+- Pier/pad: foundation element, usually a block reference (INSERT entity)
+- Wall: typically represented as LWPOLYLINE or parallel LINEs
+"""
+
 USER_PROMPT_TEMPLATE = """Drawing context:
 {drawing_context}
 

--- a/src/cad_dxf_agent/llm/proxy_client.py
+++ b/src/cad_dxf_agent/llm/proxy_client.py
@@ -1,0 +1,253 @@
+"""Proxy client — routes Gemini requests through a Cloud Run proxy.
+
+Desktop users send requests with a license key instead of GCP credentials.
+The proxy (proxy/main.py) handles Vertex AI auth and rate limiting.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ..models.ops_schema import ChangeSet
+from ..otel import get_tracer
+from ..settings import settings
+from .prompt_templates import AGENT_SYSTEM_PROMPT
+from .providers import PlannerProvider
+from .tool_definitions import ALL_TOOLS
+from .tool_executor import ToolExecutor
+from .vision_describer import describe_drawing_mock
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+MAX_AGENT_TURNS = 10
+
+
+class ProxyAgentProvider(PlannerProvider):
+    """Agent provider that routes through the Cloud Run proxy.
+
+    Mirrors AgentProvider's tool-use loop but sends requests to the proxy
+    endpoint instead of calling Vertex AI directly.
+    """
+
+    def __init__(
+        self,
+        proxy_url: str | None = None,
+        license_key: str | None = None,
+        model_name: str | None = None,
+        image_path: str | Path | None = None,
+    ) -> None:
+        self._proxy_url = (proxy_url or settings.proxy_url or "").rstrip("/")
+        self._license_key = license_key or settings.license_key or ""
+        self._model_name = model_name or settings.gemini_model
+        self._image_path = image_path
+
+        if not self._proxy_url:
+            raise ValueError("CAD_PROXY_URL is required for proxy provider")
+
+    @property
+    def name(self) -> str:
+        return f"proxy-agent ({self._model_name})"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False  # Uses license key, not API key
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        """Run tool-use agent loop through the Cloud Run proxy."""
+        with tracer.start_as_current_span("cad.proxy_agent_plan") as span:
+            span.set_attribute("cad.agent.model", self._model_name)
+
+            context = self._reconstruct_context(drawing_context)
+            executor = ToolExecutor(context, settings.protected_layers)
+
+            # Build initial prompt
+            initial_prompt = self._build_initial_prompt(prompt, drawing_context)
+
+            # Conversation history for the proxy
+            contents: list[dict[str, Any]] = [{"role": "user", "parts": [{"text": initial_prompt}]}]
+
+            # Build tool declarations for the proxy
+            tool_declarations = [
+                {
+                    "function_declarations": [
+                        {
+                            "name": t["name"],
+                            "description": t["description"],
+                            "parameters": t["parameters"],
+                        }
+                        for t in ALL_TOOLS
+                    ]
+                }
+            ]
+
+            turns = 0
+            while turns < MAX_AGENT_TURNS:
+                # Send request to proxy
+                response = self._proxy_generate(contents, tool_declarations)
+                function_calls = self._extract_function_calls(response)
+
+                if not function_calls:
+                    break
+
+                turns += 1
+                span.add_event(f"agent_turn_{turns}", {"tool_count": len(function_calls)})
+
+                # Execute tools locally
+                tool_results = []
+                for fc in function_calls:
+                    tool_name = fc["name"]
+                    tool_args = fc["args"]
+                    logger.info("Proxy agent tool call [%d]: %s(%s)", turns, tool_name, tool_args)
+
+                    try:
+                        result = executor.execute(tool_name, tool_args)
+                    except KeyError:
+                        result = {"error": f"Unknown tool: {tool_name}"}
+                    except Exception as e:
+                        result = {"error": f"Tool execution failed: {e}"}
+
+                    tool_results.append({"name": tool_name, "response": result})
+
+                # Add model's function calls to conversation
+                model_parts = []
+                for fc in function_calls:
+                    model_parts.append({"function_call": fc})
+                contents.append({"role": "model", "parts": model_parts})
+
+                # Add function responses
+                fn_parts = []
+                for tr in tool_results:
+                    fn_parts.append(
+                        {
+                            "function_response": {
+                                "name": tr["name"],
+                                "response": tr["response"],
+                            }
+                        }
+                    )
+                contents.append({"role": "function", "parts": fn_parts})
+
+            span.set_attribute("cad.agent.turns", turns)
+            span.set_attribute("cad.agent.ops_count", len(executor.operations))
+
+            return ChangeSet(
+                prompt=prompt,
+                operations=executor.operations,
+                revision_label=f"Proxy agent edit ({turns} turns): {prompt[:50]}",
+            )
+
+    def _proxy_generate(
+        self,
+        contents: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Send a generate request to the Cloud Run proxy."""
+        import urllib.request
+
+        url = f"{self._proxy_url}/v1/generate"
+        if not url.startswith(("http://", "https://")):
+            raise ValueError(f"Proxy URL must use http(s): {url}")
+
+        payload = json.dumps(
+            {
+                "model": self._model_name,
+                "contents": contents,
+                "system_instruction": AGENT_SYSTEM_PROMPT,
+                "tools": tools,
+            }
+        ).encode()
+
+        req = urllib.request.Request(  # noqa: S310
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._license_key}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            body = e.read().decode() if e.fp else ""
+            logger.error("Proxy error %d: %s", e.code, body)
+            raise RuntimeError(f"Proxy returned {e.code}: {body}") from e
+
+    def _extract_function_calls(self, response: dict) -> list[dict[str, Any]]:
+        """Extract function calls from the proxy response."""
+        calls = []
+        for candidate in response.get("candidates", []):
+            for part in candidate.get("content", {}).get("parts", []):
+                if "function_call" in part:
+                    fc = part["function_call"]
+                    calls.append(
+                        {
+                            "name": fc.get("name", ""),
+                            "args": fc.get("args", {}),
+                        }
+                    )
+        return calls
+
+    def _build_initial_prompt(self, prompt: str, drawing_context: dict) -> str:
+        """Build the initial message with drawing context."""
+        parts = []
+
+        if self._image_path:
+            try:
+                description = describe_drawing_mock()
+                parts.append(f"DRAWING VISUAL DESCRIPTION:\n{description}\n")
+            except Exception as e:
+                logger.warning("Vision description failed: %s", e)
+
+        entity_summary = json.dumps(drawing_context, indent=2, default=str)
+        parts.append(f"DRAWING ENTITIES (JSON):\n{entity_summary}\n")
+        parts.append(f"USER REQUEST:\n{prompt}")
+
+        return "\n".join(parts)
+
+    def _reconstruct_context(self, drawing_context: dict) -> Any:
+        """Reconstruct DrawingContext from the planner dict."""
+        from ..models.cad_schema import (
+            DrawingContext,
+            EntityRef,
+            EntityType,
+            LayerRule,
+            Point2D,
+        )
+
+        entities = []
+        for e in drawing_context.get("entities", []):
+            try:
+                point = None
+                if e.get("insert_point"):
+                    point = Point2D(x=e["insert_point"]["x"], y=e["insert_point"]["y"])
+                entities.append(
+                    EntityRef(
+                        handle=e["handle"],
+                        entity_type=EntityType(e["type"]),
+                        layer=e["layer"],
+                        insert_point=point,
+                        text_content=e.get("text"),
+                        block_name=e.get("block_name"),
+                    )
+                )
+            except (KeyError, ValueError):
+                continue
+
+        layers = [
+            LayerRule(name=lyr["name"], protected=lyr.get("protected", False))
+            for lyr in drawing_context.get("layers", [])
+        ]
+
+        return DrawingContext(
+            file_path=drawing_context.get("file_path", ""),
+            entities=entities,
+            layers=layers,
+            blocks=drawing_context.get("blocks", []),
+        )

--- a/src/cad_dxf_agent/llm/proxy_client.py
+++ b/src/cad_dxf_agent/llm/proxy_client.py
@@ -161,7 +161,7 @@ class ProxyAgentProvider(PlannerProvider):
             }
         ).encode()
 
-        req = urllib.request.Request(  # noqa: S310
+        req = urllib.request.Request(  # noqa: S310  # nosec B310
             url,
             data=payload,
             headers={
@@ -172,8 +172,9 @@ class ProxyAgentProvider(PlannerProvider):
         )
 
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
-                return json.loads(resp.read().decode())
+            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310  # nosec B310
+                result: dict[str, Any] = json.loads(resp.read().decode())
+                return result
         except urllib.error.HTTPError as e:
             body = e.read().decode() if e.fp else ""
             logger.error("Proxy error %d: %s", e.code, body)

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -1,0 +1,241 @@
+"""CAD tool definitions for Gemini function calling.
+
+Defines the tool schemas that the LLM agent can invoke to query and
+edit the drawing. Each tool wraps existing EntityIndex / EditEngine
+methods. The LLM never touches DXF directly — it calls these tools,
+and the host code executes them against the validated pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tool schemas for Gemini function calling
+# ---------------------------------------------------------------------------
+# Each dict follows the Gemini FunctionDeclaration schema:
+#   name, description, parameters (JSON Schema object)
+# ---------------------------------------------------------------------------
+
+FIND_ENTITIES = {
+    "name": "find_entities",
+    "description": (
+        "Search for entities in the drawing by layer, type, and/or text content. "
+        "Returns a list of matching entities with handle, type, layer, position, and text."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "layer": {
+                "type": "string",
+                "description": "Filter by layer name (case-insensitive). Example: 'STRUCTURAL'",
+            },
+            "entity_type": {
+                "type": "string",
+                "description": "Filter by entity type: LINE, LWPOLYLINE, TEXT, MTEXT, INSERT",
+                "enum": ["LINE", "LWPOLYLINE", "TEXT", "MTEXT", "INSERT"],
+            },
+            "text_contains": {
+                "type": "string",
+                "description": (
+                    "Search for entities whose text contains this string (case-insensitive)"
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+GET_ENTITY = {
+    "name": "get_entity",
+    "description": (
+        "Get full details of a single entity by its handle (unique ID). "
+        "Returns handle, type, layer, position, text content, and block name."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "The DXF entity handle (unique identifier)",
+            },
+        },
+        "required": ["handle"],
+    },
+}
+
+FIND_NEAREST = {
+    "name": "find_nearest",
+    "description": (
+        "Find the nearest entity to a given point. Useful for locating entities "
+        "at grid intersections or near specific coordinates."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "x": {"type": "number", "description": "X coordinate in drawing units"},
+            "y": {"type": "number", "description": "Y coordinate in drawing units"},
+            "entity_type": {
+                "type": "string",
+                "description": "Optional type filter",
+                "enum": ["LINE", "LWPOLYLINE", "TEXT", "MTEXT", "INSERT"],
+            },
+            "layer": {
+                "type": "string",
+                "description": "Optional layer filter (case-insensitive)",
+            },
+        },
+        "required": ["x", "y"],
+    },
+}
+
+LIST_LAYERS = {
+    "name": "list_layers",
+    "description": (
+        "List all layers in the drawing with their protection status and entity counts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+IS_PROTECTED = {
+    "name": "is_protected",
+    "description": "Check whether a layer is protected from editing.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "layer": {
+                "type": "string",
+                "description": "The layer name to check",
+            },
+        },
+        "required": ["layer"],
+    },
+}
+
+MOVE_ENTITY = {
+    "name": "move_entity",
+    "description": (
+        "Move an entity by a displacement vector (dx, dy) in drawing units. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to move",
+            },
+            "dx": {
+                "type": "number",
+                "description": "Displacement in X direction (drawing units)",
+            },
+            "dy": {
+                "type": "number",
+                "description": "Displacement in Y direction (drawing units)",
+            },
+        },
+        "required": ["handle", "dx", "dy"],
+    },
+}
+
+EDIT_TEXT = {
+    "name": "edit_text",
+    "description": (
+        "Change the text content of a TEXT or MTEXT entity. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the TEXT/MTEXT entity to edit",
+            },
+            "new_text": {
+                "type": "string",
+                "description": "The new text content",
+            },
+        },
+        "required": ["handle", "new_text"],
+    },
+}
+
+DELETE_ENTITY = {
+    "name": "delete_entity",
+    "description": (
+        "Delete an entity from the drawing. Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to delete",
+            },
+        },
+        "required": ["handle"],
+    },
+}
+
+ADD_BLOCK = {
+    "name": "add_block",
+    "description": (
+        "Insert a block reference at a specified point. "
+        "The block must exist in the drawing's block definitions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "block_name": {
+                "type": "string",
+                "description": "Name of the block definition to insert",
+            },
+            "x": {
+                "type": "number",
+                "description": "X coordinate for insertion point",
+            },
+            "y": {
+                "type": "number",
+                "description": "Y coordinate for insertion point",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Optional target layer for the block reference",
+            },
+            "scale": {
+                "type": "number",
+                "description": "Uniform scale factor (default 1.0)",
+            },
+            "rotation": {
+                "type": "number",
+                "description": "Rotation angle in degrees (default 0)",
+            },
+        },
+        "required": ["block_name", "x", "y"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Query tools (read-only) vs. edit tools (produce operations)
+# ---------------------------------------------------------------------------
+
+QUERY_TOOLS = [FIND_ENTITIES, GET_ENTITY, FIND_NEAREST, LIST_LAYERS, IS_PROTECTED]
+EDIT_TOOLS = [MOVE_ENTITY, EDIT_TEXT, DELETE_ENTITY, ADD_BLOCK]
+ALL_TOOLS = QUERY_TOOLS + EDIT_TOOLS
+
+
+def get_tool_by_name(name: str) -> dict[str, Any] | None:
+    """Look up a tool definition by name."""
+    for tool in ALL_TOOLS:
+        if tool["name"] == name:
+            return tool
+    return None
+
+
+def is_edit_tool(name: str) -> bool:
+    """Return True if the tool name is an edit (mutating) tool."""
+    return any(t["name"] == name for t in EDIT_TOOLS)

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -1,0 +1,240 @@
+"""Tool executor — runs CAD tools invoked by the LLM agent.
+
+Maps tool names to EntityIndex / drawing context operations.
+Edit tools (move, delete, edit_text, add_block) accumulate
+EditOperation objects instead of mutating the drawing directly.
+The operations are later validated and applied by the pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..core.entity_index import EntityIndex
+from ..models.cad_schema import DrawingContext, EntityRef
+from ..models.ops_schema import EditOperation, OpType
+
+logger = logging.getLogger(__name__)
+
+
+class ToolExecutor:
+    """Executes CAD tool calls against a DrawingContext.
+
+    Query tools return results immediately.
+    Edit tools accumulate EditOperation objects for later validation.
+    """
+
+    def __init__(
+        self,
+        context: DrawingContext,
+        protected_layers: list[str] | None = None,
+    ) -> None:
+        self._context = context
+        self._index = EntityIndex(context)
+        self._protected = [p.upper() for p in (protected_layers or [])]
+        self._operations: list[EditOperation] = []
+
+    @property
+    def operations(self) -> list[EditOperation]:
+        """Accumulated edit operations from tool calls."""
+        return list(self._operations)
+
+    def execute(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        """Execute a tool call and return a JSON-serializable result.
+
+        Raises KeyError for unknown tool names.
+        """
+        dispatch = {
+            "find_entities": self._find_entities,
+            "get_entity": self._get_entity,
+            "find_nearest": self._find_nearest,
+            "list_layers": self._list_layers,
+            "is_protected": self._is_protected,
+            "move_entity": self._move_entity,
+            "edit_text": self._edit_text,
+            "delete_entity": self._delete_entity,
+            "add_block": self._add_block,
+        }
+
+        handler = dispatch.get(tool_name)
+        if handler is None:
+            raise KeyError(f"Unknown tool: {tool_name}")
+
+        logger.debug("Executing tool: %s(%s)", tool_name, args)
+        return handler(args)
+
+    # --- Query tools ---
+
+    def _find_entities(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        entity_type = args.get("entity_type")
+        text_contains = args.get("text_contains")
+
+        candidates = self._index.filter(layer=layer, entity_type=entity_type)
+
+        if text_contains:
+            text_matches = self._index.search_text(text_contains)
+            match_handles = {e.handle for e in text_matches}
+            candidates = [e for e in candidates if e.handle in match_handles]
+
+        return {
+            "count": len(candidates),
+            "entities": [_entity_to_dict(e) for e in candidates[:50]],
+        }
+
+    def _get_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        return _entity_to_dict(entity)
+
+    def _find_nearest(self, args: dict[str, Any]) -> dict[str, Any]:
+        x = args["x"]
+        y = args["y"]
+        entity = self._index.nearest(
+            x,
+            y,
+            entity_type=args.get("entity_type"),
+            layer=args.get("layer"),
+        )
+        if entity is None:
+            return {"error": "No matching entity found near that point"}
+        return _entity_to_dict(entity)
+
+    def _list_layers(self, args: dict[str, Any]) -> dict[str, Any]:
+        layers = []
+        for layer in self._context.layers:
+            entity_count = sum(
+                1 for e in self._context.entities if e.layer.upper() == layer.name.upper()
+            )
+            layers.append(
+                {
+                    "name": layer.name,
+                    "protected": layer.name.upper() in self._protected,
+                    "visible": layer.visible,
+                    "frozen": layer.frozen,
+                    "entity_count": entity_count,
+                }
+            )
+        return {"layers": layers}
+
+    def _is_protected(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args["layer"]
+        return {
+            "layer": layer,
+            "protected": layer.upper() in self._protected,
+        }
+
+    # --- Edit tools (accumulate operations) ---
+
+    def _move_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot move entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.MOVE_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+            params={"dx": args["dx"], "dy": args["dy"]},
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "move_entity",
+            "handle": handle,
+            "dx": args["dx"],
+            "dy": args["dy"],
+        }
+
+    def _edit_text(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot edit entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.EDIT_TEXT,
+            target_handle=handle,
+            target_layer=entity.layer,
+            params={"new_text": args["new_text"]},
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "edit_text",
+            "handle": handle,
+            "new_text": args["new_text"],
+        }
+
+    def _delete_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot delete entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.DELETE_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "delete_entity",
+            "handle": handle,
+        }
+
+    def _add_block(self, args: dict[str, Any]) -> dict[str, Any]:
+        block_name = args["block_name"]
+        x = args["x"]
+        y = args["y"]
+        layer = args.get("layer")
+
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot insert block on protected layer: {layer}"}
+
+        op = EditOperation(
+            op_type=OpType.ADD_BLOCK,
+            target_layer=layer,
+            params={
+                "block_name": block_name,
+                "insert_point": {"x": x, "y": y},
+                "scale": args.get("scale", 1.0),
+                "rotation": args.get("rotation", 0.0),
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_block",
+            "block_name": block_name,
+            "x": x,
+            "y": y,
+        }
+
+
+def _entity_to_dict(entity: EntityRef) -> dict[str, Any]:
+    """Convert an EntityRef to a JSON-serializable dict for tool results."""
+    d: dict[str, Any] = {
+        "handle": entity.handle,
+        "type": entity.entity_type.value,
+        "layer": entity.layer,
+    }
+    if entity.insert_point:
+        d["x"] = entity.insert_point.x
+        d["y"] = entity.insert_point.y
+    if entity.text_content:
+        d["text"] = entity.text_content
+    if entity.block_name:
+        d["block_name"] = entity.block_name
+    return d

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -106,16 +106,13 @@ class ToolExecutor:
     def _list_layers(self, args: dict[str, Any]) -> dict[str, Any]:
         layers = []
         for layer in self._context.layers:
-            entity_count = sum(
-                1 for e in self._context.entities if e.layer.upper() == layer.name.upper()
-            )
             layers.append(
                 {
                     "name": layer.name,
                     "protected": layer.name.upper() in self._protected,
                     "visible": layer.visible,
                     "frozen": layer.frozen,
-                    "entity_count": entity_count,
+                    "entity_count": len(self._index.get_by_layer(layer.name)),
                 }
             )
         return {"layers": layers}

--- a/src/cad_dxf_agent/llm/vision_describer.py
+++ b/src/cad_dxf_agent/llm/vision_describer.py
@@ -73,7 +73,7 @@ def describe_drawing(image_path: str | Path) -> str:
                 [Part.from_image(image), VISION_PROMPT]  # type: ignore[arg-type]
             )
 
-            description = response.text
+            description: str = str(response.text)
             if not description:
                 raise RuntimeError("Gemini returned empty vision description")
 

--- a/src/cad_dxf_agent/llm/vision_describer.py
+++ b/src/cad_dxf_agent/llm/vision_describer.py
@@ -1,0 +1,111 @@
+"""Vision describer — Stage 1 of the two-stage hybrid vision pipeline.
+
+Takes a PNG render of a drawing and produces a text description of the
+layout using Gemini Flash vision. The description is then fed into
+Stage 2 (the agent planner) as additional context, avoiding the need
+to send the image on every turn of the tool-use loop.
+
+This module is optional — if no image is available, the agent works
+with entity JSON alone.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..otel import get_tracer
+from ..settings import settings
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+VISION_PROMPT = (
+    "You are a structural engineering drawing analyst. "
+    "Describe this 2D CAD drawing concisely. Include:\n"
+    "1. Drawing type (foundation plan, framing plan, detail, etc.)\n"
+    "2. Grid line layout (labels and approximate spacing)\n"
+    "3. Key structural elements (footings, walls, columns, beams) and their locations\n"
+    "4. Text annotations and labels visible\n"
+    "5. Title block content if visible\n"
+    "6. Overall dimensions and scale if discernible\n\n"
+    "Be factual and precise. Reference grid intersections when describing locations. "
+    "Use the coordinate system visible in the drawing."
+)
+
+
+def describe_drawing(image_path: str | Path) -> str:
+    """Send a drawing image to Gemini Flash for layout description.
+
+    Args:
+        image_path: Path to a PNG render of the drawing.
+
+    Returns:
+        Text description of the drawing layout.
+
+    Raises:
+        FileNotFoundError: If the image file doesn't exist.
+        RuntimeError: If Gemini is unavailable or returns an error.
+    """
+    with tracer.start_as_current_span("cad.vision_describe") as span:
+        image_path = Path(image_path)
+        if not image_path.exists():
+            raise FileNotFoundError(f"Image not found: {image_path}")
+
+        span.set_attribute("cad.vision.image", image_path.name)
+
+        model_name = settings.vision_model
+        span.set_attribute("cad.vision.model", model_name)
+
+        try:
+            import vertexai
+            from vertexai.generative_models import GenerativeModel, Image, Part
+
+            vertexai.init(
+                project=settings.gcp_project,
+                location=settings.gcp_location,
+            )
+
+            model = GenerativeModel(model_name)
+            image = Image.load_from_file(str(image_path))
+
+            response = model.generate_content(
+                [Part.from_image(image), VISION_PROMPT]  # type: ignore[arg-type]
+            )
+
+            description = response.text
+            if not description:
+                raise RuntimeError("Gemini returned empty vision description")
+
+            span.set_attribute("cad.vision.description_length", len(description))
+            logger.info(
+                "Vision description generated (%d chars) for %s",
+                len(description),
+                image_path.name,
+            )
+            return description
+
+        except ImportError as err:
+            raise RuntimeError(
+                "google-cloud-aiplatform not installed. "
+                "Install with: pip install google-cloud-aiplatform"
+            ) from err
+
+
+def describe_drawing_mock(image_path: str | Path | None = None) -> str:
+    """Return a mock vision description for testing without API access.
+
+    Produces a realistic structural drawing description that exercises
+    the downstream planning pipeline.
+    """
+    return (
+        "This is a structural foundation plan. "
+        "Grid lines A through E run vertically (left to right) at 20-foot spacing. "
+        "Grid lines 1 through 4 run horizontally (bottom to top) at 24-foot spacing. "
+        "Spread footings F1 through F12 are located at grid intersections, "
+        'typically 4\'-0" x 4\'-0" x 12" deep. '
+        "A continuous wall footing runs along grid line A from grid 1 to grid 4. "
+        "Column marks C1 through C12 are placed at each footing location. "
+        "Text note at bottom: 'SEE STRUCTURAL DETAILS SHEET S-2'. "
+        "Title block reads: 'FOUNDATION PLAN - BUILDING A'."
+    )

--- a/src/cad_dxf_agent/models/cad_schema.py
+++ b/src/cad_dxf_agent/models/cad_schema.py
@@ -31,6 +31,7 @@ class EntityRef(BaseModel):
     handle: str = Field(description="DXF entity handle (unique within the drawing)")
     entity_type: EntityType
     layer: str
+    space: str = Field(default="Model", description="Space: 'Model' or layout name")
     insert_point: Point2D | None = None
     text_content: str | None = None
     block_name: str | None = None
@@ -47,6 +48,13 @@ class LayerRule(BaseModel):
     color: int | None = None
 
 
+class LayoutInfo(BaseModel):
+    """Metadata about a DXF layout (paper space tab)."""
+
+    name: str
+    entity_count: int = 0
+
+
 class DrawingContext(BaseModel):
     """Normalized context model for a loaded DXF drawing."""
 
@@ -54,6 +62,7 @@ class DrawingContext(BaseModel):
     entities: list[EntityRef] = Field(default_factory=list)
     layers: list[LayerRule] = Field(default_factory=list)
     blocks: list[str] = Field(default_factory=list)
+    layouts: list[LayoutInfo] = Field(default_factory=list)
     unsupported_entity_types: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -51,8 +51,13 @@ class Settings:
         # Gemini / Vertex AI (V2)
         self.gcp_project: str | None = os.getenv("CAD_GCP_PROJECT")
         self.gcp_location: str = os.getenv("CAD_GCP_LOCATION", "us-central1")
-        self.gemini_model: str = os.getenv("CAD_GEMINI_MODEL", "gemini-1.5-pro")
+        self.gemini_model: str = os.getenv("CAD_GEMINI_MODEL", "gemini-2.5-flash")
+        self.vision_model: str = os.getenv("CAD_VISION_MODEL", "gemini-2.5-flash")
         self.gemini_max_retries: int = int(os.getenv("CAD_GEMINI_MAX_RETRIES", "1"))
+
+        # Cloud Run proxy (optional — lets users skip GCP credentials)
+        self.proxy_url: str | None = os.getenv("CAD_PROXY_URL")
+        self.license_key: str | None = os.getenv("CAD_LICENSE_KEY")
 
         # Local API
         self.api_host: str = os.getenv("CAD_API_HOST", "127.0.0.1")

--- a/src/cad_dxf_agent/ui/main_window.py
+++ b/src/cad_dxf_agent/ui/main_window.py
@@ -1,4 +1,14 @@
-"""Main desktop window — PySide6 shell for the DXF editing workflow."""
+"""Main desktop window — PySide6 shell for the DXF editing workflow.
+
+Full-featured desktop UI for Tony's structural drawing edits:
+- File open (DXF/DWG/PDF with format detection)
+- Layout/space selector
+- Prompt input with history
+- Per-operation approve/reject checkboxes
+- Undo/redo (Ctrl+Z / Ctrl+Y)
+- Export menu (DXF, PNG, PDF)
+- Status bar with entity count and layer info
+"""
 
 from __future__ import annotations
 
@@ -6,30 +16,41 @@ import logging
 import traceback
 from pathlib import Path
 
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
-    QListWidget,
     QMainWindow,
     QMessageBox,
     QPushButton,
+    QScrollArea,
+    QSplitter,
+    QStatusBar,
     QTextEdit,
+    QToolBar,
     QVBoxLayout,
     QWidget,
 )
 
 from ..core.dxf_reader import load_dxf
 from ..core.edit_engine import EditEngine
+from ..core.edit_history import EditHistory
 from ..core.preview_model import PreviewModel
 from ..core.revision_notes import insert_revision_note
 from ..core.semantic_model import build_planner_context
 from ..core.validators import validate_changeset
 from ..llm.planner import run_planner
 from ..models.config_schema import RevisionNoteConfig, RuleConfig
+from ..models.ops_schema import ChangeSet, EditOperation
 from ..settings import settings
 
 logger = logging.getLogger(__name__)
+
+FILE_FILTER = "CAD Files (*.dxf *.dwg *.pdf);;DXF Files (*.dxf);;All Files (*)"
 
 
 class MainWindow(QMainWindow):
@@ -37,102 +58,292 @@ class MainWindow(QMainWindow):
 
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("cad-dxf-agent — DXF Layout Editor")
-        self.setMinimumSize(900, 600)
+        self.setWindowTitle("CAD DXF Agent — Structural Drawing Editor")
+        self.setMinimumSize(1100, 700)
 
         self._dxf_path: Path | None = None
         self._context = None
-        self._changeset = None
+        self._changeset: ChangeSet | None = None
         self._preview = None
+        self._history: EditHistory | None = None
+        self._op_checkboxes: list[QCheckBox] = []
+        self._prompt_history: list[str] = []
         self._rule_config = RuleConfig(protected_layers=settings.protected_layers)
         self._rev_config = RevisionNoteConfig(
             enabled=settings.revision_notes_enabled,
             layer_name=settings.revision_notes_layer,
         )
 
+        self._build_menu()
+        self._build_toolbar()
         self._build_ui()
+        self._build_statusbar()
+
+    # ── Menu bar ──────────────────────────────────────────────────
+
+    def _build_menu(self):
+        menubar = self.menuBar()
+
+        # File menu
+        file_menu = menubar.addMenu("&File")
+
+        open_action = QAction("&Open...", self)
+        open_action.setShortcut(QKeySequence.StandardKey.Open)
+        open_action.triggered.connect(self._on_open)
+        file_menu.addAction(open_action)
+
+        file_menu.addSeparator()
+
+        export_dxf = QAction("Export as &DXF...", self)
+        export_dxf.triggered.connect(lambda: self._on_export("dxf"))
+        file_menu.addAction(export_dxf)
+
+        export_png = QAction("Export as &PNG...", self)
+        export_png.triggered.connect(lambda: self._on_export("png"))
+        file_menu.addAction(export_png)
+
+        export_pdf = QAction("Export as P&DF...", self)
+        export_pdf.triggered.connect(lambda: self._on_export("pdf"))
+        file_menu.addAction(export_pdf)
+
+        file_menu.addSeparator()
+
+        quit_action = QAction("&Quit", self)
+        quit_action.setShortcut(QKeySequence.StandardKey.Quit)
+        quit_action.triggered.connect(self.close)
+        file_menu.addAction(quit_action)
+
+        # Edit menu
+        edit_menu = menubar.addMenu("&Edit")
+
+        self._undo_action = QAction("&Undo", self)
+        self._undo_action.setShortcut(QKeySequence.StandardKey.Undo)
+        self._undo_action.setEnabled(False)
+        self._undo_action.triggered.connect(self._on_undo)
+        edit_menu.addAction(self._undo_action)
+
+        self._redo_action = QAction("&Redo", self)
+        self._redo_action.setShortcut(QKeySequence.StandardKey.Redo)
+        self._redo_action.setEnabled(False)
+        self._redo_action.triggered.connect(self._on_redo)
+        edit_menu.addAction(self._redo_action)
+
+    # ── Toolbar ───────────────────────────────────────────────────
+
+    def _build_toolbar(self):
+        toolbar = QToolBar("Main")
+        toolbar.setMovable(False)
+        self.addToolBar(toolbar)
+
+        self.btn_undo = QPushButton("Undo")
+        self.btn_undo.setEnabled(False)
+        self.btn_undo.clicked.connect(self._on_undo)
+        toolbar.addWidget(self.btn_undo)
+
+        self.btn_redo = QPushButton("Redo")
+        self.btn_redo.setEnabled(False)
+        self.btn_redo.clicked.connect(self._on_redo)
+        toolbar.addWidget(self.btn_redo)
+
+    # ── Main UI ───────────────────────────────────────────────────
 
     def _build_ui(self):
         central = QWidget()
         self.setCentralWidget(central)
+        main_layout = QVBoxLayout(central)
 
-        main_layout = QHBoxLayout(central)
+        splitter = QSplitter(Qt.Orientation.Horizontal)
 
-        # Left panel: controls
-        left = QVBoxLayout()
+        # ── Left panel: file + prompt + controls ──
+        left_widget = QWidget()
+        left = QVBoxLayout(left_widget)
 
-        # Open DXF
-        self.btn_open = QPushButton("Open DXF")
+        # File controls
+        file_row = QHBoxLayout()
+        self.btn_open = QPushButton("Open File...")
         self.btn_open.clicked.connect(self._on_open)
-        left.addWidget(self.btn_open)
+        file_row.addWidget(self.btn_open)
 
         self.lbl_file = QLabel("No file loaded")
-        left.addWidget(self.lbl_file)
+        file_row.addWidget(self.lbl_file, 1)
+        left.addLayout(file_row)
 
-        # Prompt
-        left.addWidget(QLabel("Prompt:"))
+        # Layout selector
+        layout_row = QHBoxLayout()
+        layout_row.addWidget(QLabel("Space:"))
+        self.cmb_layout = QComboBox()
+        self.cmb_layout.addItem("Model")
+        self.cmb_layout.setEnabled(False)
+        layout_row.addWidget(self.cmb_layout, 1)
+        left.addLayout(layout_row)
+
+        # Prompt input
+        left.addWidget(QLabel("Edit prompt:"))
         self.txt_prompt = QTextEdit()
-        self.txt_prompt.setMaximumHeight(100)
-        self.txt_prompt.setPlaceholderText("Describe the edit you want to make...")
+        self.txt_prompt.setMaximumHeight(80)
+        self.txt_prompt.setPlaceholderText('e.g. "Move the footing at grid C-4 two feet east"')
         left.addWidget(self.txt_prompt)
 
-        # Plan / Preview
+        # Action buttons
+        btn_row = QHBoxLayout()
         self.btn_plan = QPushButton("Plan && Preview")
         self.btn_plan.setEnabled(False)
         self.btn_plan.clicked.connect(self._on_plan)
-        left.addWidget(self.btn_plan)
+        btn_row.addWidget(self.btn_plan)
 
-        # Apply / Save
-        self.btn_apply = QPushButton("Apply && Save As...")
+        self.btn_apply = QPushButton("Apply Selected")
         self.btn_apply.setEnabled(False)
         self.btn_apply.clicked.connect(self._on_apply)
-        left.addWidget(self.btn_apply)
+        btn_row.addWidget(self.btn_apply)
+        left.addLayout(btn_row)
 
-        # Status
-        left.addWidget(QLabel("Status:"))
+        # Status log
+        left.addWidget(QLabel("Log:"))
         self.txt_status = QTextEdit()
         self.txt_status.setReadOnly(True)
-        self.txt_status.setMaximumHeight(120)
+        self.txt_status.setMaximumHeight(150)
         left.addWidget(self.txt_status)
 
         left.addStretch()
-        main_layout.addLayout(left, 1)
+        splitter.addWidget(left_widget)
 
-        # Right panel: operations list
-        right = QVBoxLayout()
-        right.addWidget(QLabel("Operations:"))
-        self.lst_ops = QListWidget()
-        right.addWidget(self.lst_ops)
-        main_layout.addLayout(right, 1)
+        # ── Right panel: operations with checkboxes ──
+        right_widget = QWidget()
+        right = QVBoxLayout(right_widget)
+        right.addWidget(QLabel("Proposed Operations:"))
+
+        # Select all / none
+        select_row = QHBoxLayout()
+        self.btn_select_all = QPushButton("Select All")
+        self.btn_select_all.clicked.connect(self._select_all_ops)
+        select_row.addWidget(self.btn_select_all)
+        self.btn_select_none = QPushButton("Select None")
+        self.btn_select_none.clicked.connect(self._select_none_ops)
+        select_row.addWidget(self.btn_select_none)
+        select_row.addStretch()
+        right.addLayout(select_row)
+
+        # Scrollable operations area
+        self.ops_scroll = QScrollArea()
+        self.ops_scroll.setWidgetResizable(True)
+        self.ops_container = QWidget()
+        self.ops_layout = QVBoxLayout(self.ops_container)
+        self.ops_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        self.ops_scroll.setWidget(self.ops_container)
+        right.addWidget(self.ops_scroll)
+
+        splitter.addWidget(right_widget)
+        splitter.setSizes([450, 550])
+
+        main_layout.addWidget(splitter)
+
+    # ── Status bar ────────────────────────────────────────────────
+
+    def _build_statusbar(self):
+        status = QStatusBar()
+        self.setStatusBar(status)
+        self.lbl_entity_count = QLabel("Entities: -")
+        self.lbl_layer_count = QLabel("Layers: -")
+        self.lbl_provider = QLabel(f"Provider: {settings.llm_provider}")
+        status.addWidget(self.lbl_entity_count)
+        status.addWidget(self.lbl_layer_count)
+        status.addPermanentWidget(self.lbl_provider)
+
+    # ── Helpers ───────────────────────────────────────────────────
 
     def _log_status(self, msg: str):
         self.txt_status.append(msg)
         logger.info(msg)
 
+    def _update_undo_redo(self):
+        can_undo = self._history is not None and self._history.can_undo
+        can_redo = self._history is not None and self._history.can_redo
+        self._undo_action.setEnabled(can_undo)
+        self._redo_action.setEnabled(can_redo)
+        self.btn_undo.setEnabled(can_undo)
+        self.btn_redo.setEnabled(can_redo)
+
+    def _clear_ops(self):
+        self._op_checkboxes.clear()
+        while self.ops_layout.count():
+            child = self.ops_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+    def _select_all_ops(self):
+        for cb in self._op_checkboxes:
+            cb.setChecked(True)
+
+    def _select_none_ops(self):
+        for cb in self._op_checkboxes:
+            cb.setChecked(False)
+
+    # ── Event handlers ────────────────────────────────────────────
+
     def _on_open(self):
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Open DXF File", "", "DXF Files (*.dxf);;All Files (*)"
-        )
+        path, _ = QFileDialog.getOpenFileName(self, "Open CAD File", "", FILE_FILTER)
         if not path:
             return
 
         try:
-            self._dxf_path = Path(path)
+            file_path = Path(path)
+
+            # DWG/PDF conversion if needed
+            if file_path.suffix.lower() in (".dwg", ".pdf"):
+                try:
+                    from ..core.converter import convert_to_dxf
+
+                    result = convert_to_dxf(file_path)
+                    if result.success:
+                        file_path = result.output_path
+                        self._log_status(f"Converted {path} to DXF")
+                    else:
+                        QMessageBox.warning(
+                            self,
+                            "Conversion",
+                            f"Conversion issue: {result.error}\nTrying to load anyway.",
+                        )
+                except ImportError:
+                    QMessageBox.warning(
+                        self,
+                        "Missing Converter",
+                        "DWG/PDF conversion requires the convert extra.\n"
+                        "Install with: pip install -e '.[convert]'",
+                    )
+                    return
+
+            self._dxf_path = file_path
             self._context = load_dxf(self._dxf_path)
+            self._history = EditHistory(self._dxf_path)
+
+            # Update UI
             self.lbl_file.setText(f"{self._dxf_path.name} ({self._context.entity_count} entities)")
             self.btn_plan.setEnabled(True)
             self.btn_apply.setEnabled(False)
             self._changeset = None
             self._preview = None
-            self.lst_ops.clear()
+            self._clear_ops()
+            self._update_undo_redo()
+
+            # Populate layout selector
+            self.cmb_layout.clear()
+            for layout in self._context.layouts:
+                self.cmb_layout.addItem(f"{layout.name} ({layout.entity_count})")
+            self.cmb_layout.setEnabled(len(self._context.layouts) > 1)
+
+            # Update status bar
+            self.lbl_entity_count.setText(f"Entities: {self._context.entity_count}")
+            self.lbl_layer_count.setText(f"Layers: {len(self._context.layers)}")
+
             self._log_status(f"Loaded: {self._dxf_path.name}")
             if self._context.unsupported_entity_types:
                 self._log_status(
                     f"Skipped types: {', '.join(self._context.unsupported_entity_types)}"
                 )
+
         except Exception as e:
-            QMessageBox.critical(self, "Error", f"Failed to load DXF:\n{e}")
-            logger.error("DXF load error: %s", traceback.format_exc())
+            QMessageBox.critical(self, "Error", f"Failed to load file:\n{e}")
+            logger.error("File load error: %s", traceback.format_exc())
 
     def _on_plan(self):
         if not self._context:
@@ -143,6 +354,10 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "No Prompt", "Enter a prompt describing the edit.")
             return
 
+        # Save to prompt history
+        if prompt not in self._prompt_history:
+            self._prompt_history.append(prompt)
+
         try:
             self._log_status(f"Planning: {prompt[:60]}...")
             drawing_ctx = build_planner_context(self._context)
@@ -151,18 +366,24 @@ class MainWindow(QMainWindow):
             validation = validate_changeset(self._changeset, self._context, self._rule_config)
             self._preview = PreviewModel(self._changeset, self._context, validation)
 
-            self.lst_ops.clear()
+            # Build per-operation checkboxes
+            self._clear_ops()
             for item in self._preview.items:
-                self.lst_ops.addItem(str(item))
+                cb = QCheckBox(str(item))
+                cb.setChecked(True)
+                self._op_checkboxes.append(cb)
+                self.ops_layout.addWidget(cb)
 
-            if validation.valid:
-                self._log_status(f"Plan valid: {self._changeset.op_count} operation(s)")
-                self.btn_apply.setEnabled(True)
-            else:
+            if not validation.valid:
                 for b in validation.blockers:
-                    self.lst_ops.addItem(f"BLOCKED: {b.message}")
+                    lbl = QLabel(f"BLOCKED: {b.message}")
+                    lbl.setStyleSheet("color: red; font-weight: bold;")
+                    self.ops_layout.addWidget(lbl)
                 self._log_status(f"Plan blocked: {len(validation.blockers)} issue(s)")
                 self.btn_apply.setEnabled(False)
+            else:
+                self._log_status(f"Plan valid: {self._changeset.op_count} operation(s)")
+                self.btn_apply.setEnabled(True)
 
             for w in validation.warnings:
                 self._log_status(f"Warning: {w.message}")
@@ -175,6 +396,16 @@ class MainWindow(QMainWindow):
         if not self._changeset or not self._dxf_path:
             return
 
+        # Build filtered changeset from checked operations only
+        selected_ops: list[EditOperation] = []
+        for i, cb in enumerate(self._op_checkboxes):
+            if cb.isChecked() and i < len(self._changeset.operations):
+                selected_ops.append(self._changeset.operations[i])
+
+        if not selected_ops:
+            QMessageBox.warning(self, "No Operations", "Select at least one operation to apply.")
+            return
+
         output_path, _ = QFileDialog.getSaveFileName(
             self,
             "Save As New DXF",
@@ -185,8 +416,23 @@ class MainWindow(QMainWindow):
             return
 
         try:
+            filtered = ChangeSet(
+                prompt=self._changeset.prompt,
+                operations=selected_ops,
+                revision_label=self._changeset.revision_label,
+            )
+
             engine = EditEngine(self._dxf_path)
-            results = engine.apply_changeset(self._changeset)
+            results = engine.apply_changeset(filtered)
+
+            # Capture snapshot for undo before saving
+            if self._history:
+                self._history.push(
+                    engine.doc,
+                    f"Applied {len(selected_ops)} op(s)",
+                )
+                self._update_undo_redo()
+
             engine.save(output_path)
 
             success_count = sum(1 for r in results if r.success)
@@ -205,3 +451,73 @@ class MainWindow(QMainWindow):
         except Exception as e:
             QMessageBox.critical(self, "Apply Error", f"Apply/save failed:\n{e}")
             logger.error("Apply error: %s", traceback.format_exc())
+
+    def _on_undo(self):
+        if not self._history or not self._history.can_undo:
+            return
+        doc = self._history.undo()
+        if doc:
+            self._log_status(f"Undo → {self._history.current_label}")
+            self._update_undo_redo()
+
+    def _on_redo(self):
+        if not self._history or not self._history.can_redo:
+            return
+        doc = self._history.redo()
+        if doc:
+            self._log_status(f"Redo → {self._history.current_label}")
+            self._update_undo_redo()
+
+    def _on_export(self, fmt: str):
+        if not self._dxf_path:
+            QMessageBox.warning(self, "No File", "Open a DXF file first.")
+            return
+
+        filters = {
+            "dxf": "DXF Files (*.dxf)",
+            "png": "PNG Images (*.png)",
+            "pdf": "PDF Documents (*.pdf)",
+        }
+        suffix = f".{fmt}"
+        default_name = self._dxf_path.with_suffix(suffix)
+
+        output_path, _ = QFileDialog.getSaveFileName(
+            self,
+            f"Export as {fmt.upper()}",
+            str(default_name),
+            filters.get(fmt, "All Files (*)"),
+        )
+        if not output_path:
+            return
+
+        try:
+            if fmt == "dxf":
+                import shutil
+
+                shutil.copy2(str(self._dxf_path), output_path)
+                self._log_status(f"Exported DXF to: {output_path}")
+
+            elif fmt in ("png", "pdf"):
+                try:
+                    from ..core.renderer import render_dxf
+
+                    result = render_dxf(
+                        self._dxf_path,
+                        output_format=fmt,
+                        output_path=output_path,
+                    )
+                    if result.success:
+                        self._log_status(f"Exported {fmt.upper()} to: {output_path}")
+                    else:
+                        QMessageBox.warning(self, "Export", f"Export issue: {result.error}")
+                except ImportError:
+                    QMessageBox.warning(
+                        self,
+                        "Missing Renderer",
+                        f"{fmt.upper()} export requires the draw extra.\n"
+                        "Install with: pip install -e '.[draw]'",
+                    )
+
+        except Exception as e:
+            QMessageBox.critical(self, "Export Error", f"Export failed:\n{e}")
+            logger.error("Export error: %s", traceback.format_exc())

--- a/src/cad_dxf_agent/ui/main_window.py
+++ b/src/cad_dxf_agent/ui/main_window.py
@@ -106,6 +106,10 @@ class MainWindow(QMainWindow):
         export_pdf.triggered.connect(lambda: self._on_export("pdf"))
         file_menu.addAction(export_pdf)
 
+        export_dwg = QAction("Export as D&WG...", self)
+        export_dwg.triggered.connect(lambda: self._on_export("dwg"))
+        file_menu.addAction(export_dwg)
+
         file_menu.addSeparator()
 
         quit_action = QAction("&Quit", self)
@@ -477,6 +481,7 @@ class MainWindow(QMainWindow):
             "dxf": "DXF Files (*.dxf)",
             "png": "PNG Images (*.png)",
             "pdf": "PDF Documents (*.pdf)",
+            "dwg": "DWG Files (*.dwg)",
         }
         suffix = f".{fmt}"
         default_name = self._dxf_path.with_suffix(suffix)
@@ -497,25 +502,63 @@ class MainWindow(QMainWindow):
                 shutil.copy2(str(self._dxf_path), output_path)
                 self._log_status(f"Exported DXF to: {output_path}")
 
-            elif fmt in ("png", "pdf"):
+            elif fmt == "png":
                 try:
-                    from ..core.renderer import render_dxf
+                    from ..core.renderer import render_dxf_to_png
 
-                    result = render_dxf(
-                        self._dxf_path,
-                        output_format=fmt,
-                        output_path=output_path,
-                    )
+                    result = render_dxf_to_png(self._dxf_path, output_path)
                     if result.success:
-                        self._log_status(f"Exported {fmt.upper()} to: {output_path}")
+                        self._log_status(f"Exported PNG to: {output_path}")
                     else:
                         QMessageBox.warning(self, "Export", f"Export issue: {result.error}")
                 except ImportError:
                     QMessageBox.warning(
                         self,
                         "Missing Renderer",
-                        f"{fmt.upper()} export requires the draw extra.\n"
+                        "PNG export requires the draw extra.\n"
                         "Install with: pip install -e '.[draw]'",
+                    )
+
+            elif fmt == "pdf":
+                try:
+                    from ..core.renderer import render_dxf_to_pdf
+
+                    result = render_dxf_to_pdf(self._dxf_path, output_path)
+                    if result.success:
+                        self._log_status(f"Exported PDF to: {output_path}")
+                    else:
+                        QMessageBox.warning(self, "Export", f"Export issue: {result.error}")
+                except ImportError:
+                    QMessageBox.warning(
+                        self,
+                        "Missing Renderer",
+                        "PDF export requires the draw extra.\n"
+                        "Install with: pip install -e '.[draw]'",
+                    )
+
+            elif fmt == "dwg":
+                try:
+                    from ezdxf.addons import odafc
+
+                    if not odafc.is_installed():  # type: ignore[attr-defined]
+                        QMessageBox.warning(
+                            self,
+                            "ODA Not Found",
+                            "DWG export requires ODA File Converter.\n"
+                            "Download free from:\n"
+                            "https://www.opendesign.com/guestfiles/oda_file_converter",
+                        )
+                    else:
+                        import ezdxf
+
+                        doc = ezdxf.readfile(str(self._dxf_path))
+                        odafc.export_dwg(doc, str(output_path))  # type: ignore[attr-defined]
+                        self._log_status(f"Exported DWG to: {output_path}")
+                except ImportError:
+                    QMessageBox.warning(
+                        self,
+                        "Missing ODA",
+                        "DWG export requires ezdxf with ODA File Converter.",
                     )
 
         except Exception as e:

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -1,0 +1,94 @@
+"""Tests for the agent provider — mock agent tool-use flow."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.semantic_model import build_planner_context
+from cad_dxf_agent.llm.agent_provider import MockAgentProvider
+from cad_dxf_agent.llm.planner import get_provider
+
+
+class TestMockAgentProvider:
+    """Test the mock agent provider that simulates tool-use without Gemini."""
+
+    def test_provider_name(self):
+        provider = MockAgentProvider()
+        assert provider.name == "mock-agent"
+
+    def test_no_api_key_required(self):
+        provider = MockAgentProvider()
+        assert provider.requires_api_key is False
+
+    def test_move_prompt(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Move the footing east", ctx)
+        assert changeset.op_count >= 1
+        assert changeset.operations[0].op_type == "move_entity"
+        assert changeset.operations[0].params["dx"] == 24.0
+
+    def test_delete_prompt(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Delete this entity", ctx)
+        assert changeset.op_count >= 1
+        assert changeset.operations[0].op_type == "delete_entity"
+
+    def test_text_prompt(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Change the text label", ctx)
+        assert changeset.op_count >= 1
+        assert changeset.operations[0].op_type == "edit_text"
+
+    def test_default_prompt(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Do something with the drawing", ctx)
+        assert changeset.op_count >= 1
+        assert changeset.operations[0].op_type == "move_entity"
+
+    def test_protected_layer_not_targeted(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Move something", ctx)
+        for op in changeset.operations:
+            if op.target_layer:
+                assert op.target_layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+
+    def test_revision_label_set(self, sample_context):
+        provider = MockAgentProvider()
+        ctx = build_planner_context(sample_context)
+        changeset = provider.plan("Move the column", ctx)
+        assert changeset.revision_label is not None
+        assert "Mock agent" in changeset.revision_label
+
+
+class TestGetProvider:
+    """Test that the planner factory routes to agent providers."""
+
+    def test_mock_agent_provider(self):
+        provider = get_provider("mock-agent")
+        assert isinstance(provider, MockAgentProvider)
+
+    def test_agent_provider_falls_back(self):
+        # Without google-cloud-aiplatform installed in test env,
+        # should fall back to MockAgentProvider
+        provider = get_provider("agent")
+        assert provider is not None
+
+
+class TestVisionDescriber:
+    """Test the mock vision describer."""
+
+    def test_mock_description(self):
+        from cad_dxf_agent.llm.vision_describer import describe_drawing_mock
+
+        desc = describe_drawing_mock()
+        assert "foundation plan" in desc.lower()
+        assert "grid" in desc.lower()
+
+    def test_mock_description_with_path(self):
+        from cad_dxf_agent.llm.vision_describer import describe_drawing_mock
+
+        desc = describe_drawing_mock("/some/fake/path.png")
+        assert len(desc) > 50

--- a/tests/unit/test_edit_history.py
+++ b/tests/unit/test_edit_history.py
@@ -1,0 +1,136 @@
+"""Tests for EditHistory — snapshot-based undo/redo."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.edit_history import EditHistory
+
+
+@pytest.fixture
+def dxf_file(tmp_path: Path) -> Path:
+    """Create a minimal DXF with a text entity for undo/redo testing."""
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+    msp.add_text(
+        "ORIGINAL",
+        dxfattribs={"layer": "NOTES", "height": 2.5, "insert": (10, 10)},
+    )
+    path = tmp_path / "undo_test.dxf"
+    doc.saveas(str(path))
+    return path
+
+
+class TestEditHistory:
+    def test_initial_state(self, dxf_file):
+        history = EditHistory(dxf_file)
+        assert history.depth == 0
+        assert not history.can_undo
+        assert not history.can_redo
+        assert history.current_label == "initial"
+
+    def test_push_creates_snapshot(self, dxf_file):
+        history = EditHistory(dxf_file)
+        doc = ezdxf.readfile(str(dxf_file))
+        history.push(doc, "first edit")
+        assert history.depth == 1
+        assert history.can_undo
+        assert not history.can_redo
+        assert history.current_label == "first edit"
+
+    def test_undo_returns_to_initial(self, dxf_file):
+        history = EditHistory(dxf_file)
+
+        # Make an edit
+        doc = ezdxf.readfile(str(dxf_file))
+        msp = doc.modelspace()
+        for entity in msp:
+            if entity.dxftype() == "TEXT":
+                entity.dxf.text = "MODIFIED"
+        history.push(doc, "modify text")
+
+        # Undo
+        restored = history.undo()
+        assert restored is not None
+        msp = restored.modelspace()
+        texts = [e.dxf.text for e in msp if e.dxftype() == "TEXT"]
+        assert "ORIGINAL" in texts
+
+    def test_redo_after_undo(self, dxf_file):
+        history = EditHistory(dxf_file)
+
+        # Make an edit
+        doc = ezdxf.readfile(str(dxf_file))
+        msp = doc.modelspace()
+        for entity in msp:
+            if entity.dxftype() == "TEXT":
+                entity.dxf.text = "MODIFIED"
+        history.push(doc, "modify text")
+
+        # Undo then redo
+        history.undo()
+        assert history.can_redo
+        restored = history.redo()
+        assert restored is not None
+        msp = restored.modelspace()
+        texts = [e.dxf.text for e in msp if e.dxftype() == "TEXT"]
+        assert "MODIFIED" in texts
+
+    def test_undo_at_initial_returns_none(self, dxf_file):
+        history = EditHistory(dxf_file)
+        assert history.undo() is None
+
+    def test_redo_at_latest_returns_none(self, dxf_file):
+        history = EditHistory(dxf_file)
+        doc = ezdxf.readfile(str(dxf_file))
+        history.push(doc, "edit")
+        assert history.redo() is None
+
+    def test_push_after_undo_truncates_redo(self, dxf_file):
+        history = EditHistory(dxf_file)
+
+        doc1 = ezdxf.readfile(str(dxf_file))
+        history.push(doc1, "edit 1")
+
+        doc2 = ezdxf.readfile(str(dxf_file))
+        history.push(doc2, "edit 2")
+
+        # Undo once (back to edit 1)
+        history.undo()
+        assert history.can_redo
+
+        # Push new edit (should truncate edit 2)
+        doc3 = ezdxf.readfile(str(dxf_file))
+        history.push(doc3, "edit 3")
+        assert not history.can_redo
+        assert history.depth == 2  # edit 1 + edit 3
+        assert history.current_label == "edit 3"
+
+    def test_multiple_undos(self, dxf_file):
+        history = EditHistory(dxf_file)
+
+        for i in range(3):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+
+        assert history.depth == 3
+
+        # Undo all 3
+        for _ in range(3):
+            result = history.undo()
+            assert result is not None
+
+        # Now at initial — one more undo returns None
+        assert history.undo() is None
+        assert history.current_label == "initial"
+
+    def test_get_current_doc(self, dxf_file):
+        history = EditHistory(dxf_file)
+        doc = history.get_current_doc()
+        assert doc is not None
+        msp = doc.modelspace()
+        texts = [e.dxf.text for e in msp if e.dxftype() == "TEXT"]
+        assert "ORIGINAL" in texts

--- a/tests/unit/test_proxy_client.py
+++ b/tests/unit/test_proxy_client.py
@@ -1,0 +1,206 @@
+"""Tests for proxy client provider."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from cad_dxf_agent.llm.proxy_client import ProxyAgentProvider
+
+
+@pytest.fixture
+def sample_drawing_context():
+    """Minimal drawing context dict."""
+    return {
+        "file_path": "test.dxf",
+        "entity_count": 2,
+        "layers": [
+            {"name": "STRUCTURAL", "protected": False, "entity_count": 1},
+            {"name": "TITLE", "protected": True, "entity_count": 1},
+        ],
+        "entities": [
+            {
+                "handle": "A1",
+                "type": "LINE",
+                "layer": "STRUCTURAL",
+                "space": "Model",
+                "insert_point": {"x": 0.0, "y": 0.0},
+                "text": None,
+                "block_name": None,
+            },
+            {
+                "handle": "A2",
+                "type": "TEXT",
+                "layer": "TITLE",
+                "space": "Model",
+                "insert_point": {"x": 10.0, "y": 10.0},
+                "text": "Title Block",
+                "block_name": None,
+            },
+        ],
+        "blocks": [],
+        "layouts": [{"name": "Model", "entity_count": 2}],
+        "unsupported_types": [],
+    }
+
+
+def test_proxy_requires_url():
+    """ProxyAgentProvider raises ValueError without proxy URL."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = None
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        with pytest.raises(ValueError, match="CAD_PROXY_URL"):
+            ProxyAgentProvider(proxy_url="", license_key="test")
+
+
+def test_proxy_provider_name():
+    """Name includes model name."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = "http://localhost:8080"
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        p = ProxyAgentProvider(proxy_url="http://localhost:8080", license_key="test")
+        assert "proxy-agent" in p.name
+        assert "gemini-2.5-flash" in p.name
+
+
+def test_proxy_no_api_key_needed():
+    """Proxy provider doesn't require API key."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = "http://localhost:8080"
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        p = ProxyAgentProvider(proxy_url="http://localhost:8080", license_key="test")
+        assert not p.requires_api_key
+
+
+def test_extract_function_calls():
+    """Extract function calls from proxy response JSON."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = "http://localhost:8080"
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        p = ProxyAgentProvider(proxy_url="http://localhost:8080", license_key="test")
+
+    response = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "function_call": {
+                                "name": "find_entities",
+                                "args": {"layer": "STRUCTURAL"},
+                            }
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    calls = p._extract_function_calls(response)
+    assert len(calls) == 1
+    assert calls[0]["name"] == "find_entities"
+    assert calls[0]["args"]["layer"] == "STRUCTURAL"
+
+
+def test_extract_no_function_calls():
+    """Empty response yields no function calls."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = "http://localhost:8080"
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        p = ProxyAgentProvider(proxy_url="http://localhost:8080", license_key="test")
+
+    response = {
+        "candidates": [
+            {
+                "content": {
+                    "role": "model",
+                    "parts": [{"text": "Done editing."}],
+                }
+            }
+        ]
+    }
+    calls = p._extract_function_calls(response)
+    assert len(calls) == 0
+
+
+def test_proxy_plan_with_mock_responses(sample_drawing_context):
+    """Proxy plan processes tool calls and returns ChangeSet."""
+    with patch("cad_dxf_agent.llm.proxy_client.settings") as mock_settings:
+        mock_settings.proxy_url = "http://localhost:8080"
+        mock_settings.license_key = "test"
+        mock_settings.gemini_model = "gemini-2.5-flash"
+        mock_settings.protected_layers = ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+
+        p = ProxyAgentProvider(proxy_url="http://localhost:8080", license_key="test")
+
+        # Mock _proxy_generate to return a tool call, then a text-only response
+        call_count = [0]
+
+        def mock_generate(contents, tools):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {
+                    "candidates": [
+                        {
+                            "content": {
+                                "role": "model",
+                                "parts": [
+                                    {
+                                        "function_call": {
+                                            "name": "move_entity",
+                                            "args": {
+                                                "handle": "A1",
+                                                "dx": 24.0,
+                                                "dy": 0.0,
+                                            },
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                }
+            return {
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [{"text": "Done."}],
+                        }
+                    }
+                ]
+            }
+
+        p._proxy_generate = mock_generate  # type: ignore[assignment]
+        result = p.plan("Move footing east", sample_drawing_context)
+
+        assert result.op_count == 1
+        assert result.operations[0].op_type.value == "move_entity"
+        assert result.operations[0].params["dx"] == 24.0
+
+
+def test_planner_routes_proxy():
+    """Planner factory recognizes 'proxy' provider name."""
+    from cad_dxf_agent.llm.planner import get_provider
+
+    with patch("cad_dxf_agent.llm.planner.settings") as mock_settings:
+        mock_settings.llm_provider = "proxy"
+
+    # Without CAD_PROXY_URL, falls back to mock-agent
+    provider = get_provider("proxy")
+    assert "mock-agent" in provider.name
+
+
+def test_planner_routes_proxy_agent():
+    """Planner factory recognizes 'proxy-agent' provider name."""
+    from cad_dxf_agent.llm.planner import get_provider
+
+    provider = get_provider("proxy-agent")
+    assert "mock-agent" in provider.name

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -1,0 +1,76 @@
+"""Tests for CAD tool definitions."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.llm.tool_definitions import (
+    ALL_TOOLS,
+    EDIT_TOOLS,
+    QUERY_TOOLS,
+    get_tool_by_name,
+    is_edit_tool,
+)
+
+
+class TestToolDefinitions:
+    """Verify tool schemas are well-formed and complete."""
+
+    def test_all_tools_have_required_fields(self):
+        for tool in ALL_TOOLS:
+            assert "name" in tool, f"Tool missing 'name': {tool}"
+            assert "description" in tool, f"Tool {tool['name']} missing 'description'"
+            assert "parameters" in tool, f"Tool {tool['name']} missing 'parameters'"
+            params = tool["parameters"]
+            assert params["type"] == "object"
+            assert "properties" in params
+            assert "required" in params
+
+    def test_tool_names_unique(self):
+        names = [t["name"] for t in ALL_TOOLS]
+        assert len(names) == len(set(names)), f"Duplicate tool names: {names}"
+
+    def test_query_vs_edit_partition(self):
+        query_names = {t["name"] for t in QUERY_TOOLS}
+        edit_names = {t["name"] for t in EDIT_TOOLS}
+        all_names = {t["name"] for t in ALL_TOOLS}
+        assert query_names | edit_names == all_names
+        assert query_names & edit_names == set()
+
+    def test_get_tool_by_name_found(self):
+        tool = get_tool_by_name("find_entities")
+        assert tool is not None
+        assert tool["name"] == "find_entities"
+
+    def test_get_tool_by_name_not_found(self):
+        assert get_tool_by_name("nonexistent") is None
+
+    def test_is_edit_tool(self):
+        assert is_edit_tool("move_entity")
+        assert is_edit_tool("edit_text")
+        assert is_edit_tool("delete_entity")
+        assert is_edit_tool("add_block")
+        assert not is_edit_tool("find_entities")
+        assert not is_edit_tool("list_layers")
+        assert not is_edit_tool("nonexistent")
+
+    def test_expected_query_tools(self):
+        names = {t["name"] for t in QUERY_TOOLS}
+        expected = {"find_entities", "get_entity", "find_nearest", "list_layers", "is_protected"}
+        assert names == expected
+
+    def test_expected_edit_tools(self):
+        names = {t["name"] for t in EDIT_TOOLS}
+        assert names == {"move_entity", "edit_text", "delete_entity", "add_block"}
+
+    def test_move_entity_params(self):
+        tool = get_tool_by_name("move_entity")
+        assert tool is not None
+        props = tool["parameters"]["properties"]
+        assert "handle" in props
+        assert "dx" in props
+        assert "dy" in props
+        assert set(tool["parameters"]["required"]) == {"handle", "dx", "dy"}
+
+    def test_find_entities_no_required_params(self):
+        tool = get_tool_by_name("find_entities")
+        assert tool is not None
+        assert tool["parameters"]["required"] == []

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -1,0 +1,211 @@
+"""Tests for the tool executor — CAD tool dispatch and operation accumulation."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.tool_executor import ToolExecutor
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+
+
+@pytest.fixture
+def drawing_context():
+    """Minimal drawing context for tool executor tests."""
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="A1",
+                entity_type=EntityType.LINE,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=0, y=0),
+            ),
+            EntityRef(
+                handle="A2",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=10),
+                text_content="Column C-4",
+            ),
+            EntityRef(
+                handle="A3",
+                entity_type=EntityType.INSERT,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=25, y=25),
+                block_name="COLUMN_MARK",
+            ),
+            EntityRef(
+                handle="A4",
+                entity_type=EntityType.TEXT,
+                layer="TITLE",
+                insert_point=Point2D(x=0, y=-20),
+                text_content="PROJECT TITLE",
+            ),
+        ],
+        layers=[
+            LayerRule(name="STRUCTURAL", protected=False),
+            LayerRule(name="NOTES", protected=False),
+            LayerRule(name="TITLE", protected=True),
+        ],
+        blocks=["COLUMN_MARK"],
+    )
+
+
+@pytest.fixture
+def executor(drawing_context):
+    """ToolExecutor with protected layers set."""
+    return ToolExecutor(
+        drawing_context, protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+    )
+
+
+class TestQueryTools:
+    def test_find_entities_all(self, executor):
+        result = executor.execute("find_entities", {})
+        assert result["count"] == 4
+
+    def test_find_entities_by_layer(self, executor):
+        result = executor.execute("find_entities", {"layer": "STRUCTURAL"})
+        assert result["count"] == 2
+
+    def test_find_entities_by_type(self, executor):
+        result = executor.execute("find_entities", {"entity_type": "TEXT"})
+        assert result["count"] == 2
+
+    def test_find_entities_by_text(self, executor):
+        result = executor.execute("find_entities", {"text_contains": "Column"})
+        assert result["count"] == 1
+        assert result["entities"][0]["handle"] == "A2"
+
+    def test_find_entities_combined_filters(self, executor):
+        result = executor.execute(
+            "find_entities",
+            {
+                "layer": "NOTES",
+                "entity_type": "TEXT",
+                "text_contains": "Column",
+            },
+        )
+        assert result["count"] == 1
+
+    def test_get_entity_found(self, executor):
+        result = executor.execute("get_entity", {"handle": "A1"})
+        assert result["handle"] == "A1"
+        assert result["type"] == "LINE"
+        assert result["layer"] == "STRUCTURAL"
+
+    def test_get_entity_not_found(self, executor):
+        result = executor.execute("get_entity", {"handle": "ZZZZZ"})
+        assert "error" in result
+
+    def test_find_nearest(self, executor):
+        result = executor.execute("find_nearest", {"x": 9, "y": 9})
+        assert result["handle"] == "A2"
+
+    def test_find_nearest_with_type_filter(self, executor):
+        result = executor.execute("find_nearest", {"x": 9, "y": 9, "entity_type": "LINE"})
+        assert result["handle"] == "A1"
+
+    def test_list_layers(self, executor):
+        result = executor.execute("list_layers", {})
+        assert len(result["layers"]) == 3
+        layer_names = {lyr["name"] for lyr in result["layers"]}
+        assert "STRUCTURAL" in layer_names
+
+    def test_is_protected_true(self, executor):
+        result = executor.execute("is_protected", {"layer": "TITLE"})
+        assert result["protected"] is True
+
+    def test_is_protected_false(self, executor):
+        result = executor.execute("is_protected", {"layer": "STRUCTURAL"})
+        assert result["protected"] is False
+
+
+class TestEditTools:
+    def test_move_entity_queues_operation(self, executor):
+        result = executor.execute("move_entity", {"handle": "A1", "dx": 24.0, "dy": 0.0})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == "move_entity"
+        assert op.target_handle == "A1"
+        assert op.params == {"dx": 24.0, "dy": 0.0}
+
+    def test_move_entity_protected_blocked(self, executor):
+        result = executor.execute("move_entity", {"handle": "A4", "dx": 1, "dy": 0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_move_entity_not_found(self, executor):
+        result = executor.execute("move_entity", {"handle": "ZZZ", "dx": 1, "dy": 0})
+        assert "error" in result
+
+    def test_edit_text_queues_operation(self, executor):
+        result = executor.execute("edit_text", {"handle": "A2", "new_text": "Updated"})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == "edit_text"
+        assert op.params["new_text"] == "Updated"
+
+    def test_edit_text_protected_blocked(self, executor):
+        result = executor.execute("edit_text", {"handle": "A4", "new_text": "Hacked"})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_delete_entity_queues_operation(self, executor):
+        result = executor.execute("delete_entity", {"handle": "A1"})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        assert executor.operations[0].op_type == "delete_entity"
+
+    def test_delete_entity_protected_blocked(self, executor):
+        result = executor.execute("delete_entity", {"handle": "A4"})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_add_block_queues_operation(self, executor):
+        result = executor.execute(
+            "add_block",
+            {
+                "block_name": "COLUMN_MARK",
+                "x": 50,
+                "y": 50,
+            },
+        )
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == "add_block"
+        assert op.params["block_name"] == "COLUMN_MARK"
+
+    def test_add_block_protected_layer_blocked(self, executor):
+        result = executor.execute(
+            "add_block",
+            {
+                "block_name": "COLUMN_MARK",
+                "x": 0,
+                "y": 0,
+                "layer": "TITLE",
+            },
+        )
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_multiple_operations_accumulate(self, executor):
+        executor.execute("move_entity", {"handle": "A1", "dx": 10, "dy": 0})
+        executor.execute("edit_text", {"handle": "A2", "new_text": "New"})
+        executor.execute("delete_entity", {"handle": "A3"})
+        assert len(executor.operations) == 3
+
+
+class TestUnknownTool:
+    def test_unknown_tool_raises(self, executor):
+        with pytest.raises(KeyError, match="Unknown tool"):
+            executor.execute("fly_to_moon", {})


### PR DESCRIPTION
## Summary

Complete MVP v1 implementation for Tony's structural drawing editor. Seven commits, each addressing a distinct phase of the CTO plan:

- **Tool-use agent architecture** — Gemini function calling with 9 CAD tools (5 query + 4 edit), ToolExecutor, two-stage vision pipeline, MockAgentProvider for testing
- **Undo/redo** — Snapshot-based EditHistory with ezdxf serialization, can_undo/can_redo, cursor navigation
- **Layout/paper space** — EntityRef.space field, LayoutInfo model, dxf_reader parses all named layouts
- **Desktop UI rewrite** — Full PySide6 shell: menu bar, toolbar, layout selector, per-op approve/reject checkboxes, prompt history, status bar
- **Cloud Run Gemini proxy** — FastAPI proxy with license key auth and rate limiting so desktop users skip GCP credentials. ProxyAgentProvider client.
- **Windows packaging** — PyInstaller spec, Inno Setup installer script, GitHub Actions workflow (build on tag push)
- **Export wiring** — PNG/PDF via renderer, DWG via ODA File Converter, all accessible from File menu

### New files (12)
- `src/cad_dxf_agent/llm/tool_definitions.py` — 9 CAD tool schemas
- `src/cad_dxf_agent/llm/tool_executor.py` — Host-side tool dispatch
- `src/cad_dxf_agent/llm/vision_describer.py` — PNG → Gemini → layout description
- `src/cad_dxf_agent/llm/agent_provider.py` — Tool-use agent loop + MockAgentProvider
- `src/cad_dxf_agent/llm/proxy_client.py` — ProxyAgentProvider HTTP client
- `src/cad_dxf_agent/core/edit_history.py` — Snapshot-based undo/redo
- `proxy/main.py` — Cloud Run FastAPI proxy
- `proxy/Dockerfile`, `proxy/requirements.txt`, `proxy/cloudbuild.yaml`
- `installer/cad-dxf-agent.spec` — PyInstaller config
- `installer/setup.iss` — Inno Setup Windows installer
- `.github/workflows/build-windows.yml` — CI for Windows builds

### Modified files (5)
- `src/cad_dxf_agent/settings.py` — gemini-2.5-flash default, vision_model, proxy_url, license_key
- `src/cad_dxf_agent/llm/planner.py` — agent, mock-agent, proxy provider routing
- `src/cad_dxf_agent/llm/prompt_templates.py` — structural engineering domain prompt
- `src/cad_dxf_agent/models/cad_schema.py` — space field, LayoutInfo, layouts
- `src/cad_dxf_agent/ui/main_window.py` — complete UI rewrite + export wiring

### Tests: 211 pass (53 new)

## Test plan

- [x] All 211 tests pass locally (unit + smoke)
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)
- [ ] CI passes on push
- [ ] Windows build workflow triggers on tag
- [ ] Load Tony's real DWG file end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows installer + automated build/release workflow for desktop distribution.
  * Undo/redo snapshot history for DXF editing; DXF reader now includes layouts/paper spaces and per-layout metadata.
  * FastAPI proxy service (authenticated, rate-limited) and Cloud Build/Run deployment.
  * LLM agent & proxy-agent support, tool-based planning/execution, and vision-based drawing description.
  * UI enhancements: menu, toolbar, operation selection, export, and undo/redo integration.

* **Tests**
  * Unit tests covering agents, proxy, edit history, tool definitions, and tool executor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->