### PR TITLE
feat(test): v0.2.0 testing infrastructure

### DIFF
--- a/000-docs/022-AA-AACR-v0.2-testing-infrastructure-aar.md
+++ b/000-docs/022-AA-AACR-v0.2-testing-infrastructure-aar.md
@@ -1,0 +1,57 @@
+# AAR: v0.2.0 Testing Infrastructure
+
+**Doc ID:** 022-AA-AACR
+**Date:** 2026-02-21
+**Branch:** `test/v2-testing-infrastructure`
+
+## What Was Built
+
+Comprehensive testing infrastructure to close critical gaps identified in the v0.1.0 release (222 tests, zero integration tests, zero coverage on dxf_writer/edit_engine/preview_model).
+
+### Test Count Delta
+
+| Metric | Before | After | Delta |
+|--------|--------|-------|-------|
+| Total tests | 222 | 297 | +75 |
+| Unit tests | ~218 | ~282 | +64 |
+| Integration tests | 0 | 15 | +15 |
+| Coverage | ~50% | ~68% | +18pp |
+| fail_under threshold | 50% | 65% | +15pp |
+
+### New Test Files
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `test_dxf_writer.py` | 7 | save-as, copy, path guards, round-trip |
+| `test_edit_engine.py` | 10 | move/edit_text/delete/add_block with DXF reload |
+| `test_preview_model.py` | 10 | descriptions, validity, summary |
+| `test_semantic_model.py` | 9 | planner context, compact context |
+| `test_settings.py` | 6 | env var parsing, api keys |
+| `test_changeset_snapshot.py` | 3 | syrupy snapshot regression |
+| `test_validators.py` (extended) | +9 | delete, add_block, distance, Inf, empty |
+| `test_dxf_reader.py` (extended) | +5 | HATCH, SPLINE, ELLIPSE, unsupported, empty |
+| `test_pipeline_integration.py` | 5 | full pipeline flows |
+| `test_undo_redo_integration.py` | 2 | EditHistory + EditEngine |
+| `test_agent_loop_integration.py` | 8 | ScriptedAgentProvider + golden trajectories |
+
+### New Infrastructure
+
+- **ScriptedAgentProvider** — fake-backend pattern for LLM testing without API calls
+- **DXF factory** — programmatic structural drawing builder (grids, columns, dimensions)
+- **ChangeSet factory** — one-liner test data builders
+- **5 golden trajectory fixtures** — JSON-documented correct agent behavior
+- **syrupy snapshots** — ChangeSet structure regression tests
+
+### Key Decisions
+
+1. **ScriptedAgentProvider over VCR cassettes** — cassettes require a real API, scripted replays test behavior deterministically. VCR deferred to when real Gemini integration testing begins.
+2. **Programmatic DXF factories over stored files** — reproducible, parameterizable, no binary blobs in git.
+3. **Coverage threshold 65% not 80%** — UI module (main_window.py) has 0% and rightfully so (PySide6 requires display server). 65% is achievable without testing the GUI.
+4. **Golden trajectories as JSON** — machine-readable, versionable, parametrized via pytest.
+
+## Verification
+
+- `make check` passes (lint + format + typecheck + test + smoke)
+- `make test-cov` shows 67.74% coverage (above 65% threshold)
+- `pytest tests/integration/ -v` — 15/15 pass
+- All 297 tests pass in ~27s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,12 +105,37 @@ Optional tracing via `otel.py` bootstrap module. Off by default, CI-safe (no net
 
 ## Testing
 
-- **Unit tests** (`tests/unit/`): schemas, validators, parser, reader — no DXF files on disk
-- **Smoke tests** (`tests/smoke/`): end-to-end pipeline via `test_e2e_mock.py`
-- **Standalone smoke** (`scripts/smoke_test.py`): creates DXF, runs full pipeline, verifies output
-- **Fixtures** in `tests/conftest.py`: `sample_dxf` creates a temp DXF with all V1 entity types; `sample_context` loads it; `rule_config` provides default rules
-- Pytest markers: `@pytest.mark.smoke`, `@pytest.mark.slow`
-- Coverage threshold: 50% (`fail_under` in pyproject.toml)
+### Test Tiers
+
+| Tier | Location | Count | What |
+|------|----------|-------|------|
+| Unit | `tests/unit/` | ~270 | Schemas, validators, reader, writer, engine, preview, settings, semantic model, snapshots |
+| Integration | `tests/integration/` | ~15 | Full pipeline, undo/redo, agent loop with ScriptedAgentProvider |
+| Smoke | `tests/smoke/` + `scripts/smoke_test.py` | ~5 | End-to-end pipeline via mock planner |
+
+### LLM Testing Patterns
+
+- **ScriptedAgentProvider** (`tests/helpers/scripted_provider.py`): replay canned tool-call sequences through the real `ToolExecutor`. Industry "fake backend" pattern — tests behavior, not implementation.
+- **Golden trajectories** (`tests/fixtures/trajectories/*.json`): JSON files documenting correct agent behavior per prompt type (Google ADK pattern). 5 trajectories: move, delete, edit_text, add_block, protected_layer_reject.
+- **Snapshot tests** (`tests/unit/test_changeset_snapshot.py`): syrupy snapshots catch accidental ChangeSet structure changes when prompts evolve. Run `--snapshot-update` to accept intentional changes.
+
+### Test Helpers
+
+- `tests/helpers/dxf_factory.py` — programmatic DXF builders (structural drawings with 200+ entities, minimal, empty). No stored DXF files.
+- `tests/helpers/changeset_factory.py` — one-liner `make_move()`, `make_delete()`, `make_edit_text()`, `make_add_block()` builders.
+- `tests/conftest.py` — `sample_dxf`, `sample_context`, `rule_config` fixtures.
+
+### Running Tests
+
+```bash
+make test            # All tests
+make test-unit       # Unit tests only
+make test-integration # Integration tests only
+make test-cov        # All tests with coverage report
+```
+
+- Pytest markers: `@pytest.mark.smoke`, `@pytest.mark.slow`, `@pytest.mark.integration`
+- Coverage threshold: 65% (`fail_under` in pyproject.toml)
 
 ## CI
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format typecheck test smoke check run clean
+.PHONY: install lint format typecheck test test-unit test-integration test-cov smoke check run clean
 
 install:
 	pip install -e ".[dev]"
@@ -15,6 +15,12 @@ typecheck:
 
 test:
 	pytest -v
+
+test-unit:
+	pytest tests/unit/ -v
+
+test-integration:
+	pytest tests/integration/ -v -m integration
 
 test-cov:
 	pytest --cov=cad_dxf_agent --cov-report=term-missing -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ gemini = [
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "syrupy>=4.0",
     "ruff>=0.5",
     "mypy>=1.10",
     "pre-commit>=3.7",
@@ -108,6 +109,7 @@ addopts = "--strict-markers -v"
 markers = [
     "smoke: end-to-end smoke tests",
     "slow: tests that take significant time",
+    "integration: integration tests (full pipeline, multi-module)",
 ]
 
 [tool.coverage.run]
@@ -115,4 +117,4 @@ source = ["cad_dxf_agent"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 50
+fail_under = 65

--- a/tests/fixtures/trajectories/add_block.json
+++ b/tests/fixtures/trajectories/add_block.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "Insert a new COLUMN_MARK block at grid position E-3",
+  "description": "Agent lists layers, then inserts a block on STRUCTURAL layer",
+  "expected_turns": [
+    {
+      "tool_calls": [
+        {"name": "list_layers", "args": {}}
+      ]
+    },
+    {
+      "tool_calls": [
+        {"name": "add_block", "args": {"block_name": "COLUMN_MARK", "x": 120.0, "y": 60.0, "layer": "STRUCTURAL"}}
+      ]
+    }
+  ],
+  "expected_op_types": ["add_block"],
+  "expected_op_count": 1,
+  "must_not_touch_layers": ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+}

--- a/tests/fixtures/trajectories/delete_entity.json
+++ b/tests/fixtures/trajectories/delete_entity.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "Delete the first structural element",
+  "description": "Agent finds a structural entity and deletes it",
+  "expected_turns": [
+    {
+      "tool_calls": [
+        {"name": "find_entities", "args": {"layer": "STRUCTURAL"}}
+      ]
+    },
+    {
+      "tool_calls": [
+        {"name": "delete_entity", "args": {"handle": "__FIRST_MATCH__"}}
+      ]
+    }
+  ],
+  "expected_op_types": ["delete_entity"],
+  "expected_op_count": 1,
+  "must_not_touch_layers": ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+}

--- a/tests/fixtures/trajectories/edit_text_label.json
+++ b/tests/fixtures/trajectories/edit_text_label.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "Rename column label C-4 to C-4A",
+  "description": "Agent finds text entity containing C-4 and edits it",
+  "expected_turns": [
+    {
+      "tool_calls": [
+        {"name": "find_entities", "args": {"text_contains": "C-4"}}
+      ]
+    },
+    {
+      "tool_calls": [
+        {"name": "edit_text", "args": {"handle": "__FIRST_MATCH__", "new_text": "C-4A"}}
+      ]
+    }
+  ],
+  "expected_op_types": ["edit_text"],
+  "expected_op_count": 1,
+  "must_not_touch_layers": ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+}

