### PR TITLE
feat(test): live Gemini API test infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format typecheck test test-unit test-integration test-cov smoke check run clean build build-clean
+.PHONY: install lint format typecheck test test-unit test-integration test-live test-cov smoke check run clean build build-clean
 
 install:
 	pip install -e ".[dev]"
@@ -21,6 +21,9 @@ test-unit:
 
 test-integration:
 	pytest tests/integration/ -v -m integration
+
+test-live:
+	pytest tests/live/ -v -m live_api -s
 
 test-cov:
 	pytest --cov=cad_dxf_agent --cov-report=term-missing -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore = ["S101"]  # Allow assert in tests
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "S106"]
-"scripts/**/*.py" = ["S603", "S607"]  # subprocess calls in build scripts are safe
+"scripts/**/*.py" = ["S603", "S607", "E402"]  # subprocess + sys.path before imports
 
 [tool.mypy]
 python_version = "3.11"
@@ -115,6 +115,7 @@ markers = [
     "smoke: end-to-end smoke tests",
     "slow: tests that take significant time",
     "integration: integration tests (full pipeline, multi-module)",
+    "live_api: tests that call real Gemini API (require GOOGLE_CLOUD_PROJECT)",
 ]
 
 [tool.coverage.run]

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -96,7 +96,7 @@ def main() -> int:
         print("\n[2/7] Loading DXF into DrawingContext...")
         context = load_dxf(input_dxf)
         print(f"  Entities: {context.entity_count}")
-        print(f"  Layers: {[l.name for l in context.layers]}")
+        print(f"  Layers: {[layer.name for layer in context.layers]}")
         print(f"  Protected: {context.get_protected_layers()}")
         print(f"  Blocks: {context.blocks}")
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,0 +1,60 @@
+"""Conftest for live API tests — skips unless GCP credentials are available."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# The marker applied to all tests in this directory
+LIVE_API_REASON = (
+    "Live API tests require GOOGLE_CLOUD_PROJECT env var "
+    "and valid GCP credentials (gcloud auth application-default login)"
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip live_api tests when GCP credentials are not available."""
+    skip_live = pytest.mark.skip(reason=LIVE_API_REASON)
+    for item in items:
+        if "live_api" in item.keywords and not os.getenv("GOOGLE_CLOUD_PROJECT"):
+            item.add_marker(skip_live)
+
+
+@pytest.fixture
+def gcp_project():
+    """Return the GCP project ID from environment."""
+    project = os.getenv("GOOGLE_CLOUD_PROJECT")
+    if not project:
+        pytest.skip(LIVE_API_REASON)
+    return project
+
+
+@pytest.fixture
+def gcp_location():
+    """Return the GCP location (default: us-central1)."""
+    return os.getenv("CAD_GCP_LOCATION", "us-central1")
+
+
+@pytest.fixture
+def structural_drawing(tmp_path):
+    """Create a realistic structural drawing for live tests."""
+    from tests.helpers.dxf_factory import create_structural_drawing
+
+    return create_structural_drawing(tmp_path)
+
+
+@pytest.fixture
+def structural_context(structural_drawing):
+    """Load the structural drawing into a DrawingContext."""
+    from cad_dxf_agent.core.dxf_reader import load_dxf
+
+    return load_dxf(structural_drawing)
+
+
+@pytest.fixture
+def planner_context(structural_context):
+    """Build a planner context dict from the structural drawing."""
+    from cad_dxf_agent.core.semantic_model import build_planner_context
+
+    return build_planner_context(structural_context)

