### PR TITLE
feat(infra): dedicated GCP project + WIF for CI live tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,28 @@ jobs:
         with:
           name: coverage-report
           path: .coverage
+
+  live-test:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
+      - name: Install dependencies
+        run: pip install -e ".[dev,gemini]"
+      - name: Run live API tests
+        run: pytest tests/live/ -v -m live_api -s
+        env:
+          CAD_GCP_PROJECT: ${{ vars.GCP_PROJECT_ID }}
+          CAD_GCP_LOCATION: us-central1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,8 @@ Mock mode (`CAD_LLM_PROVIDER=mock`, the default) works without any API key. All 
 Live tests in `tests/live/` hit real Gemini via Vertex AI on the `cad-dxf-agent` GCP project.
 
 ```bash
-# Local: set ADC to cad-dxf-agent project
+# Local: set ADC + run with project env var
 gcloud auth application-default login
-gcloud auth application-default set-quota-project cad-dxf-agent
 CAD_GCP_PROJECT=cad-dxf-agent pytest tests/live/ -v -m live_api -s
 
 # CI: runs automatically on push to main via WIF (tokenless, no secrets)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,19 @@ make run           # python -m cad_dxf_agent.app
 
 Mock mode (`CAD_LLM_PROVIDER=mock`, the default) works without any API key. All tests and the smoke test use mock mode.
 
+### Live API Tests
+
+Live tests in `tests/live/` hit real Gemini via Vertex AI on the `cad-dxf-agent` GCP project.
+
+```bash
+# Local: set ADC to cad-dxf-agent project
+gcloud auth application-default login
+gcloud auth application-default set-quota-project cad-dxf-agent
+CAD_GCP_PROJECT=cad-dxf-agent pytest tests/live/ -v -m live_api -s
+
+# CI: runs automatically on push to main via WIF (tokenless, no secrets)
+```
+
 ## Architecture
 
 ### Pipeline Flow

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,8 +1,11 @@
-"""Conftest for live API tests — skips unless ADC (Application Default Credentials) work.
+"""Conftest for live API tests — skips unless GCP credentials are available.
 
-Uses the same auth pattern as all other GCP projects:
-  - google.auth.default() for credential + project auto-detection
-  - No special env vars required — just `gcloud auth application-default login`
+Project detection order:
+  1. CAD_GCP_PROJECT env var (set in CI via GitHub Actions vars)
+  2. google.auth.default() ADC auto-detection (local dev)
+
+Local dev: `gcloud auth application-default login`
+CI: WIF via google-github-actions/auth@v2 (tokenless)
 """
 
 from __future__ import annotations
@@ -16,7 +19,12 @@ LIVE_API_REASON = (
 
 
 def _detect_gcp_project() -> str | None:
-    """Auto-detect GCP project from ADC, same as vertexai.init() does."""
+    """Auto-detect GCP project: env var first, then ADC."""
+    import os
+
+    project = os.getenv("CAD_GCP_PROJECT")
+    if project:
+        return project
     try:
         import google.auth  # type: ignore[import-untyped]
 

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -10,6 +10,8 @@ CI: WIF via google-github-actions/auth@v2 (tokenless)
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 LIVE_API_REASON = (
@@ -20,8 +22,6 @@ LIVE_API_REASON = (
 
 def _detect_gcp_project() -> str | None:
     """Auto-detect GCP project: env var first, then ADC."""
-    import os
-
     project = os.getenv("CAD_GCP_PROJECT")
     if project:
         return project
@@ -56,8 +56,6 @@ def gcp_project():
 @pytest.fixture
 def gcp_location():
     """Return the GCP location (default: us-central1)."""
-    import os
-
     return os.getenv("CAD_GCP_LOCATION", "us-central1")
 
 


### PR DESCRIPTION
## Summary

- Created dedicated `cad-dxf-agent` GCP project so live API tests stop hitting `hustleapp-production`
- Set up Workload Identity Federation (WIF) for tokenless CI auth — no secrets needed
- Added `live-test` CI job that runs on push to main (after unit tests pass)
- Updated `tests/live/conftest.py` to prefer `CAD_GCP_PROJECT` env var over raw ADC

## GCP Resources Created

| Resource | Value |
|----------|-------|
| Project | `cad-dxf-agent` (688314245119) |
| Service Account | `cad-dxf-agent-ci@cad-dxf-agent.iam.gserviceaccount.com` |
| WIF Pool | `github-actions-pool` |
| OIDC Provider | `github` (scoped to `jeremylongshore` repos) |
| SA Role | `roles/aiplatform.user` (inference only) |

## GitHub Repo Variables

- `GCP_PROJECT_ID` = `cad-dxf-agent`
- `WIF_PROVIDER` = `projects/688314245119/.../github`
- `WIF_SERVICE_ACCOUNT` = `cad-dxf-agent-ci@...`

## Test plan

- [x] 15/18 live tests pass against new project (3 pre-existing flaky/error-type mismatches)
- [x] `CAD_GCP_PROJECT` env var correctly overrides ADC
- [x] WIF pool + provider are ACTIVE
- [ ] CI `live-test` job authenticates via WIF on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated live API tests that run on pushes to the main branch and can be run locally or in CI.

* **Documentation**
  * Added a Live API Tests section with setup and usage instructions for running tests against Gemini/Vertex AI.

* **Chores**
  * Improved GCP project detection to prefer an explicit environment variable for CI and local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->