--- a/tests/fixtures/trajectories/move_column_east.json
+++ b/tests/fixtures/trajectories/move_column_east.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "Move column C-4 east by 2 feet",
+  "description": "Agent finds entity by text, then moves it east (dx=24 inches)",
+  "expected_turns": [
+    {
+      "tool_calls": [
+        {"name": "find_entities", "args": {"text_contains": "C-4"}}
+      ]
+    },
+    {
+      "tool_calls": [
+        {"name": "move_entity", "args": {"handle": "__FIRST_MATCH__", "dx": 24.0, "dy": 0.0}}
+      ]
+    }
+  ],
+  "expected_op_types": ["move_entity"],
+  "expected_op_count": 1,
+  "must_not_touch_layers": ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+}

--- a/tests/fixtures/trajectories/protected_layer_reject.json
+++ b/tests/fixtures/trajectories/protected_layer_reject.json
@@ -1,0 +1,19 @@
+{
+  "prompt": "Move the project title text east",
+  "description": "Agent finds entity on TITLE layer, attempts move, gets rejected — 0 ops produced",
+  "expected_turns": [
+    {
+      "tool_calls": [
+        {"name": "find_entities", "args": {"layer": "TITLE"}}
+      ]
+    },
+    {
+      "tool_calls": [
+        {"name": "move_entity", "args": {"handle": "__TITLE_ENTITY__", "dx": 24.0, "dy": 0.0}}
+      ]
+    }
+  ],
+  "expected_op_types": [],
+  "expected_op_count": 0,
+  "must_not_touch_layers": ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+}

--- a/tests/helpers/changeset_factory.py
+++ b/tests/helpers/changeset_factory.py
@@ -1,0 +1,96 @@
+"""ChangeSet factory — one-liner test data builders for operations.
+
+Each builder returns a ready-to-validate ChangeSet with sensible defaults.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+
+def make_move(
+    handle: str,
+    *,
+    dx: float = 24.0,
+    dy: float = 0.0,
+    prompt: str = "Move entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single move operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.MOVE_ENTITY,
+                target_handle=handle,
+                params={"dx": dx, "dy": dy},
+            )
+        ],
+    )
+
+
+def make_delete(
+    handle: str,
+    *,
+    prompt: str = "Delete entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single delete operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.DELETE_ENTITY,
+                target_handle=handle,
+            )
+        ],
+    )
+
+
+def make_edit_text(
+    handle: str,
+    new_text: str = "UPDATED TEXT",
+    *,
+    prompt: str = "Edit text",
+) -> ChangeSet:
+    """Build a ChangeSet with a single edit_text operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.EDIT_TEXT,
+                target_handle=handle,
+                params={"new_text": new_text},
+            )
+        ],
+    )
+
+
+def make_add_block(
+    block_name: str = "COLUMN_MARK",
+    x: float = 50.0,
+    y: float = 50.0,
+    *,
+    layer: str | None = None,
+    prompt: str = "Add block",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_block operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_BLOCK,
+                target_layer=layer,
+                params={
+                    "block_name": block_name,
+                    "insert_point": {"x": x, "y": y},
+                },
+            )
+        ],
+    )
+
+
+def make_multi_op(
+    *operations: EditOperation,
+    prompt: str = "Multi-op changeset",
+) -> ChangeSet:
+    """Build a ChangeSet from multiple EditOperation objects."""
+    return ChangeSet(prompt=prompt, operations=list(operations))