--- a/tests/live/test_agent_loop.py
+++ b/tests/live/test_agent_loop.py
@@ -1,0 +1,74 @@
+"""Live tests for AgentProvider tool-use loop against real Vertex AI.
+
+These tests verify the iterative find → edit pattern works end-to-end:
+the agent discovers entities via query tools, then edits them via edit tools.
+
+Run with: make test-live  (or pytest tests/live/ -m live_api)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.live_api
+class TestAgentLoopLive:
+    """Agent tool-use loop produces valid ChangeSets with real Gemini."""
+
+    def test_agent_move_produces_ops(self, gcp_project, gcp_location, planner_context):
+        """Agent loop: find entities → move one → returns ChangeSet with move op."""
+        from cad_dxf_agent.llm.agent_provider import AgentProvider
+
+        provider = AgentProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Move the column mark at grid B-2 one foot north",
+            planner_context,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1
+        # Agent should have used at least one tool turn
+        assert "Agent edit" in (changeset.revision_label or "")
+
+    def test_agent_delete_produces_ops(self, gcp_project, gcp_location, planner_context):
+        """Agent loop: find → delete produces valid ChangeSet."""
+        from cad_dxf_agent.llm.agent_provider import AgentProvider
+
+        provider = AgentProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Delete the dimension at the bottom of the drawing",
+            planner_context,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1
+
+    def test_agent_respects_protected_layers(self, gcp_project, gcp_location, planner_context):
+        """Agent should not produce ops on protected layers even if asked."""
+        from cad_dxf_agent.llm.agent_provider import AgentProvider
+
+        provider = AgentProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Delete the project title",
+            planner_context,
+        )
+
+        # Either 0 ops (correctly refused) or ops that don't target protected layers
+        protected = {"TITLE", "TITLEBLOCK", "SEAL", "REVISION"}
+        for op in changeset.operations:
+            if op.target_layer:
+                assert op.target_layer.upper() not in protected
+
+    def test_agent_multi_op(self, gcp_project, gcp_location, planner_context):
+        """Agent can produce multiple operations in one prompt."""
+        from cad_dxf_agent.llm.agent_provider import AgentProvider
+
+        provider = AgentProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Move column A-1 east by 2 feet and update its label to 'A-1R'",
+            planner_context,
+        )
+
+        assert changeset is not None
+        # Ideally 2 ops, but at least 1
+        assert changeset.op_count >= 1

--- a/tests/live/test_benchmark.py
+++ b/tests/live/test_benchmark.py
@@ -1,0 +1,57 @@
+"""Benchmark tests for Gemini API latency and cost tracking.
+
+Measures round-trip time for each provider type and reports results.
+Not meant to fail — purely informational metrics.
+
+Run with: make test-live  (or pytest tests/live/ -m live_api -s)
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.mark.live_api
+class TestBenchmarkLive:
+    """Latency benchmarks for live Gemini calls."""
+
+    def test_oneshot_latency(self, gcp_project, gcp_location, planner_context):
+        """Measure one-shot GeminiProvider round-trip time."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+
+        start = time.monotonic()
+        changeset = provider.plan(
+            "Move the column at grid A-1 east by 24 inches",
+            planner_context,
+        )
+        elapsed = time.monotonic() - start
+
+        print(f"\n  One-shot latency: {elapsed:.2f}s")
+        print(f"  Operations: {changeset.op_count}")
+
+        # Soft assertion — just flag if unusually slow
+        assert elapsed < 60, f"One-shot took {elapsed:.1f}s (expected <60s)"
+
+    def test_agent_latency(self, gcp_project, gcp_location, planner_context):
+        """Measure agent tool-use loop round-trip time."""
+        from cad_dxf_agent.llm.agent_provider import AgentProvider
+
+        provider = AgentProvider(project=gcp_project, location=gcp_location)
+
+        start = time.monotonic()
+        changeset = provider.plan(
+            "Move the column at grid B-2 north by 12 inches",
+            planner_context,
+        )
+        elapsed = time.monotonic() - start
+
+        print(f"\n  Agent loop latency: {elapsed:.2f}s")
+        print(f"  Operations: {changeset.op_count}")
+        print(f"  Revision: {changeset.revision_label}")
+
+        # Agent loop is slower (multiple turns), allow more time
+        assert elapsed < 120, f"Agent loop took {elapsed:.1f}s (expected <120s)"

--- a/tests/live/test_error_handling.py
+++ b/tests/live/test_error_handling.py
@@ -1,0 +1,62 @@
+"""Live tests for error handling and resilience against real Vertex AI.
+
+Tests that the providers handle edge cases gracefully:
+bad credentials, invalid models, safety filters, etc.
+
+Run with: make test-live  (or pytest tests/live/ -m live_api)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.live_api
+class TestErrorHandlingLive:
+    """Provider error handling with real API calls."""
+
+    def test_invalid_model_raises(self, gcp_project, gcp_location, planner_context):
+        """Using a non-existent model name raises an error."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(
+            project=gcp_project,
+            location=gcp_location,
+            model_name="gemini-nonexistent-99",
+        )
+
+        with pytest.raises((ValueError, RuntimeError, ConnectionError, OSError)):
+            provider.plan("Move something", planner_context)
+
+    def test_invalid_project_raises(self, planner_context):
+        """Using a non-existent project raises an error."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(
+            project="nonexistent-project-999999",
+            location="us-central1",
+        )
+
+        with pytest.raises((ValueError, RuntimeError, ConnectionError, OSError)):
+            provider.plan("Move something", planner_context)
+
+    def test_vision_missing_file_raises(self, gcp_project):
+        """describe_drawing raises FileNotFoundError for missing image."""
+        from cad_dxf_agent.llm.vision_describer import describe_drawing
+
+        with pytest.raises(FileNotFoundError):
+            describe_drawing("/nonexistent/path/drawing.png")
+
+    def test_retry_on_invalid_response(self, gcp_project, gcp_location, planner_context):
+        """Provider retries on validation failure (tests retry logic path)."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        # A very ambiguous prompt may trigger a retry if first response is malformed
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Do something interesting with the entities near grid C",
+            planner_context,
+        )
+
+        # Should not crash even if it needed to retry
+        assert changeset is not None

--- a/tests/live/test_gemini_oneshot.py
+++ b/tests/live/test_gemini_oneshot.py
@@ -1,0 +1,90 @@
+"""Live tests for one-shot GeminiProvider against real Vertex AI.
+
+These tests call the actual Gemini API and validate that the response
+is a structurally valid ChangeSet. They require:
+  - GOOGLE_CLOUD_PROJECT env var set
+  - Valid GCP credentials (gcloud auth application-default login)
+  - pip install -e ".[gemini]"
+
+Run with: make test-live  (or pytest tests/live/ -m live_api)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.live_api
+class TestGeminiOneShotLive:
+    """One-shot GeminiProvider returns valid ChangeSets from real prompts."""
+
+    def test_move_entity_prompt(self, gcp_project, gcp_location, planner_context):
+        """Gemini produces a valid ChangeSet for a move request."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Move the column mark at grid A-1 two feet east",
+            planner_context,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1
+        for op in changeset.operations:
+            assert op.op_type is not None
+
+    def test_edit_text_prompt(self, gcp_project, gcp_location, planner_context):
+        """Gemini produces a valid ChangeSet for a text edit."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Change the label at column A-1 to read 'RELOCATED'",
+            planner_context,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1
+
+    def test_delete_entity_prompt(self, gcp_project, gcp_location, planner_context):
+        """Gemini produces a valid ChangeSet for a delete request."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Delete the footing schedule note",
+            planner_context,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1
+
+    def test_protected_layer_not_targeted(self, gcp_project, gcp_location, planner_context):
+        """Gemini should not produce ops targeting protected layers."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Move the text on the NOTES layer 10 units north",
+            planner_context,
+        )
+
+        protected = {"TITLE", "TITLEBLOCK", "SEAL", "REVISION"}
+        for op in changeset.operations:
+            if op.target_layer:
+                assert op.target_layer.upper() not in protected, (
+                    f"Op targets protected layer: {op.target_layer}"
+                )
+
+    def test_empty_prompt_returns_changeset(self, gcp_project, gcp_location, planner_context):
+        """Even an ambiguous prompt returns a valid (possibly empty) ChangeSet."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Make the drawing better",
+            planner_context,
+        )
+
+        # Should not crash — may return 0 or more ops
+        assert changeset is not None

--- a/tests/live/test_vision_pipeline.py
+++ b/tests/live/test_vision_pipeline.py
@@ -1,0 +1,78 @@
+"""Live tests for the vision pipeline (describe_drawing) against real Vertex AI.
+
+Tests that Gemini Flash can analyze a PNG render of a DXF drawing
+and produce a meaningful text description.
+
+Run with: make test-live  (or pytest tests/live/ -m live_api)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.live_api
+class TestVisionPipelineLive:
+    """Vision describer produces meaningful descriptions from real Gemini."""
+
+    @pytest.fixture
+    def drawing_png(self, structural_drawing, tmp_path):
+        """Render the structural drawing to PNG for vision tests."""
+        try:
+            from cad_dxf_agent.core.renderer import render_dxf_to_png
+
+            png_path = tmp_path / "drawing.png"
+            result = render_dxf_to_png(structural_drawing, png_path)
+            if result.success:
+                return png_path
+        except ImportError:
+            pass
+
+        # Fallback: create a minimal PNG with pillow
+        try:
+            from PIL import Image
+
+            img = Image.new("RGB", (800, 600), "white")
+            png_path = tmp_path / "drawing.png"
+            img.save(str(png_path))
+            return png_path
+        except ImportError:
+            pytest.skip("Neither matplotlib nor Pillow available for PNG creation")
+
+    def test_describe_drawing_returns_text(self, gcp_project, drawing_png):
+        """describe_drawing returns a non-empty string description."""
+        from cad_dxf_agent.llm.vision_describer import describe_drawing
+
+        description = describe_drawing(drawing_png)
+
+        assert isinstance(description, str)
+        assert len(description) > 50, "Description too short to be meaningful"
+
+    def test_description_mentions_structural_elements(self, gcp_project, drawing_png):
+        """Description should reference drawing elements."""
+        from cad_dxf_agent.llm.vision_describer import describe_drawing
+
+        description = describe_drawing(drawing_png).lower()
+
+        # At least some of these should appear in a structural drawing description
+        structural_terms = ["grid", "column", "line", "structural", "plan", "drawing"]
+        matches = [term for term in structural_terms if term in description]
+        assert len(matches) >= 1, (
+            f"Description doesn't mention any structural terms: {description[:200]}"
+        )
+
+    def test_vision_with_gemini_provider(
+        self, gcp_project, gcp_location, planner_context, drawing_png
+    ):
+        """GeminiProvider with image_path produces valid ChangeSet."""
+        from cad_dxf_agent.llm.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(project=gcp_project, location=gcp_location)
+        changeset = provider.plan(
+            "Move a column mark 12 inches north",
+            planner_context,
+            image_path=drawing_png,
+        )
+
+        assert changeset is not None
+        assert changeset.op_count >= 1


