### PR TITLE
feat: V2.3 paper space / layout editing support

### DIFF
--- a/src/cad_dxf_agent/core/edit_engine.py
+++ b/src/cad_dxf_agent/core/edit_engine.py
@@ -18,6 +18,7 @@ class EditEngine:
     """Applies structured operations to a DXF document.
 
     Operates on a working copy — never modifies the original file.
+    Supports both model space and paper space layouts.
     """
 
     def __init__(self, dxf_path: str | Path) -> None:
@@ -25,6 +26,16 @@ class EditEngine:
         self.doc = ezdxf.readfile(str(self.dxf_path))
         self.msp = self.doc.modelspace()
         self._applied: list[AppliedChange] = []
+
+    def _get_layout(self, space: str):
+        """Resolve the ezdxf layout object for a space name.
+
+        Returns model space for 'Model', or the named paper space layout.
+        Raises KeyError if a named layout doesn't exist.
+        """
+        if space == "Model":
+            return self.msp
+        return self.doc.layouts.get(space)
 
     def apply_changeset(self, changeset: ChangeSet) -> list[AppliedChange]:
         """Apply all operations in a validated changeset.
@@ -133,12 +144,19 @@ class EditEngine:
             return AppliedChange(operation=op, success=False, description="Entity not found")
 
         try:
-            self.msp.delete_entity(entity)
+            layout = self._get_layout(op.target_space)
+            layout.delete_entity(entity)
             return AppliedChange(
                 operation=op,
                 success=True,
                 entity_handle=op.target_handle,
                 description=f"Deleted entity {op.target_handle}",
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
             )
         except Exception as e:
             return AppliedChange(operation=op, success=False, description=f"Delete failed: {e}")
@@ -159,11 +177,13 @@ class EditEngine:
                     description=f"Block definition not found: {block_name}",
                 )
 
+            layout = self._get_layout(op.target_space)
+
             attribs = {}
             if op.target_layer:
                 attribs["layer"] = op.target_layer
 
-            ref = self.msp.add_blockref(
+            ref = layout.add_blockref(
                 block_name,
                 insert=(x, y),
                 dxfattribs={
@@ -178,6 +198,12 @@ class EditEngine:
                 success=True,
                 entity_handle=ref.dxf.handle,
                 description=f"Inserted block {block_name} at ({x}, {y})",
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
             )
         except Exception as e:
             return AppliedChange(operation=op, success=False, description=f"Add block failed: {e}")

--- a/src/cad_dxf_agent/core/revision_notes.py
+++ b/src/cad_dxf_agent/core/revision_notes.py
@@ -53,17 +53,34 @@ def insert_revision_note(
     output_path: str | Path,
     changes: list[AppliedChange],
     config: RevisionNoteConfig,
+    *,
+    layout_name: str = "Model",
 ) -> str:
     """Insert a revision note into a DXF file on the dedicated AI_REV_NOTES layer.
 
     Operates on an already-edited DXF (post-apply). Saves to output_path.