--- a/tests/helpers/dxf_factory.py
+++ b/tests/helpers/dxf_factory.py
@@ -1,0 +1,197 @@
+"""DXF factory — programmatic builders for realistic test drawings.
+
+Builds reproducible drawings with ezdxf. No stored DXF files needed.
+Mimics real structural engineering drawings with grids, columns,
+dimension chains, notes, and title blocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ezdxf
+
+
+def create_structural_drawing(
+    tmp_path: Path,
+    *,
+    grid_cols: int = 5,
+    grid_rows: int = 4,
+    grid_spacing: float = 30.0,
+    add_title_block: bool = True,
+    add_dimensions: bool = True,
+    add_notes: bool = True,
+    filename: str = "structural.dxf",
+) -> Path:
+    """Build a realistic structural drawing with 200+ entities.
+
+    Generates:
+    - Grid lines (STRUCTURAL layer)
+    - Column marks as block inserts (STRUCTURAL layer)
+    - Dimension chains (NOTES layer)
+    - Text labels on columns (NOTES layer)
+    - Title block text (TITLE layer, protected)
+    - Revision text (REVISION layer, protected)
+
+    Returns path to the saved DXF.
+    """
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+
+    # Layers
+    doc.layers.add("STRUCTURAL", color=1)
+    doc.layers.add("NOTES", color=3)
+    doc.layers.add("TITLE", color=7)
+    doc.layers.add("TITLEBLOCK", color=7)
+    doc.layers.add("SEAL", color=7)
+    doc.layers.add("REVISION", color=7)
+
+    # Block definition
+    block = doc.blocks.new("COLUMN_MARK")
+    block.add_circle((0, 0), radius=2)
+    block.add_line((-1.5, -1.5), (1.5, 1.5))
+    block.add_line((-1.5, 1.5), (1.5, -1.5))
+
+    # Grid lines + column marks
+    col_labels = [chr(65 + i) for i in range(grid_cols)]  # A, B, C, ...
+
+    for col_idx in range(grid_cols):
+        x = col_idx * grid_spacing
+        # Vertical grid line
+        msp.add_line(
+            (x, 0),
+            (x, (grid_rows - 1) * grid_spacing),
+            dxfattribs={"layer": "STRUCTURAL"},
+        )
+        # Column label at top
+        msp.add_text(
+            col_labels[col_idx],
+            dxfattribs={
+                "layer": "NOTES",
+                "height": 3.0,
+                "insert": (x, (grid_rows - 1) * grid_spacing + 10),
+            },
+        )
+
+    for row_idx in range(grid_rows):
+        y = row_idx * grid_spacing
+        # Horizontal grid line
+        msp.add_line(
+            (0, y),
+            ((grid_cols - 1) * grid_spacing, y),
+            dxfattribs={"layer": "STRUCTURAL"},
+        )
+        # Row label at left
+        msp.add_text(
+            str(row_idx + 1),
+            dxfattribs={
+                "layer": "NOTES",
+                "height": 3.0,
+                "insert": (-10, y),
+            },
+        )
+
+    # Column marks at intersections
+    for col_idx in range(grid_cols):
+        for row_idx in range(grid_rows):
+            x = col_idx * grid_spacing
+            y = row_idx * grid_spacing
+            label = f"{col_labels[col_idx]}-{row_idx + 1}"
+
+            msp.add_blockref(
+                "COLUMN_MARK",
+                insert=(x, y),
+                dxfattribs={"layer": "STRUCTURAL"},
+            )
+            msp.add_text(
+                label,
+                dxfattribs={
+                    "layer": "NOTES",
+                    "height": 1.5,
+                    "insert": (x + 3, y + 3),
+                },
+            )
+
+    # Dimension chains along bottom
+    if add_dimensions:
+        for col_idx in range(grid_cols - 1):
+            x1 = col_idx * grid_spacing
+            x2 = (col_idx + 1) * grid_spacing
+            dim = msp.add_aligned_dim(
+                p1=(x1, 0),
+                p2=(x2, 0),
+                distance=-8,
+                dxfattribs={"layer": "NOTES"},
+            )
+            dim.render()
+
+    # Extra notes
+    if add_notes:
+        msp.add_mtext(
+            "FOOTING SCHEDULE\nSee detail A/S-3 for reinforcing",
+            dxfattribs={
+                "layer": "NOTES",
+                "insert": (0, -25),
+                "char_height": 2.0,
+            },
+        )
+        msp.add_mtext(
+            "ALL DIMENSIONS IN FEET-INCHES\nUNLESS OTHERWISE NOTED",
+            dxfattribs={
+                "layer": "NOTES",
+                "insert": (60, -25),
+                "char_height": 1.5,
+            },
+        )
+
+    # Title block on protected layer
+    if add_title_block:
+        msp.add_text(
+            "STRUCTURAL FOUNDATION PLAN",
+            dxfattribs={"layer": "TITLE", "height": 5.0, "insert": (0, -50)},
+        )
+        msp.add_text(
+            "PROJECT: DEMO BUILDING",
+            dxfattribs={"layer": "TITLEBLOCK", "height": 3.0, "insert": (0, -58)},
+        )
+        msp.add_text(
+            "SEAL: PE-12345",
+            dxfattribs={"layer": "SEAL", "height": 2.0, "insert": (0, -65)},
+        )
+        msp.add_text(
+            "REV 0 - ISSUED FOR CONSTRUCTION",
+            dxfattribs={"layer": "REVISION", "height": 2.0, "insert": (0, -72)},
+        )
+
+    # Additional structural elements to push entity count up
+    for i in range(8):
+        pts = [
+            (i * 15, -10),
+            (i * 15 + 10, -10),
+            (i * 15 + 10, -5),
+            (i * 15, -5),
+        ]
+        msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": "STRUCTURAL"})
+
+    dxf_path = tmp_path / filename
+    doc.saveas(str(dxf_path))
+    return dxf_path
+
+
+def create_minimal_dxf(tmp_path: Path, *, filename: str = "minimal.dxf") -> Path:
+    """Create a minimal DXF with just one entity for simple tests."""
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+    doc.layers.add("STRUCTURAL", color=1)
+    msp.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    dxf_path = tmp_path / filename
+    doc.saveas(str(dxf_path))
+    return dxf_path
+
+
+def create_empty_dxf(tmp_path: Path, *, filename: str = "empty.dxf") -> Path:
+    """Create a DXF with no user entities (only standard DXF blocks)."""
+    doc = ezdxf.new(dxfversion="R2018")
+    dxf_path = tmp_path / filename
+    doc.saveas(str(dxf_path))
+    return dxf_path

--- a/tests/helpers/scripted_provider.py
+++ b/tests/helpers/scripted_provider.py
@@ -1,0 +1,97 @@
+"""Scripted agent provider — replays canned tool-call sequences through the real ToolExecutor.
+
+Industry 'fake backend' pattern: tests declare exactly what tools the 'LLM' calls,
+the real executor validates protection rules, builds ops. Better than MagicMock
+because it tests actual behavior.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.llm.providers import PlannerProvider
+from cad_dxf_agent.llm.tool_executor import ToolExecutor
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.ops_schema import ChangeSet
+from cad_dxf_agent.settings import settings
+
+
+class ScriptedAgentProvider(PlannerProvider):
+    """Replays a scripted sequence of tool calls through the real ToolExecutor.
+
+    Args:
+        turns: List of turns, where each turn is a list of (tool_name, args) tuples.
+               Example: [
+                   [("find_entities", {"layer": "STRUCTURAL"})],
+                   [("move_entity", {"handle": "ABC", "dx": 24.0, "dy": 0.0})],
+               ]
+    """
+
+    def __init__(self, turns: list[list[tuple[str, dict]]]) -> None:
+        self._turns = turns
+
+    @property
+    def name(self) -> str:
+        return "scripted-agent"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        """Execute scripted tool calls through the real ToolExecutor."""
+        context = _reconstruct_context(drawing_context)
+        executor = ToolExecutor(context, settings.protected_layers)
+
+        results: list[dict] = []
+        for turn in self._turns:
+            for tool_name, args in turn:
+                try:
+                    result = executor.execute(tool_name, args)
+                except KeyError:
+                    result = {"error": f"Unknown tool: {tool_name}"}
+                results.append(result)
+
+        return ChangeSet(
+            prompt=prompt,
+            operations=executor.operations,
+            revision_label=f"Scripted agent: {prompt[:50]}",
+        )
+
+
+def _reconstruct_context(drawing_context: dict) -> DrawingContext:
+    """Reconstruct a DrawingContext from planner context dict."""
+    entities = []
+    for e in drawing_context.get("entities", []):
+        try:
+            point = None
+            if e.get("insert_point"):
+                point = Point2D(x=e["insert_point"]["x"], y=e["insert_point"]["y"])
+            entities.append(
+                EntityRef(
+                    handle=e["handle"],
+                    entity_type=EntityType(e["type"]),
+                    layer=e["layer"],
+                    insert_point=point,
+                    text_content=e.get("text"),
+                    block_name=e.get("block_name"),
+                )
+            )
+        except (KeyError, ValueError):
+            continue
+
+    layers = [
+        LayerRule(name=lyr["name"], protected=lyr.get("protected", False))
+        for lyr in drawing_context.get("layers", [])
+    ]
+
+    return DrawingContext(
+        file_path=drawing_context.get("file_path", ""),
+        entities=entities,
+        layers=layers,
+        blocks=drawing_context.get("blocks", []),
+    )

--- a/tests/helpers/scripted_provider.py
+++ b/tests/helpers/scripted_provider.py
@@ -81,7 +81,12 @@ def _reconstruct_context(drawing_context: dict) -> DrawingContext:
                     block_name=e.get("block_name"),
                 )
             )