### PR DESCRIPTION
## Summary

- 18 live API tests across 5 modules for testing against real Vertex AI Gemini
- Auto-skip infrastructure: all tests skip gracefully when `GOOGLE_CLOUD_PROJECT` is not set (zero CI impact — 18 skipped in 0.05s)
- `make test-live` target for local execution with GCP credentials

### Test Modules

| Module | Tests | Coverage |
|--------|-------|----------|
| `test_gemini_oneshot.py` | 5 | One-shot provider: move, edit, delete, protected layer guard, empty prompt |
| `test_agent_loop.py` | 4 | Agent tool-use loop: move, delete, protected layers, multi-op |
| `test_vision_pipeline.py` | 3 | Vision describer + vision-guided planning |
| `test_error_handling.py` | 4 | Invalid model/project, missing files, retry logic |
| `test_benchmark.py` | 2 | Latency tracking for one-shot and agent modes |

### Additional Fixes

- Fix `smoke_test.py` E741 lint (ambiguous variable name `l` -> `layer`)
- Add E402 per-file-ignore for `scripts/` (sys.path before imports is unavoidable)
- Add `live_api` pytest marker to pyproject.toml

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] `ruff format --check` passes (87 files)
- [x] Unit tests pass (16/16 on test_validators)
- [x] Live tests collect and skip without GCP creds (18 skipped in 0.05s)
- [x] `make test-live` target works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive live API test suite validating agent loop functionality, error handling, vision pipeline integration, and Gemini provider performance against real Vertex AI.
  * Introduced performance benchmarking tests for API latency measurement.

* **Chores**
  * Updated build configuration to support live API testing with environment-based test execution.
  * Minor code style improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->