+    When ``layout_name`` is provided and is not "Model", the note is inserted
+    into the named paper space layout instead of model space.
     Returns the note text that was inserted.
     """
     with tracer.start_as_current_span("cad.revision_note") as span:
         span.set_attribute("cad.revision.layer", config.layer_name)
+        span.set_attribute("cad.revision.layout", layout_name)
 
         doc = ezdxf.readfile(str(dxf_path))
-        msp = doc.modelspace()
+
+        # Resolve target layout
+        if layout_name == "Model":
+            target = doc.modelspace()
+        else:
+            try:
+                target = doc.layouts.get(layout_name)
+            except KeyError:
+                logger.warning(
+                    "Layout %r not found, falling back to model space",
+                    layout_name,
+                )
+                target = doc.modelspace()
 
         # Ensure the notes layer exists
         if config.layer_name not in doc.layers:
@@ -71,7 +88,7 @@ def insert_revision_note(
 
         note_text = generate_note_text(changes, config)
 
-        msp.add_mtext(
+        target.add_mtext(
             note_text,
             dxfattribs={
                 "layer": config.layer_name,
@@ -81,7 +98,12 @@ def insert_revision_note(
         )
 
         doc.saveas(str(output_path))
-        logger.info("Inserted revision note on layer %s: %s", config.layer_name, note_text)
+        logger.info(
+            "Inserted revision note on layer %s in %s: %s",
+            config.layer_name,
+            layout_name,
+            note_text,
+        )
         return note_text
 
 

--- a/src/cad_dxf_agent/core/revision_notes.py
+++ b/src/cad_dxf_agent/core/revision_notes.py
@@ -69,7 +69,8 @@ def insert_revision_note(
 
         doc = ezdxf.readfile(str(dxf_path))
 
-        # Resolve target layout
+        # Resolve target layout (BaseLayout is the common type for both)
+        target: ezdxf.layouts.BaseLayout
         if layout_name == "Model":
             target = doc.modelspace()
         else:

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -159,6 +159,7 @@ class ToolExecutor:
             op_type=OpType.MOVE_ENTITY,
             target_handle=handle,
             target_layer=entity.layer,
+            target_space=entity.space,
             params={"dx": args["dx"], "dy": args["dy"]},
         )
         self._operations.append(op)
@@ -182,6 +183,7 @@ class ToolExecutor:
             op_type=OpType.EDIT_TEXT,
             target_handle=handle,
             target_layer=entity.layer,
+            target_space=entity.space,
             params={"new_text": args["new_text"]},
         )
         self._operations.append(op)
@@ -204,6 +206,7 @@ class ToolExecutor:
             op_type=OpType.DELETE_ENTITY,
             target_handle=handle,
             target_layer=entity.layer,
+            target_space=entity.space,
         )
         self._operations.append(op)
         return {
@@ -217,6 +220,7 @@ class ToolExecutor:
         x = args["x"]
         y = args["y"]
         layer = args.get("layer")
+        space = args.get("space", "Model")
 
         if layer and layer.upper() in self._protected:
             return {"error": f"Cannot insert block on protected layer: {layer}"}
@@ -224,6 +228,7 @@ class ToolExecutor:
         op = EditOperation(
             op_type=OpType.ADD_BLOCK,
             target_layer=layer,
+            target_space=space,
             params={
                 "block_name": block_name,
                 "insert_point": {"x": x, "y": y},
@@ -247,6 +252,7 @@ def _entity_to_dict(entity: EntityRef) -> dict[str, Any]:
         "handle": entity.handle,
         "type": entity.entity_type.value,
         "layer": entity.layer,
+        "space": entity.space,
     }
     if entity.insert_point:
         d["x"] = entity.insert_point.x

--- a/src/cad_dxf_agent/models/ops_schema.py
+++ b/src/cad_dxf_agent/models/ops_schema.py
@@ -26,6 +26,10 @@ class EditOperation(BaseModel):
         description="Handle of the target entity (required for move/edit/delete)",
     )
     target_layer: str | None = None
+    target_space: str = Field(
+        default="Model",
+        description="Space/layout name: 'Model' or a paper space layout name",
+    )
     params: dict[str, Any] = Field(default_factory=dict)
 
     # move_entity params: dx, dy

--- a/tests/helpers/dxf_factory.py
+++ b/tests/helpers/dxf_factory.py
@@ -195,3 +195,61 @@ def create_empty_dxf(tmp_path: Path, *, filename: str = "empty.dxf") -> Path:
     dxf_path = tmp_path / filename
     doc.saveas(str(dxf_path))
     return dxf_path
+
+
+def create_drawing_with_layout(
+    tmp_path: Path,
+    *,
+    layout_name: str = "Sheet1",
+    filename: str = "with_layout.dxf",
+) -> Path:
+    """Create a DXF with entities in both model space and a named paper space layout.
+
+    Model space gets:
+    - 2 lines on STRUCTURAL
+    - 1 text on NOTES ("Model Note")
+    - 1 block insert (COLUMN_MARK) on STRUCTURAL
+
+    Paper space layout gets:
+    - 1 text on NOTES ("Layout Note")
+    - 1 line on STRUCTURAL
+    - 1 mtext on NOTES ("Layout Detail")
+
+    Returns path to the saved DXF.
+    """
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+
+    # Layers
+    doc.layers.add("STRUCTURAL", color=1)
+    doc.layers.add("NOTES", color=3)
+    doc.layers.add("TITLE", color=7)
+
+    # Block definition
+    block = doc.blocks.new("COLUMN_MARK")
+    block.add_circle((0, 0), radius=2)
+
+    # --- Model space entities ---
+    msp.add_line((0, 0), (100, 0), dxfattribs={"layer": "STRUCTURAL"})
+    msp.add_line((0, 0), (0, 100), dxfattribs={"layer": "STRUCTURAL"})
+    msp.add_text(
+        "Model Note",
+        dxfattribs={"layer": "NOTES", "height": 2.5, "insert": (10, 10)},
+    )
+    msp.add_blockref("COLUMN_MARK", insert=(50, 50), dxfattribs={"layer": "STRUCTURAL"})
+
+    # --- Paper space layout ---
+    layout = doc.layouts.new(layout_name)
+    layout.add_text(
+        "Layout Note",
+        dxfattribs={"layer": "NOTES", "height": 3.0, "insert": (5, 5)},
+    )
+    layout.add_line((0, 0), (200, 0), dxfattribs={"layer": "STRUCTURAL"})
+    layout.add_mtext(
+        "Layout Detail",
+        dxfattribs={"layer": "NOTES", "insert": (20, 20), "char_height": 2.0},
+    )
+
+    dxf_path = tmp_path / filename
+    doc.saveas(str(dxf_path))
+    return dxf_path

--- a/tests/integration/test_paper_space_integration.py
+++ b/tests/integration/test_paper_space_integration.py
@@ -1,0 +1,151 @@
+"""Integration tests for paper space editing (full pipeline)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.revision_notes import insert_revision_note
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig, RuleConfig
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+from tests.helpers.dxf_factory import create_drawing_with_layout
+
+
+class TestPaperSpacePipelineIntegration:
+    """Full pipeline tests for layout-targeted edits."""
+
+    def test_move_in_layout_full_pipeline(self, tmp_path):
+        """Load → validate → apply move in layout → save → reload → verify."""
+        dxf = create_drawing_with_layout(tmp_path)
+        ctx = load_dxf(dxf)
+        rules = RuleConfig()
+
+        # Find a layout entity
+        layout_text = next(
+            e for e in ctx.entities if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                    params={"dx": 20.0, "dy": 10.0},
+                )
+            ],
+            prompt="Move layout note east and north",
+        )
+
+        # Validate
+        validation = validate_changeset(changeset, ctx, rules)
+        assert validation.valid
+
+        # Apply
+        engine = EditEngine(dxf)
+        results = engine.apply_changeset(changeset)
+        assert all(r.success for r in results)
+
+        # Save
+        out = tmp_path / "output.dxf"
+        engine.save(out)
+
+        # Reload and verify
+        reloaded = load_dxf(out)
+        moved = reloaded.get_entity_by_handle(layout_text.handle)
+        assert moved is not None
+        assert moved.space == "Sheet1"
+        assert abs(moved.insert_point.x - 25.0) < 0.1  # 5 + 20
+        assert abs(moved.insert_point.y - 15.0) < 0.1  # 5 + 10
+
+    def test_delete_in_layout_with_revision_note(self, tmp_path):
+        """Delete layout entity → insert revision note in same layout."""
+        dxf = create_drawing_with_layout(tmp_path)
+        ctx = load_dxf(dxf)
+
+        layout_text = next(
+            e for e in ctx.entities if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                )
+            ],
+            prompt="Delete layout note",
+        )
+
+        engine = EditEngine(dxf)
+        results = engine.apply_changeset(changeset)
+        assert results[0].success
+
+        edited_path = tmp_path / "edited.dxf"
+        engine.save(edited_path)
+
+        # Insert revision note in same layout
+        config = RevisionNoteConfig()
+        final_path = tmp_path / "final.dxf"
+        note_text = insert_revision_note(
+            edited_path, final_path, results, config, layout_name="Sheet1"
+        )
+        assert "Deleted entity" in note_text
+
+        # Verify: layout has note but no longer has the deleted text
+        reloaded = load_dxf(final_path)
+        sheet_entities = [e for e in reloaded.entities if e.space == "Sheet1"]
+        deleted_still = [e for e in sheet_entities if e.text_content == "Layout Note"]
+        assert len(deleted_still) == 0
+        rev_notes = [e for e in sheet_entities if e.layer == config.layer_name]
+        assert len(rev_notes) >= 1
+
+    def test_multi_space_changeset(self, tmp_path):
+        """A changeset with ops in both model and layout spaces."""
+        dxf = create_drawing_with_layout(tmp_path)
+        ctx = load_dxf(dxf)
+        rules = RuleConfig()
+
+        model_text = next(
+            e for e in ctx.entities if e.space == "Model" and e.text_content == "Model Note"
+        )
+        layout_text = next(
+            e for e in ctx.entities if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=model_text.handle,
+                    target_layer=model_text.layer,
+                    target_space="Model",
+                    params={"new_text": "Updated Model"},
+                ),
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                    params={"new_text": "Updated Layout"},
+                ),
+            ],
+            prompt="Edit text in both spaces",
+        )
+
+        validation = validate_changeset(changeset, ctx, rules)
+        assert validation.valid
+
+        engine = EditEngine(dxf)
+        results = engine.apply_changeset(changeset)
+        assert all(r.success for r in results)
+
+        out = tmp_path / "multi_space.dxf"
+        engine.save(out)
+
+        reloaded = load_dxf(out)
+        assert reloaded.get_entity_by_handle(model_text.handle).text_content == "Updated Model"
+        assert reloaded.get_entity_by_handle(layout_text.handle).text_content == "Updated Layout"