-        except (KeyError, ValueError):
+        except (KeyError, ValueError) as exc:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Skipping malformed entity in test context: %s (data=%s)", exc, e
+            )
             continue
 
     layers = [

--- a/tests/integration/test_agent_loop_integration.py
+++ b/tests/integration/test_agent_loop_integration.py
@@ -1,0 +1,170 @@
+"""Integration tests for the agent tool-use loop using ScriptedAgentProvider.
+
+Tests that scripted tool-call sequences produce correct operations when
+routed through the real ToolExecutor with real protection rules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.semantic_model import build_planner_context
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.models.config_schema import RuleConfig
+from cad_dxf_agent.models.ops_schema import OpType
+from tests.helpers.scripted_provider import ScriptedAgentProvider
+
+TRAJECTORY_DIR = Path(__file__).parent.parent / "fixtures" / "trajectories"
+
+
+@pytest.mark.integration
+class TestScriptedAgentLoop:
+    def test_scripted_two_turn_move(self, sample_dxf, tmp_path):
+        """Scripted: find entity → move it → verify 1 move_entity op."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+
+        # Find an editable entity handle
+        editable = next(
+            e
+            for e in context.entities
+            if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+        )
+
+        provider = ScriptedAgentProvider(
+            turns=[
+                [("find_entities", {"layer": "STRUCTURAL"})],
+                [("move_entity", {"handle": editable.handle, "dx": 24.0, "dy": 0.0})],
+            ]
+        )
+
+        changeset = provider.plan("Move column east by 2 feet", planner_ctx)
+        assert changeset.op_count == 1
+        assert changeset.operations[0].op_type == OpType.MOVE_ENTITY
+        assert changeset.operations[0].params["dx"] == 24.0
+
+        # Validate the changeset
+        rules = RuleConfig()
+        validation = validate_changeset(changeset, context, rules)
+        assert validation.valid
+
+    def test_scripted_protected_layer_rejection(self, sample_dxf):
+        """Scripted: move on protected layer → 0 ops produced."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+
+        title_entity = next(e for e in context.entities if e.layer.upper() == "TITLE")
+
+        provider = ScriptedAgentProvider(
+            turns=[
+                [("find_entities", {"layer": "TITLE"})],
+                [("move_entity", {"handle": title_entity.handle, "dx": 24.0, "dy": 0.0})],
+            ]
+        )
+
+        changeset = provider.plan("Move the title", planner_ctx)
+        # ToolExecutor refuses to queue the op on protected layer → 0 ops
+        assert changeset.op_count == 0
+
+    def test_scripted_multi_op(self, sample_dxf):
+        """Scripted: two ops in one turn → both queued."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+
+        editables = [
+            e
+            for e in context.entities
+            if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+        ]
+        assert len(editables) >= 2
+
+        provider = ScriptedAgentProvider(
+            turns=[
+                [
+                    ("move_entity", {"handle": editables[0].handle, "dx": 10, "dy": 0}),
+                    ("move_entity", {"handle": editables[1].handle, "dx": -10, "dy": 0}),
+                ],
+            ]
+        )
+
+        changeset = provider.plan("Swap two entities", planner_ctx)
+        assert changeset.op_count == 2
+
+
+@pytest.mark.integration
+class TestGoldenTrajectories:
+    """Parametrized tests over trajectory fixture files.
+
+    Each trajectory defines a prompt, expected tool-call sequence, and
+    expected operation outcomes. The test builds a dynamic ScriptedAgentProvider
+    from the trajectory and validates the results.
+    """
+
+    @staticmethod
+    def _load_trajectories():
+        """Load all trajectory JSON files."""
+        trajectories = []
+        for path in sorted(TRAJECTORY_DIR.glob("*.json")):
+            with open(path) as f:
+                data = json.load(f)
+            data["_file"] = path.name
+            trajectories.append(data)
+        return trajectories
+
+    @pytest.fixture(params=_load_trajectories.__func__(), ids=lambda t: t["_file"])
+    def trajectory(self, request):
+        return request.param
+
+    def test_trajectory_golden_file(self, sample_dxf, trajectory):
+        """Validate that a golden trajectory produces expected op types and counts."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+
+        # Build turns from trajectory, resolving __FIRST_MATCH__ handles
+        turns = []
+        first_editable = next(
+            (
+                e
+                for e in context.entities
+                if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+            ),
+            None,
+        )
+        title_entity = next(
+            (e for e in context.entities if e.layer.upper() == "TITLE"),
+            None,
+        )
+
+        for turn_spec in trajectory["expected_turns"]:
+            turn_calls = []
+            for tc in turn_spec["tool_calls"]:
+                args = dict(tc["args"])
+                # Resolve placeholder handles
+                for key, val in args.items():
+                    if val == "__FIRST_MATCH__" and first_editable:
+                        args[key] = first_editable.handle
+                    elif val == "__TITLE_ENTITY__" and title_entity:
+                        args[key] = title_entity.handle
+                turn_calls.append((tc["name"], args))
+            turns.append(turn_calls)
+
+        provider = ScriptedAgentProvider(turns=turns)
+        changeset = provider.plan(trajectory["prompt"], planner_ctx)
+
+        # Verify expected op count
+        assert changeset.op_count == trajectory["expected_op_count"]
+
+        # Verify expected op types
+        actual_types = [op.op_type.value for op in changeset.operations]
+        assert actual_types == trajectory["expected_op_types"]
+
+        # Verify must_not_touch_layers
+        for op in changeset.operations:
+            if op.target_layer:
+                assert op.target_layer.upper() not in [
+                    layer.upper() for layer in trajectory["must_not_touch_layers"]
+                ]

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -1,0 +1,194 @@
+"""Integration tests — full pipeline: load → plan → validate → edit → save → verify."""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.preview_model import PreviewModel
+from cad_dxf_agent.core.revision_notes import insert_revision_note
+from cad_dxf_agent.core.semantic_model import build_planner_context
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.llm.planner import run_planner
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig, RuleConfig
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+
+def _run_pipeline(sample_dxf, tmp_path, prompt):
+    """Run the full pipeline and return (output_path, context, changeset, results)."""
+    context = load_dxf(sample_dxf)
+    planner_ctx = build_planner_context(context)
+    changeset = run_planner(prompt, planner_ctx)
+
+    rules = RuleConfig()
+    validation = validate_changeset(changeset, context, rules)
+    PreviewModel(changeset, context, validation)
+
+    if not validation.valid:
+        return None, context, changeset, []
+
+    work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+    engine = EditEngine(work)
+    results = engine.apply_changeset(changeset)
+    output = tmp_path / "output.dxf"
+    engine.save(output)
+    return output, context, changeset, results
+
+
+@pytest.mark.integration
+class TestPipelineIntegration:
+    def test_move_reflected_in_output_dxf(self, sample_dxf, tmp_path):
+        """Full pipeline: move prompt → output DXF has entity at new position."""
+        context = load_dxf(sample_dxf)
+        editable = next(
+            e
+            for e in context.entities
+            if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+        )
+
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+
+        # Read original position
+        doc_before = ezdxf.readfile(str(work))
+        entity_before = doc_before.entitydb.get(editable.handle)
+        assert entity_before is not None
+
+        # Build and apply a move changeset
+        cs = ChangeSet(
+            prompt="move test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editable.handle,
+                    params={"dx": 15.0, "dy": 10.0},
+                )
+            ],
+        )
+        rules = RuleConfig()
+        validation = validate_changeset(cs, context, rules)
+        assert validation.valid
+
+        engine = EditEngine(work)
+        results = engine.apply_changeset(cs)
+        assert all(r.success for r in results)
+
+        output = tmp_path / "moved.dxf"
+        engine.save(output)
+
+        # Reload and verify position changed
+        doc_after = ezdxf.readfile(str(output))
+        assert doc_after.entitydb.get(editable.handle) is not None
+
+    def test_delete_reduces_entity_count(self, sample_dxf, tmp_path):
+        """Full pipeline: delete → output DXF has fewer entities."""
+        context = load_dxf(sample_dxf)
+        editable = next(
+            e
+            for e in context.entities
+            if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+        )
+
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        doc_before = ezdxf.readfile(str(work))
+        count_before = len(list(doc_before.modelspace()))
+
+        cs = ChangeSet(
+            prompt="delete test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=editable.handle,
+                )
+            ],
+        )
+        rules = RuleConfig()
+        validation = validate_changeset(cs, context, rules)
+        assert validation.valid
+
+        engine = EditEngine(work)
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+
+        output = tmp_path / "deleted.dxf"
+        engine.save(output)
+
+        doc_after = ezdxf.readfile(str(output))
+        count_after = len(list(doc_after.modelspace()))
+        assert count_after < count_before
+
+    def test_revision_note_in_output_dxf(self, sample_dxf, tmp_path):
+        """Full pipeline: revision notes appear as MTEXT on AI_REV_NOTES layer."""
+        output, context, changeset, results = _run_pipeline(
+            sample_dxf, tmp_path, "move this entity"
+        )
+        assert output is not None
+        assert any(r.success for r in results)
+
+        config = RevisionNoteConfig()
+        final = tmp_path / "final.dxf"
+        insert_revision_note(output, final, results, config)
+
+        doc = ezdxf.readfile(str(final))
+        rev_notes = [
+            e for e in doc.modelspace() if e.dxftype() == "MTEXT" and e.dxf.layer == "AI_REV_NOTES"
+        ]
+        assert len(rev_notes) >= 1
+        assert "REV" in rev_notes[0].text
+
+    def test_validation_blocks_protected_layer(self, sample_dxf, tmp_path):
+        """Full pipeline: attempt to edit protected layer is blocked."""
+        context = load_dxf(sample_dxf)
+        title_entity = next(e for e in context.entities if e.layer.upper() == "TITLE")
+
+        cs = ChangeSet(
+            prompt="move title",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=title_entity.handle,
+                    params={"dx": 10, "dy": 0},
+                )
+            ],
+        )
+        rules = RuleConfig()
+        validation = validate_changeset(cs, context, rules)
+        assert not validation.valid
+        assert len(validation.blockers) >= 1
+
+    def test_multi_op_changeset_all_applied(self, sample_dxf, tmp_path):
+        """Full pipeline: multiple operations all get applied."""
+        context = load_dxf(sample_dxf)
+        editables = [
+            e
+            for e in context.entities
+            if e.layer.upper() not in ("TITLE", "TITLEBLOCK", "SEAL", "REVISION")
+        ]
+        assert len(editables) >= 2
+
+        cs = ChangeSet(
+            prompt="multi-op test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editables[0].handle,
+                    params={"dx": 5, "dy": 5},
+                ),
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editables[1].handle,
+                    params={"dx": -5, "dy": -5},
+                ),
+            ],
+        )
+        rules = RuleConfig()
+        validation = validate_changeset(cs, context, rules)
+        assert validation.valid
+
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        engine = EditEngine(work)
+        results = engine.apply_changeset(cs)
+        assert len(results) == 2
+        assert all(r.success for r in results)

--- a/tests/integration/test_undo_redo_integration.py
+++ b/tests/integration/test_undo_redo_integration.py
@@ -1,0 +1,94 @@
+"""Integration tests for undo/redo with the EditHistory + EditEngine pipeline."""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.edit_history import EditHistory
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+
+def _get_text_value(doc, handle):
+    """Get the text value of a TEXT entity by handle."""
+    entity = doc.entitydb.get(handle)
+    if entity is None:
+        return None
+    return entity.dxf.text
+
+
+def _find_text_handle(dxf_path, text_content):
+    """Find handle of TEXT entity with given content."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == "TEXT" and e.dxf.text == text_content:
+            return e.dxf.handle
+    return None
+
+
+@pytest.mark.integration
+class TestUndoRedoIntegration:
+    def test_apply_then_undo_restores_original(self, sample_dxf, tmp_path):
+        """Apply an edit, then undo restores the original text."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _find_text_handle(work, "Column C-4")
+        assert handle is not None
+
+        history = EditHistory(work)
+
+        # Apply edit
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="edit text",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=handle,
+                    params={"new_text": "CHANGED"},
+                )
+            ],
+        )
+        engine.apply_changeset(cs)
+        history.push(engine.doc, "edit text")
+
+        # Verify change took effect
+        assert _get_text_value(engine.doc, handle) == "CHANGED"
+
+        # Undo
+        restored_doc = history.undo()
+        assert restored_doc is not None
+        assert _get_text_value(restored_doc, handle) == "Column C-4"
+
+    def test_undo_then_redo_reapplies(self, sample_dxf, tmp_path):
+        """Undo then redo restores the edited state."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _find_text_handle(work, "Column C-4")
+        assert handle is not None
+
+        history = EditHistory(work)
+
+        # Apply edit
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="edit text",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=handle,
+                    params={"new_text": "MODIFIED"},
+                )
+            ],
+        )
+        engine.apply_changeset(cs)
+        history.push(engine.doc, "edit text")
+
+        # Undo
+        history.undo()
+        assert history.can_redo
+
+        # Redo
+        redone_doc = history.redo()
+        assert redone_doc is not None
+        assert _get_text_value(redone_doc, handle) == "MODIFIED"

