### PR TITLE
fix: use ADC for live API tests instead of env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ markers = [
     "smoke: end-to-end smoke tests",
     "slow: tests that take significant time",
     "integration: integration tests (full pipeline, multi-module)",
-    "live_api: tests that call real Gemini API (require GOOGLE_CLOUD_PROJECT)",
+    "live_api: tests that call real Gemini API (require ADC via gcloud auth)",
 ]
 
 [tool.coverage.run]

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,30 +1,45 @@
-"""Conftest for live API tests — skips unless GCP credentials are available."""
+"""Conftest for live API tests — skips unless ADC (Application Default Credentials) work.
+
+Uses the same auth pattern as all other GCP projects:
+  - google.auth.default() for credential + project auto-detection
+  - No special env vars required — just `gcloud auth application-default login`
+"""
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
-# The marker applied to all tests in this directory
 LIVE_API_REASON = (
-    "Live API tests require GOOGLE_CLOUD_PROJECT env var "
-    "and valid GCP credentials (gcloud auth application-default login)"
+    "Live API tests require Application Default Credentials. "
+    "Run: gcloud auth application-default login"
 )
 
 
+def _detect_gcp_project() -> str | None:
+    """Auto-detect GCP project from ADC, same as vertexai.init() does."""
+    try:
+        import google.auth  # type: ignore[import-untyped]
+
+        _, project = google.auth.default()
+        return project
+    except Exception:
+        return None
+
+
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip live_api tests when GCP credentials are not available."""
+    """Auto-skip live_api tests when ADC is not available."""
+    if _detect_gcp_project() is not None:
+        return  # ADC works, don't skip anything
     skip_live = pytest.mark.skip(reason=LIVE_API_REASON)
     for item in items:
-        if "live_api" in item.keywords and not os.getenv("GOOGLE_CLOUD_PROJECT"):
+        if "live_api" in item.keywords:
             item.add_marker(skip_live)
 
 
 @pytest.fixture
 def gcp_project():
-    """Return the GCP project ID from environment."""
-    project = os.getenv("GOOGLE_CLOUD_PROJECT")
+    """Return the GCP project ID auto-detected from ADC."""
+    project = _detect_gcp_project()
     if not project:
         pytest.skip(LIVE_API_REASON)
     return project
@@ -33,6 +48,8 @@ def gcp_project():
 @pytest.fixture
 def gcp_location():
     """Return the GCP location (default: us-central1)."""
+    import os
+
     return os.getenv("CAD_GCP_LOCATION", "us-central1")
 
 

--- a/tests/live/test_gemini_oneshot.py
+++ b/tests/live/test_gemini_oneshot.py
@@ -2,8 +2,7 @@
 
 These tests call the actual Gemini API and validate that the response
 is a structurally valid ChangeSet. They require:
-  - GOOGLE_CLOUD_PROJECT env var set
-  - Valid GCP credentials (gcloud auth application-default login)
+  - Application Default Credentials (gcloud auth application-default login)
   - pip install -e ".[gemini]"
 
 Run with: make test-live  (or pytest tests/live/ -m live_api)


### PR DESCRIPTION
## Summary

- Live test conftest was gating on `GOOGLE_CLOUD_PROJECT` env var — but no other project uses that pattern
- Now uses `google.auth.default()` to auto-detect ADC, matching DiagnosticPro and Hustle patterns
- Just need `gcloud auth application-default login` — no special env vars

### Changes

- `tests/live/conftest.py` — replaced `os.getenv("GOOGLE_CLOUD_PROJECT")` with `google.auth.default()` auto-detection
- `tests/live/test_gemini_oneshot.py` — updated docstring to remove env var reference
- `pyproject.toml` — updated marker description

## Test plan

- [x] `ruff check` passes
- [x] Live tests collect (18 tests)
- [x] Unit tests still pass (16/16)
- [x] ADC auto-detects project (`hustleapp-production`)
- [x] Tests no longer skip when ADC is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated live API tests to use Application Default Credentials (ADC) for authentication instead of environment variables. Users running tests should execute `gcloud auth application-default login` to set up credentials.

* **Documentation**
  * Updated test documentation to reflect ADC-based authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->