--- a/tests/unit/test_paper_space.py
+++ b/tests/unit/test_paper_space.py
@@ -1,0 +1,385 @@
+"""Tests for paper space / layout editing support."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.revision_notes import insert_revision_note
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+from cad_dxf_agent.models.ops_schema import AppliedChange, ChangeSet, EditOperation, OpType
+from tests.helpers.dxf_factory import create_drawing_with_layout
+
+
+@pytest.fixture
+def layout_dxf(tmp_path):
+    """DXF with model space + paper space layout entities."""
+    return create_drawing_with_layout(tmp_path, layout_name="Sheet1")
+
+
+@pytest.fixture
+def layout_context(layout_dxf):
+    """DrawingContext loaded from the layout DXF."""
+    return load_dxf(layout_dxf)
+
+
+class TestDxfReaderLayouts:
+    """Verify dxf_reader loads both model and layout entities."""
+
+    def test_layout_entities_loaded(self, layout_context):
+        """Entities from the named layout are present in the context."""
+        layout_entities = [e for e in layout_context.entities if e.space == "Sheet1"]
+        assert len(layout_entities) == 3  # text, line, mtext
+
+    def test_model_entities_loaded(self, layout_context):
+        """Model space entities are still loaded correctly."""
+        model_entities = [e for e in layout_context.entities if e.space == "Model"]
+        assert len(model_entities) >= 4  # 2 lines, 1 text, 1 insert
+
+    def test_layout_info_present(self, layout_context):
+        """LayoutInfo is generated for both Model and Sheet1."""
+        names = {lay.name for lay in layout_context.layouts}
+        assert "Model" in names
+        assert "Sheet1" in names
+
+    def test_layout_entity_count(self, layout_context):
+        """LayoutInfo tracks correct entity count per layout."""
+        sheet_info = next(lay for lay in layout_context.layouts if lay.name == "Sheet1")
+        assert sheet_info.entity_count == 3
+
+    def test_entity_space_field(self, layout_context):
+        """Each entity carries the correct space field."""
+        layout_text = [
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        ]
+        assert len(layout_text) == 1
+
+
+class TestEditEngineLayoutSupport:
+    """Verify EditEngine can edit entities in paper space layouts."""
+
+    def test_move_layout_entity(self, layout_dxf, layout_context, tmp_path):
+        """Move an entity in a named layout — position changes."""
+        # Find the layout text entity
+        layout_text = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                    params={"dx": 10.0, "dy": 5.0},
+                )
+            ],
+            prompt="Move layout text",
+        )
+        results = engine.apply_changeset(changeset)
+        assert results[0].success
+
+        # Save and reload to verify position changed
+        out = tmp_path / "moved.dxf"
+        engine.save(out)
+        reloaded = load_dxf(out)
+        moved = reloaded.get_entity_by_handle(layout_text.handle)
+        assert moved is not None
+        assert moved.insert_point is not None
+        assert abs(moved.insert_point.x - 15.0) < 0.1  # 5 + 10
+        assert abs(moved.insert_point.y - 10.0) < 0.1  # 5 + 5
+
+    def test_edit_text_layout_entity(self, layout_dxf, layout_context, tmp_path):
+        """Edit text on a layout TEXT entity."""
+        layout_text = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                    params={"new_text": "Updated Layout Note"},
+                )
+            ],
+            prompt="Edit layout text",
+        )
+        results = engine.apply_changeset(changeset)
+        assert results[0].success
+
+        out = tmp_path / "edited.dxf"
+        engine.save(out)
+        reloaded = load_dxf(out)
+        edited = reloaded.get_entity_by_handle(layout_text.handle)
+        assert edited is not None
+        assert edited.text_content == "Updated Layout Note"
+
+    def test_delete_layout_entity(self, layout_dxf, layout_context, tmp_path):
+        """Delete an entity from a paper space layout."""
+        layout_text = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                )
+            ],
+            prompt="Delete layout text",
+        )
+        results = engine.apply_changeset(changeset)
+        assert results[0].success
+
+        out = tmp_path / "deleted.dxf"
+        engine.save(out)
+        reloaded = load_dxf(out)
+        # Entity count in Sheet1 should be reduced
+        sheet_entities = [e for e in reloaded.entities if e.space == "Sheet1"]
+        assert len(sheet_entities) == 2  # was 3, now 2
+
+    def test_add_block_to_layout(self, layout_dxf, layout_context, tmp_path):
+        """Insert a block reference into a paper space layout."""
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_BLOCK,
+                    target_layer="STRUCTURAL",
+                    target_space="Sheet1",
+                    params={
+                        "block_name": "COLUMN_MARK",
+                        "insert_point": {"x": 100, "y": 100},
+                    },
+                )
+            ],
+            prompt="Add block to layout",
+        )
+        results = engine.apply_changeset(changeset)
+        assert results[0].success
+
+        out = tmp_path / "block_added.dxf"
+        engine.save(out)
+        reloaded = load_dxf(out)
+        sheet_entities = [e for e in reloaded.entities if e.space == "Sheet1"]
+        assert len(sheet_entities) == 4  # was 3, now 4
+
+    def test_model_space_unaffected_by_layout_edit(self, layout_dxf, layout_context, tmp_path):
+        """Editing layout entities does not change model space entity count."""
+        model_before = len([e for e in layout_context.entities if e.space == "Model"])
+
+        layout_text = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle=layout_text.handle,
+                    target_layer=layout_text.layer,
+                    target_space="Sheet1",
+                )
+            ],
+            prompt="Delete layout entity",
+        )
+        engine.apply_changeset(changeset)
+
+        out = tmp_path / "isolation.dxf"
+        engine.save(out)
+        reloaded = load_dxf(out)
+        model_after = len([e for e in reloaded.entities if e.space == "Model"])
+        assert model_after == model_before
+
+    def test_invalid_layout_name_fails(self, layout_dxf):
+        """Targeting a nonexistent layout fails gracefully."""
+        engine = EditEngine(layout_dxf)
+        changeset = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY,
+                    target_handle="FAKE",
+                    target_layer="NOTES",
+                    target_space="NonExistentLayout",
+                )
+            ],
+            prompt="Bad layout",
+        )
+        results = engine.apply_changeset(changeset)
+        assert not results[0].success
+
+
+class TestRevisionNotesLayout:
+    """Verify revision notes can be inserted into paper space layouts."""
+
+    def test_revision_note_in_layout(self, layout_dxf, tmp_path):
+        """Revision note is inserted into the named layout, not model space."""
+        config = RevisionNoteConfig()
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle="ABC",
+                    target_space="Sheet1",
+                    params={"dx": 10, "dy": 0},
+                ),
+                success=True,
+                entity_handle="ABC",
+                description="Moved entity",
+            )
+        ]
+
+        out = tmp_path / "rev_note.dxf"
+        note_text = insert_revision_note(
+            layout_dxf, out, changes, config, layout_name="Sheet1"
+        )
+        assert "Moved entity" in note_text
+
+        # Verify note is in the layout
+        reloaded = load_dxf(out)
+        sheet_entities = [e for e in reloaded.entities if e.space == "Sheet1"]
+        note_entities = [
+            e for e in sheet_entities if e.layer == config.layer_name
+        ]
+        assert len(note_entities) >= 1
+
+    def test_revision_note_default_model_space(self, layout_dxf, tmp_path):
+        """Default layout_name='Model' puts note in model space."""
+        config = RevisionNoteConfig()
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle="ABC",
+                    params={"dx": 10, "dy": 0},
+                ),
+                success=True,
+                entity_handle="ABC",
+                description="Moved entity",
+            )
+        ]
+
+        out = tmp_path / "rev_note_model.dxf"
+        insert_revision_note(layout_dxf, out, changes, config)
+
+        reloaded = load_dxf(out)
+        model_notes = [
+            e
+            for e in reloaded.entities
+            if e.space == "Model" and e.layer == config.layer_name
+        ]
+        assert len(model_notes) >= 1
+
+    def test_revision_note_invalid_layout_falls_back(self, layout_dxf, tmp_path):
+        """Invalid layout name falls back to model space."""
+        config = RevisionNoteConfig()
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle="ABC",
+                    params={"dx": 10, "dy": 0},
+                ),
+                success=True,
+                entity_handle="ABC",
+                description="Moved entity",
+            )
+        ]
+
+        out = tmp_path / "rev_fallback.dxf"
+        insert_revision_note(
+            layout_dxf, out, changes, config, layout_name="NoSuchLayout"
+        )
+
+        reloaded = load_dxf(out)
+        model_notes = [
+            e
+            for e in reloaded.entities
+            if e.space == "Model" and e.layer == config.layer_name
+        ]
+        assert len(model_notes) >= 1
+
+
+class TestToolExecutorSpaceAwareness:
+    """Verify ToolExecutor propagates space to operations and results."""
+
+    def test_entity_dict_includes_space(self, layout_context):
+        """_entity_to_dict includes space field."""
+        from cad_dxf_agent.llm.tool_executor import _entity_to_dict
+
+        layout_entity = next(
+            e for e in layout_context.entities if e.space == "Sheet1"
+        )
+        result = _entity_to_dict(layout_entity)
+        assert result["space"] == "Sheet1"
+
+    def test_find_entities_returns_space(self, layout_context):
+        """find_entities tool results include space for each entity."""
+        from cad_dxf_agent.llm.tool_executor import ToolExecutor
+        from cad_dxf_agent.settings import settings
+
+        executor = ToolExecutor(layout_context, settings.protected_layers)
+        result = executor.execute("find_entities", {"layer": "NOTES"})
+        spaces = {e["space"] for e in result["entities"]}
+        assert "Sheet1" in spaces
+        assert "Model" in spaces
+
+    def test_move_propagates_space(self, layout_context):
+        """move_entity sets target_space from entity's space."""
+        from cad_dxf_agent.llm.tool_executor import ToolExecutor
+        from cad_dxf_agent.settings import settings
+
+        layout_entity = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        executor = ToolExecutor(layout_context, settings.protected_layers)
+        executor.execute(
+            "move_entity", {"handle": layout_entity.handle, "dx": 5, "dy": 5}
+        )
+
+        ops = executor.operations
+        assert len(ops) == 1
+        assert ops[0].target_space == "Sheet1"
+
+    def test_delete_propagates_space(self, layout_context):
+        """delete_entity sets target_space from entity's space."""
+        from cad_dxf_agent.llm.tool_executor import ToolExecutor
+        from cad_dxf_agent.settings import settings
+
+        layout_entity = next(
+            e
+            for e in layout_context.entities
+            if e.space == "Sheet1" and e.text_content == "Layout Note"
+        )
+
+        executor = ToolExecutor(layout_context, settings.protected_layers)
+        executor.execute("delete_entity", {"handle": layout_entity.handle})
+
+        ops = executor.operations
+        assert len(ops) == 1
+        assert ops[0].target_space == "Sheet1"