--- a/tests/unit/__snapshots__/test_changeset_snapshot.ambr
+++ b/tests/unit/__snapshots__/test_changeset_snapshot.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: TestChangeSetSnapshots.test_delete_prompt_snapshot
+  dict({
+    'op_count': 1,
+    'operations': list([
+      dict({
+        'has_target_handle': True,
+        'has_target_layer': True,
+        'op_type': 'delete_entity',
+        'params': dict({
+        }),
+      }),
+    ]),
+    'prompt': 'delete this element',
+  })
+# ---
+# name: TestChangeSetSnapshots.test_move_prompt_snapshot
+  dict({
+    'op_count': 1,
+    'operations': list([
+      dict({
+        'has_target_handle': True,
+        'has_target_layer': True,
+        'op_type': 'move_entity',
+        'params': dict({
+          'dx': 24.0,
+          'dy': 0.0,
+        }),
+      }),
+    ]),
+    'prompt': 'move this column',
+  })
+# ---
+# name: TestChangeSetSnapshots.test_text_prompt_snapshot
+  dict({
+    'op_count': 1,
+    'operations': list([
+      dict({
+        'has_target_handle': True,
+        'has_target_layer': True,
+        'op_type': 'edit_text',
+        'params': dict({
+          'new_text': 'UPDATED BY CAD-DXF-AGENT',
+        }),
+      }),
+    ]),
+    'prompt': 'change text label',
+  })
+# ---

--- a/tests/unit/test_changeset_snapshot.py
+++ b/tests/unit/test_changeset_snapshot.py
@@ -1,0 +1,64 @@
+"""Snapshot tests for ChangeSet structure — catch accidental changes.
+
+Uses syrupy to snapshot the serialized ChangeSet from the MockProvider.
+If the prompt→changeset mapping changes, the snapshot will fail,
+forcing an explicit --snapshot-update.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.semantic_model import build_planner_context
+from cad_dxf_agent.llm.planner import run_planner
+
+
+def _changeset_to_comparable(changeset):
+    """Convert changeset to a snapshot-friendly dict.
+
+    Strips handles (they vary per DXF creation) but keeps op types,
+    params, and structure intact.
+    """
+    ops = []
+    for op in changeset.operations:
+        ops.append(
+            {
+                "op_type": op.op_type.value,
+                "params": op.params,
+                "has_target_handle": op.target_handle is not None,
+                "has_target_layer": op.target_layer is not None,
+            }
+        )
+    return {
+        "op_count": changeset.op_count,
+        "prompt": changeset.prompt,
+        "operations": ops,
+    }
+
+
+class TestChangeSetSnapshots:
+    def test_move_prompt_snapshot(self, sample_dxf, snapshot):
+        """Snapshot: 'move' prompt produces a stable changeset structure."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+        changeset = run_planner("move this column", planner_ctx)
+
+        result = _changeset_to_comparable(changeset)
+        assert result == snapshot
+
+    def test_delete_prompt_snapshot(self, sample_dxf, snapshot):
+        """Snapshot: 'delete' prompt produces a stable changeset structure."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+        changeset = run_planner("delete this element", planner_ctx)
+
+        result = _changeset_to_comparable(changeset)
+        assert result == snapshot
+
+    def test_text_prompt_snapshot(self, sample_dxf, snapshot):
+        """Snapshot: 'text' prompt produces a stable changeset structure."""
+        context = load_dxf(sample_dxf)
+        planner_ctx = build_planner_context(context)
+        changeset = run_planner("change text label", planner_ctx)
+
+        result = _changeset_to_comparable(changeset)
+        assert result == snapshot

--- a/tests/unit/test_dxf_reader.py
+++ b/tests/unit/test_dxf_reader.py
@@ -65,3 +65,88 @@ class TestDxfReader:
 
     def test_metadata_present(self, sample_context):
         assert "dxf_version" in sample_context.metadata
+
+
+class TestDxfReaderV2Entities:
+    """Tests for V2 entity types beyond the original V1 set."""
+
+    def test_hatch_entity_parsed(self, tmp_path):
+        """HATCH entities are loaded with centroid position."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        doc.layers.add("STRUCTURAL", color=1)
+        hatch = msp.add_hatch(color=1, dxfattribs={"layer": "STRUCTURAL"})
+        hatch.paths.add_polyline_path([(0, 0), (10, 0), (10, 10), (0, 10)], is_closed=True)
+        dxf_path = tmp_path / "hatch.dxf"
+        doc.saveas(str(dxf_path))
+
+        context = load_dxf(dxf_path)
+        hatches = [e for e in context.entities if e.entity_type == EntityType.HATCH]
+        assert len(hatches) == 1
+        assert hatches[0].insert_point is not None
+
+    def test_spline_entity_parsed(self, tmp_path):
+        """SPLINE entities are loaded."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        doc.layers.add("STRUCTURAL", color=1)
+        msp.add_spline(
+            fit_points=[(0, 0), (5, 10), (10, 0)],
+            dxfattribs={"layer": "STRUCTURAL"},
+        )
+        dxf_path = tmp_path / "spline.dxf"
+        doc.saveas(str(dxf_path))
+
+        context = load_dxf(dxf_path)
+        splines = [e for e in context.entities if e.entity_type == EntityType.SPLINE]
+        assert len(splines) == 1
+
+    def test_ellipse_entity_parsed(self, tmp_path):
+        """ELLIPSE entities are loaded with ratio attribute."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        doc.layers.add("STRUCTURAL", color=1)
+        msp.add_ellipse(
+            center=(30, 30),
+            major_axis=(10, 0, 0),
+            ratio=0.5,
+            dxfattribs={"layer": "STRUCTURAL"},
+        )
+        dxf_path = tmp_path / "ellipse.dxf"
+        doc.saveas(str(dxf_path))
+
+        context = load_dxf(dxf_path)
+        ellipses = [e for e in context.entities if e.entity_type == EntityType.ELLIPSE]
+        assert len(ellipses) == 1
+        assert ellipses[0].attributes.get("ratio") == 0.5
+
+    def test_unsupported_entity_types_recorded(self, tmp_path):
+        """Entity types not in our enum are recorded in unsupported_entity_types."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        # POINT is not in our EntityType enum
+        msp.add_point((5, 5))
+        dxf_path = tmp_path / "point.dxf"
+        doc.saveas(str(dxf_path))
+
+        context = load_dxf(dxf_path)
+        assert "POINT" in context.unsupported_entity_types
+
+    def test_empty_dxf(self, tmp_path):
+        """An empty DXF (no user entities) loads with zero entity count."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        dxf_path = tmp_path / "empty.dxf"
+        doc.saveas(str(dxf_path))
+
+        context = load_dxf(dxf_path)
+        assert context.entity_count == 0

--- a/tests/unit/test_dxf_writer.py
+++ b/tests/unit/test_dxf_writer.py
@@ -1,0 +1,72 @@
+"""Tests for dxf_writer — save-as and copy operations."""
+
+from __future__ import annotations
+
+import ezdxf
+
+from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing, save_as_new_dxf
+
+
+class TestSaveAsNewDxf:
+    def test_save_as_new_dxf_succeeds(self, sample_dxf, tmp_path):
+        """Save-as creates a valid new DXF at the output path."""
+        output = tmp_path / "output" / "result.dxf"
+        result = save_as_new_dxf(sample_dxf, output)
+
+        assert result == output
+        assert output.exists()
+        # Verify it's a valid DXF
+        doc = ezdxf.readfile(str(output))
+        assert doc is not None
+
+    def test_save_as_same_path_raises_valueerror(self, sample_dxf):
+        """Overwriting the source file is blocked."""
+        import pytest
+
+        with pytest.raises(ValueError, match="must differ"):
+            save_as_new_dxf(sample_dxf, sample_dxf)
+
+    def test_save_as_creates_parent_dirs(self, sample_dxf, tmp_path):
+        """Nested output directories are created automatically."""
+        output = tmp_path / "deep" / "nested" / "dir" / "out.dxf"
+        assert not output.parent.exists()
+
+        result = save_as_new_dxf(sample_dxf, output)
+        assert result.exists()
+
+    def test_save_as_preserves_entities(self, sample_dxf, tmp_path):
+        """Round-trip: saved DXF retains the same entities."""
+        output = tmp_path / "round_trip.dxf"
+        save_as_new_dxf(sample_dxf, output)
+
+        original = ezdxf.readfile(str(sample_dxf))
+        saved = ezdxf.readfile(str(output))
+
+        orig_count = len(list(original.modelspace()))
+        saved_count = len(list(saved.modelspace()))
+        assert saved_count == orig_count
+
+    def test_save_as_does_not_modify_source(self, sample_dxf, tmp_path):
+        """Source file bytes are unchanged after save-as."""
+        original_bytes = sample_dxf.read_bytes()
+        output = tmp_path / "out.dxf"
+        save_as_new_dxf(sample_dxf, output)
+        assert sample_dxf.read_bytes() == original_bytes
+
+
+class TestCopyDxfForEditing:
+    def test_copy_round_trip(self, sample_dxf, tmp_path):
+        """Copy produces a byte-identical working copy."""
+        work = tmp_path / "work.dxf"
+        result = copy_dxf_for_editing(sample_dxf, work)
+
+        assert result == work
+        assert work.exists()
+        assert work.read_bytes() == sample_dxf.read_bytes()
+
+    def test_copy_same_path_raises(self, sample_dxf):
+        """Copying to the same path is blocked."""
+        import pytest
+
+        with pytest.raises(ValueError, match="must differ"):
+            copy_dxf_for_editing(sample_dxf, sample_dxf)

--- a/tests/unit/test_edit_engine.py
+++ b/tests/unit/test_edit_engine.py
@@ -1,0 +1,314 @@
+"""Tests for edit_engine — applies validated operations to DXF documents."""
+
+from __future__ import annotations
+
+import hashlib
+
+import ezdxf
+
+from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+
+def _get_text_handle(dxf_path, text_content):
+    """Find the handle of a TEXT entity with the given text."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == "TEXT" and e.dxf.text == text_content:
+            return e.dxf.handle
+    return None
+
+
+def _get_mtext_handle(dxf_path, text_fragment):
+    """Find the handle of an MTEXT entity containing the given text."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == "MTEXT" and text_fragment in e.text:
+            return e.dxf.handle
+    return None
+
+
+def _get_first_handle(dxf_path, dxf_type="LINE"):
+    """Find the handle of the first entity of the given DXF type."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == dxf_type:
+            return e.dxf.handle
+    return None
+
+
+def _get_insert_handle(dxf_path, block_name="COLUMN_MARK"):
+    """Find the handle of the first INSERT of the given block."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == "INSERT" and e.dxf.name == block_name:
+            return e.dxf.handle
+    return None
+
+
+class TestApplyMove:
+    def test_apply_move_changes_position(self, sample_dxf, tmp_path):
+        """Move operation shifts entity position in the DXF."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_first_handle(work, "LINE")
+        assert handle is not None
+
+        # Read original position
+        doc_before = ezdxf.readfile(str(work))
+        entity_before = doc_before.entitydb.get(handle)
+        start_x_before = entity_before.dxf.start.x
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test move",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 10.0, "dy": 5.0},
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+
+        # Save and reload to verify
+        output = tmp_path / "moved.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        entity_after = doc_after.entitydb.get(handle)
+        assert abs(entity_after.dxf.start.x - (start_x_before + 10.0)) < 0.01
+
+
+class TestApplyEditText:
+    def test_apply_edit_text_on_text_entity(self, sample_dxf, tmp_path):
+        """Edit text on a TEXT entity updates dxf.text."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_text_handle(work, "Column C-4")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test edit text",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=handle,
+                    params={"new_text": "Column C-4A"},
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+
+        output = tmp_path / "edited.dxf"
+        engine.save(output)
+        doc = ezdxf.readfile(str(output))
+        entity = doc.entitydb.get(handle)
+        assert entity.dxf.text == "Column C-4A"
+
+    def test_apply_edit_text_on_mtext_entity(self, sample_dxf, tmp_path):
+        """Edit text on an MTEXT entity updates entity.text."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_mtext_handle(work, "Footing detail")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test edit mtext",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=handle,
+                    params={"new_text": "Updated note"},
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+
+        output = tmp_path / "edited_mtext.dxf"
+        engine.save(output)
+        doc = ezdxf.readfile(str(output))
+        entity = doc.entitydb.get(handle)
+        assert entity.text == "Updated note"
+
+    def test_apply_edit_text_on_non_text_fails(self, sample_dxf, tmp_path):
+        """Edit text on a LINE entity returns success=False."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_first_handle(work, "LINE")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test bad edit",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=handle,
+                    params={"new_text": "nope"},
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert not results[0].success
+        assert "Cannot edit text" in results[0].description
+
+
+class TestApplyDelete:
+    def test_apply_delete_removes_entity(self, sample_dxf, tmp_path):
+        """Delete operation removes the entity from modelspace."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+
+        doc_before = ezdxf.readfile(str(work))
+        count_before = len(list(doc_before.modelspace()))
+
+        handle = _get_first_handle(work, "LINE")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test delete",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=handle,
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+
+        output = tmp_path / "deleted.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        count_after = len(list(doc_after.modelspace()))
+        assert count_after == count_before - 1
+
+    def test_apply_delete_not_found_fails(self, sample_dxf, tmp_path):
+        """Delete on a nonexistent handle returns success=False."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle="DOES_NOT_EXIST_999",
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert not results[0].success
+        assert "not found" in results[0].description.lower()
+
+
+class TestApplyAddBlock:
+    def test_apply_add_block_inserts_reference(self, sample_dxf, tmp_path):
+        """Add block inserts a new INSERT entity in modelspace."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+
+        doc_before = ezdxf.readfile(str(work))
+        insert_count_before = sum(1 for e in doc_before.modelspace() if e.dxftype() == "INSERT")
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test add block",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    params={
+                        "block_name": "COLUMN_MARK",
+                        "insert_point": {"x": 99.0, "y": 99.0},
+                    },
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success
+        assert results[0].entity_handle  # Got a handle back
+
+        output = tmp_path / "added.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        insert_count_after = sum(1 for e in doc_after.modelspace() if e.dxftype() == "INSERT")
+        assert insert_count_after == insert_count_before + 1
+
+    def test_apply_add_block_nonexistent_block_fails(self, sample_dxf, tmp_path):
+        """Adding a block that doesn't exist in the doc returns success=False."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    params={
+                        "block_name": "NONEXISTENT_BLOCK",
+                        "insert_point": {"x": 0, "y": 0},
+                    },
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert not results[0].success
+        assert "not found" in results[0].description.lower()
+
+
+class TestAppliedChangesAccumulate:
+    def test_applied_changes_accumulate(self, sample_dxf, tmp_path):
+        """Multiple changeset applications accumulate in applied_changes."""
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_first_handle(work, "LINE")
+
+        engine = EditEngine(work)
+        cs1 = ChangeSet(
+            prompt="move",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 1, "dy": 0},
+                )
+            ],
+        )
+        cs2 = ChangeSet(
+            prompt="move again",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 2, "dy": 0},
+                )
+            ],
+        )
+        engine.apply_changeset(cs1)
+        engine.apply_changeset(cs2)
+        assert len(engine.applied_changes) == 2
+
+
+class TestOriginalFileUntouched:
+    def test_original_file_untouched(self, sample_dxf, tmp_path):
+        """After edit + save, the original file is byte-identical."""
+        sha_before = hashlib.sha256(sample_dxf.read_bytes()).hexdigest()
+
+        work = copy_dxf_for_editing(sample_dxf, tmp_path / "work.dxf")
+        handle = _get_first_handle(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 100, "dy": 100},
+                )
+            ],
+        )
+        engine.apply_changeset(cs)
+        engine.save(tmp_path / "output.dxf")
+
+        sha_after = hashlib.sha256(sample_dxf.read_bytes()).hexdigest()
+        assert sha_before == sha_after