--- a/tests/unit/test_paper_space.py
+++ b/tests/unit/test_paper_space.py
@@ -252,17 +252,13 @@ class TestRevisionNotesLayout:
         ]
 
         out = tmp_path / "rev_note.dxf"
-        note_text = insert_revision_note(
-            layout_dxf, out, changes, config, layout_name="Sheet1"
-        )
+        note_text = insert_revision_note(layout_dxf, out, changes, config, layout_name="Sheet1")
         assert "Moved entity" in note_text
 
         # Verify note is in the layout
         reloaded = load_dxf(out)
         sheet_entities = [e for e in reloaded.entities if e.space == "Sheet1"]
-        note_entities = [
-            e for e in sheet_entities if e.layer == config.layer_name
-        ]
+        note_entities = [e for e in sheet_entities if e.layer == config.layer_name]
         assert len(note_entities) >= 1
 
     def test_revision_note_default_model_space(self, layout_dxf, tmp_path):
@@ -286,9 +282,7 @@ class TestRevisionNotesLayout:
 
         reloaded = load_dxf(out)
         model_notes = [
-            e
-            for e in reloaded.entities
-            if e.space == "Model" and e.layer == config.layer_name
+            e for e in reloaded.entities if e.space == "Model" and e.layer == config.layer_name
         ]
         assert len(model_notes) >= 1
 
@@ -309,15 +303,11 @@ class TestRevisionNotesLayout:
         ]
 
         out = tmp_path / "rev_fallback.dxf"
-        insert_revision_note(
-            layout_dxf, out, changes, config, layout_name="NoSuchLayout"
-        )
+        insert_revision_note(layout_dxf, out, changes, config, layout_name="NoSuchLayout")
 
         reloaded = load_dxf(out)
         model_notes = [
-            e
-            for e in reloaded.entities
-            if e.space == "Model" and e.layer == config.layer_name
+            e for e in reloaded.entities if e.space == "Model" and e.layer == config.layer_name
         ]
         assert len(model_notes) >= 1
 
@@ -329,9 +319,7 @@ class TestToolExecutorSpaceAwareness:
         """_entity_to_dict includes space field."""
         from cad_dxf_agent.llm.tool_executor import _entity_to_dict
 
-        layout_entity = next(
-            e for e in layout_context.entities if e.space == "Sheet1"
-        )
+        layout_entity = next(e for e in layout_context.entities if e.space == "Sheet1")
         result = _entity_to_dict(layout_entity)
         assert result["space"] == "Sheet1"
 
@@ -358,9 +346,7 @@ class TestToolExecutorSpaceAwareness:
         )
 
         executor = ToolExecutor(layout_context, settings.protected_layers)