--- a/tests/unit/test_preview_model.py
+++ b/tests/unit/test_preview_model.py
@@ -1,0 +1,143 @@
+"""Tests for preview_model — human-readable preview of proposed changes."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.preview_model import PreviewItem, PreviewModel
+from cad_dxf_agent.models.changes_schema import ValidationResult
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+
+class TestPreviewItem:
+    def test_str_format(self):
+        item = PreviewItem(0, "Move entity east")
+        assert str(item) == "[0] Move entity east"
+
+    def test_str_with_index(self):
+        item = PreviewItem(3, "Delete column")
+        assert str(item) == "[3] Delete column"
+
+
+class TestPreviewModelDescriptions:
+    def test_move_description(self, sample_context):
+        """Move op produces a description with dx, dy."""
+        editable = next(e for e in sample_context.entities if e.layer.upper() not in ("TITLE",))
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editable.handle,
+                    params={"dx": 24.0, "dy": 0.0},
+                )
+            ],
+        )
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        assert len(preview.items) == 1
+        desc = preview.items[0].description
+        assert "Move" in desc
+        assert "(24.0, 0.0)" in desc
+
+    def test_edit_text_description(self, sample_context):
+        """Edit text op includes the new text in the description."""
+        text_entity = next(
+            e for e in sample_context.entities if e.text_content and e.layer.upper() != "TITLE"
+        )
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=text_entity.handle,
+                    params={"new_text": "NEW LABEL"},
+                )
+            ],
+        )
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Edit text" in desc
+        assert "NEW LABEL" in desc
+
+    def test_delete_description(self, sample_context):
+        """Delete op mentions 'Delete' in the description."""
+        editable = next(e for e in sample_context.entities if e.layer.upper() not in ("TITLE",))
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=editable.handle,
+                )
+            ],
+        )
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Delete" in desc
+
+    def test_add_block_description(self, sample_context):
+        """Add block op includes block name and insert point."""
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    params={
+                        "block_name": "COLUMN_MARK",
+                        "insert_point": {"x": 50, "y": 50},
+                    },
+                )
+            ],
+        )
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "COLUMN_MARK" in desc
+        assert "(50, 50)" in desc
+
+
+class TestPreviewModelValidity:
+    def test_is_valid_no_blockers(self, sample_context):
+        """Preview reports valid when validation has no blockers."""
+        cs = ChangeSet(prompt="test", operations=[])
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+        assert preview.is_valid
+
+    def test_is_valid_with_blockers(self, sample_context):
+        """Preview reports invalid when validation has blockers."""
+        cs = ChangeSet(prompt="test", operations=[])
+        validation = ValidationResult()
+        validation.add_blocker("Something is wrong", 0)
+        preview = PreviewModel(cs, sample_context, validation)
+        assert not preview.is_valid
+
+
+class TestPreviewModelSummary:
+    def test_summary_includes_operation_count(self, sample_context):
+        editable = next(e for e in sample_context.entities if e.layer.upper() not in ("TITLE",))
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editable.handle,
+                    params={"dx": 1, "dy": 1},
+                )
+            ],
+        )
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+        assert "1 operation(s)" in preview.summary
+
+    def test_summary_shows_blocked_when_invalid(self, sample_context):
+        cs = ChangeSet(prompt="test", operations=[])
+        validation = ValidationResult()
+        validation.add_blocker("blocked!", 0)
+        preview = PreviewModel(cs, sample_context, validation)
+        assert "BLOCKED" in preview.summary

--- a/tests/unit/test_semantic_model.py
+++ b/tests/unit/test_semantic_model.py
@@ -1,0 +1,63 @@
+"""Tests for semantic_model — context summaries for the LLM planner."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.semantic_model import build_compact_context, build_planner_context
+
+
+class TestBuildPlannerContext:
+    def test_has_required_keys(self, sample_context):
+        """Planner context dict has all expected top-level keys."""
+        ctx = build_planner_context(sample_context)
+        assert "file_path" in ctx
+        assert "entity_count" in ctx
+        assert "layers" in ctx
+        assert "entities" in ctx
+        assert "blocks" in ctx
+
+    def test_entity_count_matches(self, sample_context):
+        """Entity count in context matches DrawingContext.entity_count."""
+        ctx = build_planner_context(sample_context)
+        assert ctx["entity_count"] == sample_context.entity_count
+        assert len(ctx["entities"]) == sample_context.entity_count
+
+    def test_entities_have_handles(self, sample_context):
+        """Each entity in the planner context has a handle."""
+        ctx = build_planner_context(sample_context)
+        for entity in ctx["entities"]:
+            assert "handle" in entity
+            assert entity["handle"]  # Non-empty
+
+    def test_layers_have_protected_flag(self, sample_context):
+        """Layer entries include a protected flag."""
+        ctx = build_planner_context(sample_context)
+        protected_names = {layer["name"] for layer in ctx["layers"] if layer["protected"]}
+        assert "TITLE" in protected_names
+
+
+class TestBuildCompactContext:
+    def test_compact_has_summary_header(self, sample_context):
+        """Compact context starts with DRAWING SUMMARY."""
+        compact = build_compact_context(sample_context)
+        assert compact.startswith("DRAWING SUMMARY:")
+
+    def test_compact_has_entity_count(self, sample_context):
+        """Compact context includes total entity count."""
+        compact = build_compact_context(sample_context)
+        assert f"Total entities: {sample_context.entity_count}" in compact
+
+    def test_compact_marks_protected_layers(self, sample_context):
+        """Protected layers are marked with (PROTECTED) in compact context."""
+        compact = build_compact_context(sample_context)
+        assert "(PROTECTED)" in compact
+
+    def test_compact_includes_blocks(self, sample_context):
+        """Compact context lists available blocks."""
+        compact = build_compact_context(sample_context)
+        assert "COLUMN_MARK" in compact
+
+    def test_compact_has_tool_instructions(self, sample_context):
+        """Compact context ends with tool-use instructions."""
+        compact = build_compact_context(sample_context)
+        assert "find_entities()" in compact
+        assert "Do NOT guess entity handles" in compact

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,55 @@
+"""Tests for settings — environment-based configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestSettings:
+    def test_default_provider_is_mock(self):
+        """Default LLM provider is 'mock'."""
+        from cad_dxf_agent.settings import Settings
+
+        with patch.dict(os.environ, {}, clear=True):
+            s = Settings()
+            assert s.llm_provider == "mock"
+
+    def test_custom_protected_layers(self):
+        """Custom protected layers are parsed and uppercased."""
+        from cad_dxf_agent.settings import Settings
+
+        with patch.dict(os.environ, {"CAD_PROTECTED_LAYERS": "foo, bar, baz"}, clear=True):
+            s = Settings()
+            assert s.protected_layers == ["FOO", "BAR", "BAZ"]
+
+    def test_revision_notes_disabled(self):
+        """Revision notes can be disabled via env var."""
+        from cad_dxf_agent.settings import Settings
+
+        with patch.dict(os.environ, {"CAD_REVISION_NOTES_ENABLED": "false"}, clear=True):
+            s = Settings()
+            assert s.revision_notes_enabled is False
+
+    def test_data_dir(self):
+        """data_dir points to ~/.cad-dxf-agent."""
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.data_dir == Path.home() / ".cad-dxf-agent"
+
+    def test_get_api_key_known_provider(self):
+        """get_api_key returns the env var value for known providers."""
+        from cad_dxf_agent.settings import Settings
+
+        with patch.dict(os.environ, {"CAD_OPENAI_API_KEY": "sk-test123"}, clear=True):
+            s = Settings()
+            assert s.get_api_key("openai") == "sk-test123"
+
+    def test_get_api_key_unknown_provider(self):
+        """get_api_key returns None for unknown providers."""
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.get_api_key("unknown_provider") is None

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -143,3 +143,190 @@ class TestEditTextValidation:
 
         result = validate_changeset(changeset, sample_context, rule_config)
         assert not result.valid
+
+    def test_blocks_non_string_new_text(self, sample_context, rule_config):
+        """edit_text with non-string new_text is blocked."""
+        text_entity = next(
+            e
+            for e in sample_context.entities
+            if e.text_content
+            and e.layer.upper() not in [pl.upper() for pl in rule_config.protected_layers]
+        )
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=text_entity.handle,
+                    params={"new_text": 42},
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "string" in result.blockers[0].message.lower()
+
+
+class TestDeleteValidation:
+    def test_delete_on_editable_layer_valid(self, sample_context, rule_config):
+        """Delete on an editable layer passes validation."""
+        editable = next(
+            e
+            for e in sample_context.entities
+            if e.layer.upper() not in [pl.upper() for pl in rule_config.protected_layers]
+        )
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=editable.handle,
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert result.valid
+
+    def test_delete_on_protected_layer_blocked(self, sample_context, rule_config):
+        """Delete on a protected layer is blocked."""
+        title_entity = next(e for e in sample_context.entities if e.layer.upper() == "TITLE")
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=title_entity.handle,
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "protected layer" in result.blockers[0].message.lower()
+
+
+class TestAddBlockValidation:
+    def test_add_block_missing_block_name(self, sample_context, rule_config):
+        """add_block without block_name is blocked."""
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    params={"insert_point": {"x": 0, "y": 0}},
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "block_name" in result.blockers[0].message.lower()
+
+    def test_add_block_missing_insert_point(self, sample_context, rule_config):
+        """add_block without insert_point is blocked."""
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    params={"block_name": "COLUMN_MARK"},
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "insert_point" in result.blockers[0].message.lower()
+
+    def test_add_block_on_protected_layer_blocked(self, sample_context, rule_config):
+        """add_block targeting a protected layer is blocked."""
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    target_layer="TITLE",
+                    params={
+                        "block_name": "COLUMN_MARK",
+                        "insert_point": {"x": 0, "y": 0},
+                    },
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "protected layer" in result.blockers[0].message.lower()
+
+    def test_add_block_valid(self, sample_context, rule_config):
+        """add_block with all required params on editable layer passes."""
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    target_layer="STRUCTURAL",
+                    params={
+                        "block_name": "COLUMN_MARK",
+                        "insert_point": {"x": 50, "y": 50},
+                    },
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert result.valid
+
+
+class TestMoveDistanceWarning:
+    def test_max_move_distance_warning(self, sample_context):
+        """Move beyond max_move_distance generates a warning (not blocker)."""
+        from cad_dxf_agent.models.config_schema import RuleConfig
+
+        rules = RuleConfig(max_move_distance=10.0)
+        editable = next(
+            e
+            for e in sample_context.entities
+            if e.layer.upper() not in [pl.upper() for pl in rules.protected_layers]
+        )
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editable.handle,
+                    params={"dx": 100.0, "dy": 0.0},
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rules)
+        # Should be valid (warning, not blocker)
+        assert result.valid
+        assert len(result.warnings) == 1
+        assert "exceeds" in result.warnings[0].message.lower()
+
+    def test_move_with_inf_blocked(self, sample_context, rule_config):
+        """Move with Inf coordinate is blocked."""
+        editable = next(
+            e
+            for e in sample_context.entities
+            if e.layer.upper() not in [pl.upper() for pl in rule_config.protected_layers]
+        )
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=editable.handle,
+                    params={"dx": float("inf"), "dy": 0},
+                )
+            ],
+        )
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert not result.valid
+        assert "inf" in result.blockers[0].message.lower()
+
+
+class TestEmptyChangeset:
+    def test_empty_changeset_valid(self, sample_context, rule_config):
+        """An empty changeset passes validation."""
+        changeset = ChangeSet(prompt="test", operations=[])
+        result = validate_changeset(changeset, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+        assert len(result.warnings) == 0


### PR DESCRIPTION
## Summary

- **+75 tests** (222 → 297), **+18pp coverage** (50% → 68%), **0 → 15 integration tests**
- ScriptedAgentProvider: replay canned tool-call sequences through the real ToolExecutor — industry fake-backend pattern for LLM loop testing without API keys
- DXF/ChangeSet factories for programmatic test data (no stored files)
- 5 golden trajectory fixtures (Google ADK pattern) documenting correct agent behavior
- Syrupy snapshot tests catching accidental ChangeSet structure changes
- Full pipeline integration tests: load → plan → validate → edit → save → reload → verify
- Undo/redo integration (EditHistory + EditEngine)
- P0 unit tests for previously zero-coverage modules (dxf_writer, edit_engine, preview_model, semantic_model, settings)

## Commits

1. `feat(test): add testing scaffold` — helpers, factories, trajectory fixtures, pyproject/Makefile config
2. `test(core): P0 unit tests` — dxf_writer (7), edit_engine (10), preview_model (10), validators (+9)
3. `test(integration): pipeline, undo/redo, agent loop` — 15 integration tests incl. parametrized golden trajectories
4. `test(llm): snapshots, V2 entities, semantic_model, settings` — 23 new tests + syrupy snapshots
5. `docs: CLAUDE.md testing section + AAR` — comprehensive test strategy docs

## Test plan

- [x] `make check` passes (lint + format + typecheck + tests + smoke)
- [x] `make test-cov` → 67.74% coverage (above 65% threshold)
- [x] `pytest tests/integration/ -v` → 15/15 pass
- [x] 297 tests, 0 failures
- [x] Smoke test passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded suite to 297 tests (~68% coverage) with new unit and integration scenarios (agent loop, full pipeline, undo/redo), golden trajectory fixtures, and snapshot checks.
  * Added test helpers and programmatic drawing fixtures to improve reproducibility.

* **Chores**
  * New test targets for unit and integration runs; added snapshot testing support and increased coverage threshold to 65%.

* **Documentation**
  * Expanded testing docs with tiers, patterns, helpers, and running-tests guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->