-        executor.execute(
-            "move_entity", {"handle": layout_entity.handle, "dx": 5, "dy": 5}
-        )
+        executor.execute("move_entity", {"handle": layout_entity.handle, "dx": 5, "dy": 5})
 
         ops = executor.operations
         assert len(ops) == 1


### PR DESCRIPTION
## Summary

- EditEngine resolves correct layout for all operations via `target_space` field on `EditOperation`
- ToolExecutor propagates entity space to operations and includes `space` in tool result dicts
- RevisionNotes accepts `layout_name` parameter, falls back to model space for invalid layouts
- DXF factory gains `create_drawing_with_layout()` builder for test drawings with named layouts

## Changes

### Core (`src/cad_dxf_agent/`)
- `models/ops_schema.py` — `EditOperation.target_space` field (default "Model")
- `core/edit_engine.py` — `_get_layout()` resolver, delete/add_block use target layout
- `core/revision_notes.py` — `layout_name` kwarg on `insert_revision_note()`
- `llm/tool_executor.py` — space propagation in all edit tools + `_entity_to_dict()`

### Tests
- `tests/unit/test_paper_space.py` — 18 tests: reader layouts, EditEngine ops, RevisionNotes, ToolExecutor
- `tests/integration/test_paper_space_integration.py` — 3 tests: full pipeline, multi-space changeset
- `tests/helpers/dxf_factory.py` — `create_drawing_with_layout()` factory

### Verification
- 318 tests pass (up from 297)
- `ruff check` clean
- `mypy` clean
- Zero regressions on existing tests

## PRD Acceptance Criterion
- [x] #3: Can read layout/paper space entities
- [x] All V1 acceptance criteria still pass

## Test plan
- [x] Unit: move/edit_text/delete/add_block in named layout
- [x] Unit: model space isolation (layout edits don't affect model space)
- [x] Unit: invalid layout name fails gracefully
- [x] Unit: revision notes in layout vs model space vs fallback
- [x] Unit: ToolExecutor space propagation in ops and results
- [x] Integration: full pipeline move in layout → reload → verify
- [x] Integration: delete + revision note in same layout
- [x] Integration: multi-space changeset (Model + Sheet1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for editing entities in paper-space layouts (move, text edit, delete, block insert).
  * Insert revision notes into specific paper-space layouts with fallback to model space when missing.
  * Edit operations now preserve and target the intended layout/space, with clearer layout-related feedback.

* **Tests**
  * Added comprehensive unit and integration tests covering paper-space workflows and cross-space edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->