### PR TITLE
feat(ui): responsive pipeline with QThread worker and progress UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,23 @@ jobs:
           name: coverage-report
           path: .coverage
 
+  gui-test:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install system deps for Qt
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1-mesa-glx
+      - name: Install dependencies
+        run: pip install -e ".[dev,gui]"
+      - name: Run GUI tests
+        run: pytest tests/gui/ -v -m gui
+        env:
+          QT_QPA_PLATFORM: offscreen
+
   live-test:
     runs-on: ubuntu-latest
     needs: [test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ markers = [
     "slow: tests that take significant time",
     "integration: integration tests (full pipeline, multi-module)",
     "live_api: tests that call real Gemini API (require ADC via gcloud auth)",
+    "gui: GUI tests (require PySide6 and QT_QPA_PLATFORM=offscreen)",
 ]
 
 [tool.coverage.run]

--- a/src/cad_dxf_agent/ui/main_window.py
+++ b/src/cad_dxf_agent/ui/main_window.py
@@ -8,6 +8,7 @@ Full-featured desktop UI for Tony's structural drawing edits:
 - Undo/redo (Ctrl+Z / Ctrl+Y)
 - Export menu (DXF, PNG, PDF)
 - Status bar with entity count and layer info
+- Non-blocking pipeline with progress indicators
 """
 
 from __future__ import annotations
@@ -19,13 +20,18 @@ from pathlib import Path
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction, QKeySequence
 from PySide6.QtWidgets import (
+    QApplication,
     QCheckBox,
     QComboBox,
+    QDialog,
+    QDialogButtonBox,
     QFileDialog,
     QHBoxLayout,
     QLabel,
     QMainWindow,
     QMessageBox,
+    QPlainTextEdit,
+    QProgressBar,
     QPushButton,
     QScrollArea,
     QSplitter,
@@ -37,16 +43,11 @@ from PySide6.QtWidgets import (
 )
 
 from ..core.dxf_reader import load_dxf
-from ..core.edit_engine import EditEngine
 from ..core.edit_history import EditHistory
-from ..core.preview_model import PreviewModel
-from ..core.revision_notes import insert_revision_note
-from ..core.semantic_model import build_planner_context
-from ..core.validators import validate_changeset
-from ..llm.planner import run_planner
 from ..models.config_schema import RevisionNoteConfig, RuleConfig
 from ..models.ops_schema import ChangeSet, EditOperation
 from ..settings import settings
+from .pipeline_worker import ApplyResult, PipelineWorker, PlanResult
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,12 @@ class MainWindow(QMainWindow):
             enabled=settings.revision_notes_enabled,
             layer_name=settings.revision_notes_layer,
         )
+
+        # Pipeline worker state
+        self._worker: PipelineWorker | None = None
+        self._last_stages: list = []
+        self._plan_stage_count = 4  # build_context, planner, validate, preview
+        self._apply_stage_count = 3  # edit_engine, save, revision_notes
 
         self._build_menu()
         self._build_toolbar()
@@ -149,6 +156,13 @@ class MainWindow(QMainWindow):
         self.btn_redo.clicked.connect(self._on_redo)
         toolbar.addWidget(self.btn_redo)
 
+        toolbar.addSeparator()
+
+        self.btn_timings = QPushButton("Timings")
+        self.btn_timings.setEnabled(False)
+        self.btn_timings.clicked.connect(self._on_show_timings)
+        toolbar.addWidget(self.btn_timings)
+
     # ── Main UI ───────────────────────────────────────────────────
 
     def _build_ui(self):
@@ -200,6 +214,16 @@ class MainWindow(QMainWindow):
         self.btn_apply.clicked.connect(self._on_apply)
         btn_row.addWidget(self.btn_apply)
         left.addLayout(btn_row)
+
+        # Progress bar (hidden by default)
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.hide()
+        left.addWidget(self.progress_bar)
+
+        self.lbl_stage = QLabel("")
+        self.lbl_stage.hide()
+        left.addWidget(self.lbl_stage)
 
         # Status log
         left.addWidget(QLabel("Log:"))
@@ -374,39 +398,23 @@ class MainWindow(QMainWindow):
         if prompt not in self._prompt_history:
             self._prompt_history.append(prompt)
 
-        try:
-            self._log_status(f"Planning: {prompt[:60]}...")
-            drawing_ctx = build_planner_context(self._context)
-            self._changeset = run_planner(prompt, drawing_ctx)
+        # Cancel any running worker
+        self._cancel_worker()
 
-            validation = validate_changeset(self._changeset, self._context, self._rule_config)
-            self._preview = PreviewModel(self._changeset, self._context, validation)
+        self._log_status(f"Planning: {prompt[:60]}...")
+        self.btn_plan.setEnabled(False)
+        self.btn_apply.setEnabled(False)
+        self._show_progress(self._plan_stage_count)
 
-            # Build per-operation checkboxes
-            self._clear_ops()
-            for item in self._preview.items:
-                cb = QCheckBox(str(item))
-                cb.setChecked(True)
-                self._op_checkboxes.append(cb)
-                self.ops_layout.addWidget(cb)
-
-            if not validation.valid:
-                for b in validation.blockers:
-                    lbl = QLabel(f"BLOCKED: {b.message}")
-                    lbl.setStyleSheet("color: red; font-weight: bold;")
-                    self.ops_layout.addWidget(lbl)
-                self._log_status(f"Plan blocked: {len(validation.blockers)} issue(s)")
-                self.btn_apply.setEnabled(False)
-            else:
-                self._log_status(f"Plan valid: {self._changeset.op_count} operation(s)")
-                self.btn_apply.setEnabled(True)
-
-            for w in validation.warnings:
-                self._log_status(f"Warning: {w.message}")
-
-        except Exception as e:
-            QMessageBox.critical(self, "Planner Error", f"Planning failed:\n{e}")
-            logger.error("Planner error: %s", traceback.format_exc())
+        worker = PipelineWorker(self)
+        worker.setup_plan(prompt, self._context, self._rule_config)
+        worker.stage_started.connect(self._on_stage_started)
+        worker.stage_finished.connect(self._on_stage_finished)
+        worker.plan_succeeded.connect(self._on_plan_succeeded)
+        worker.plan_failed.connect(self._on_plan_failed)
+        worker.finished.connect(self._on_worker_finished)
+        self._worker = worker
+        worker.start()
 
     def _on_apply(self):
         if not self._changeset or not self._dxf_path:
@@ -422,6 +430,7 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "No Operations", "Select at least one operation to apply.")
             return
 
+        # File dialog stays on main thread (native dialog)
         output_path, _ = QFileDialog.getSaveFileName(
             self,
             "Save As New DXF",
@@ -431,42 +440,158 @@ class MainWindow(QMainWindow):
         if not output_path:
             return
 
-        try:
-            filtered = ChangeSet(
-                prompt=self._changeset.prompt,
-                operations=selected_ops,
-                revision_label=self._changeset.revision_label,
-            )
+        # Cancel any running worker
+        self._cancel_worker()
 
-            engine = EditEngine(self._dxf_path)
-            results = engine.apply_changeset(filtered)
+        filtered = ChangeSet(
+            prompt=self._changeset.prompt,
+            operations=selected_ops,
+            revision_label=self._changeset.revision_label,
+        )
 
-            # Capture snapshot for undo before saving
-            if self._history:
-                self._history.push(
-                    engine.doc,
-                    f"Applied {len(selected_ops)} op(s)",
-                )
-                self._update_undo_redo()
+        self.btn_plan.setEnabled(False)
+        self.btn_apply.setEnabled(False)
+        self._show_progress(self._apply_stage_count)
 
-            engine.save(output_path)
+        worker = PipelineWorker(self)
+        worker.setup_apply(
+            filtered, self._dxf_path, output_path, self._rule_config, self._rev_config
+        )
+        worker.stage_started.connect(self._on_stage_started)
+        worker.stage_finished.connect(self._on_stage_finished)
+        worker.apply_succeeded.connect(self._on_apply_succeeded)
+        worker.apply_failed.connect(self._on_apply_failed)
+        worker.finished.connect(self._on_worker_finished)
+        self._worker = worker
+        worker.start()
 
-            success_count = sum(1 for r in results if r.success)
-            self._log_status(f"Applied {success_count}/{len(results)} operations")
+    # ── Worker signal slots ──────────────────────────────────────
 
-            # Insert revision note if enabled
-            if self._rev_config.enabled:
-                note_text = insert_revision_note(
-                    output_path, output_path, results, self._rev_config
-                )
-                self._log_status(f"Revision note: {note_text}")
+    def _on_stage_started(self, stage_name: str):
+        self.lbl_stage.setText(f"Stage: {stage_name}...")
+        self.statusBar().showMessage(f"Running: {stage_name}")
 
-            self._log_status(f"Saved to: {output_path}")
-            QMessageBox.information(self, "Success", f"Saved to:\n{output_path}")
+    def _on_stage_finished(self, stage_name: str, duration_ms: float):
+        self._log_status(f"  {stage_name}: {duration_ms:.0f} ms")
+        self.progress_bar.setValue(self.progress_bar.value() + 1)
 
-        except Exception as e:
-            QMessageBox.critical(self, "Apply Error", f"Apply/save failed:\n{e}")
-            logger.error("Apply error: %s", traceback.format_exc())
+    def _on_plan_succeeded(self, result: PlanResult):
+        self._last_stages = result.stages
+        self.btn_timings.setEnabled(True)
+        self._changeset = result.changeset
+        self._preview = result.preview
+
+        # Build per-operation checkboxes
+        self._clear_ops()
+        for item in self._preview.items:
+            cb = QCheckBox(str(item))
+            cb.setChecked(True)
+            self._op_checkboxes.append(cb)
+            self.ops_layout.addWidget(cb)
+
+        if not result.validation.valid:
+            for b in result.validation.blockers:
+                lbl = QLabel(f"BLOCKED: {b.message}")
+                lbl.setStyleSheet("color: red; font-weight: bold;")
+                self.ops_layout.addWidget(lbl)
+            self._log_status(f"Plan blocked: {len(result.validation.blockers)} issue(s)")
+            self.btn_apply.setEnabled(False)
+        else:
+            self._log_status(f"Plan valid: {self._changeset.op_count} operation(s)")
+            self.btn_apply.setEnabled(True)
+
+        for w in result.validation.warnings:
+            self._log_status(f"Warning: {w.message}")
+
+    def _on_plan_failed(self, error: str):
+        QMessageBox.critical(self, "Planner Error", f"Planning failed:\n{error}")
+        logger.error("Planner error: %s", error)
+        self.btn_plan.setEnabled(self._context is not None)
+
+    def _on_apply_succeeded(self, result: ApplyResult):
+        self._last_stages = result.stages
+        self.btn_timings.setEnabled(True)
+
+        # Push to edit history for undo support
+        if self._history:
+            success_count = sum(1 for r in result.applied_changes if r.success)
+            self._history.push(result.engine_doc, f"Applied {success_count} op(s)")
+            self._update_undo_redo()
+
+        success_count = sum(1 for r in result.applied_changes if r.success)
+        total = len(result.applied_changes)
+        self._log_status(f"Applied {success_count}/{total} operations")
+
+        if result.note_text:
+            self._log_status(f"Revision note: {result.note_text}")
+
+        self._log_status(f"Saved to: {result.output_path}")
+        QMessageBox.information(self, "Success", f"Saved to:\n{result.output_path}")
+
+    def _on_apply_failed(self, error: str):
+        QMessageBox.critical(self, "Apply Error", f"Apply/save failed:\n{error}")
+        logger.error("Apply error: %s", error)
+
+    def _on_worker_finished(self):
+        self._hide_progress()
+        self._worker = None
+        self.btn_plan.setEnabled(self._context is not None)
+
+    # ── Progress helpers ───────────────────────────────────────
+
+    def _show_progress(self, stage_count: int):
+        self.progress_bar.setMaximum(stage_count)
+        self.progress_bar.setValue(0)
+        self.progress_bar.show()
+        self.lbl_stage.show()
+
+    def _hide_progress(self):
+        self.progress_bar.hide()
+        self.lbl_stage.hide()
+        self.lbl_stage.setText("")
+        self.statusBar().clearMessage()
+
+    def _cancel_worker(self):
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.cancel()
+            self._worker.wait(5000)
+            self._worker = None
+
+    # ── Timings dialog ─────────────────────────────────────────
+
+    def _on_show_timings(self):
+        if not self._last_stages:
+            return
+
+        lines = ["Stage Timings", "=" * 40]
+        total_ms = 0.0
+        for sr in self._last_stages:
+            status = "OK" if sr.success else f"FAIL: {sr.error}"
+            lines.append(f"  {sr.stage.value:20s}  {sr.duration_ms:8.1f} ms  {status}")
+            total_ms += sr.duration_ms
+        lines.append("-" * 40)
+        lines.append(f"  {'Total':20s}  {total_ms:8.1f} ms")
+        text = "\n".join(lines)
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Pipeline Timings")
+        dlg.setMinimumSize(450, 300)
+        layout = QVBoxLayout(dlg)
+
+        txt = QPlainTextEdit(text)
+        txt.setReadOnly(True)
+        layout.addWidget(txt)
+
+        btn_box = QDialogButtonBox()
+        btn_copy = btn_box.addButton("Copy to Clipboard", QDialogButtonBox.ButtonRole.ActionRole)
+        btn_copy.clicked.connect(lambda: QApplication.clipboard().setText(text))
+        btn_close = btn_box.addButton(QDialogButtonBox.StandardButton.Close)
+        btn_close.clicked.connect(dlg.close)
+        layout.addWidget(btn_box)
+
+        dlg.exec()
+
+    # ── Undo / Redo ────────────────────────────────────────────
 
     def _on_undo(self):
         if not self._history or not self._history.can_undo:
@@ -576,3 +701,9 @@ class MainWindow(QMainWindow):
         except Exception as e:
             QMessageBox.critical(self, "Export Error", f"Export failed:\n{e}")
             logger.error("Export error: %s", traceback.format_exc())
+
+    # ── Window lifecycle ───────────────────────────────────────
+
+    def closeEvent(self, event):  # noqa: N802
+        self._cancel_worker()
+        super().closeEvent(event)

--- a/src/cad_dxf_agent/ui/pipeline_worker.py
+++ b/src/cad_dxf_agent/ui/pipeline_worker.py
@@ -1,0 +1,300 @@
+"""Pipeline worker — runs plan/apply stages on a background QThread."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import QThread, Signal
+
+from ..core.edit_engine import EditEngine
+from ..core.preview_model import PreviewModel
+from ..core.revision_notes import insert_revision_note
+from ..core.semantic_model import build_planner_context
+from ..core.validators import validate_changeset
+from ..llm.planner import run_planner
+from ..models.cad_schema import DrawingContext
+from ..models.changes_schema import ValidationResult
+from ..models.config_schema import RevisionNoteConfig, RuleConfig
+from ..models.ops_schema import AppliedChange, ChangeSet
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineStage(StrEnum):
+    """Named stages in the plan/apply pipeline."""
+
+    BUILD_CONTEXT = "Build Context"
+    RUN_PLANNER = "Run Planner"
+    VALIDATE = "Validate"
+    PREVIEW = "Preview"
+    EDIT_ENGINE = "Edit Engine"
+    SAVE = "Save"
+    REVISION_NOTES = "Revision Notes"
+
+
+@dataclass
+class StageResult:
+    """Timing and outcome for a single pipeline stage."""
+
+    stage: PipelineStage
+    duration_ms: float
+    success: bool = True
+    error: str = ""
+
+
+@dataclass
+class PlanResult:
+    """Outcome of a plan run."""
+
+    changeset: ChangeSet
+    validation: ValidationResult
+    preview: PreviewModel
+    stages: list[StageResult] = field(default_factory=list)
+
+
+@dataclass
+class ApplyResult:
+    """Outcome of an apply run."""
+
+    applied_changes: list[AppliedChange]
+    output_path: str
+    note_text: str
+    engine_doc: Any  # ezdxf.document.Drawing — kept for EditHistory.push()
+    stages: list[StageResult] = field(default_factory=list)
+
+
+class PipelineWorker(QThread):
+    """Runs pipeline stages off the main thread.
+
+    Usage::
+
+        worker = PipelineWorker()
+        worker.setup_plan(prompt, context, rule_config)
+        worker.plan_succeeded.connect(on_ok)
+        worker.plan_failed.connect(on_err)
+        worker.start()
+    """
+
+    # Signals
+    stage_started = Signal(str)
+    stage_finished = Signal(str, float)  # stage name, duration_ms
+    plan_succeeded = Signal(object)  # PlanResult
+    plan_failed = Signal(str)  # error message
+    apply_succeeded = Signal(object)  # ApplyResult
+    apply_failed = Signal(str)  # error message
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._mode: str = ""  # "plan" or "apply"
+        self._cancelled = False
+
+        # Plan params
+        self._prompt: str = ""
+        self._context: DrawingContext | None = None
+        self._rule_config: RuleConfig | None = None
+
+        # Apply params
+        self._changeset: ChangeSet | None = None
+        self._dxf_path: Path | None = None
+        self._output_path: str = ""
+        self._rev_config: RevisionNoteConfig | None = None
+
+    # ── Setup ──────────────────────────────────────────────────
+
+    def setup_plan(
+        self,
+        prompt: str,
+        context: DrawingContext,
+        rule_config: RuleConfig,
+    ) -> None:
+        """Configure for a plan run. Call before start()."""
+        self._mode = "plan"
+        self._prompt = prompt
+        self._context = context
+        self._rule_config = rule_config
+
+    def setup_apply(
+        self,
+        changeset: ChangeSet,
+        dxf_path: Path,
+        output_path: str,
+        rule_config: RuleConfig,
+        rev_config: RevisionNoteConfig,
+    ) -> None:
+        """Configure for an apply run. Call before start()."""
+        self._mode = "apply"
+        self._changeset = changeset
+        self._dxf_path = dxf_path
+        self._output_path = output_path
+        self._rule_config = rule_config
+        self._rev_config = rev_config
+
+    def cancel(self) -> None:
+        """Request cancellation (checked between stages)."""
+        self._cancelled = True
+
+    # ── Thread entry ───────────────────────────────────────────
+
+    def run(self) -> None:  # noqa: A003
+        """QThread entry point — dispatches to plan or apply."""
+        self._cancelled = False
+        try:
+            if self._mode == "plan":
+                self._run_plan()
+            elif self._mode == "apply":
+                self._run_apply()
+            else:
+                self.plan_failed.emit(f"Unknown mode: {self._mode}")
+        except Exception as exc:
+            msg = f"{type(exc).__name__}: {exc}"
+            logger.error("Pipeline worker error: %s", msg)
+            if self._mode == "plan":
+                self.plan_failed.emit(msg)
+            else:
+                self.apply_failed.emit(msg)
+
+    # ── Plan pipeline ──────────────────────────────────────────
+
+    def _run_plan(self) -> None:
+        assert self._context is not None
+        assert self._rule_config is not None
+        stages: list[StageResult] = []
+
+        # Stage 1: Build context
+        drawing_ctx, sr = self._timed_stage(
+            PipelineStage.BUILD_CONTEXT,
+            lambda: build_planner_context(self._context),  # type: ignore[arg-type]
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.plan_failed.emit(sr.error or "Cancelled")
+            return
+
+        # Stage 2: Run planner
+        changeset, sr = self._timed_stage(
+            PipelineStage.RUN_PLANNER,
+            lambda: run_planner(self._prompt, drawing_ctx),
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.plan_failed.emit(sr.error or "Cancelled")
+            return
+
+        # Stage 3: Validate
+        validation, sr = self._timed_stage(
+            PipelineStage.VALIDATE,
+            lambda: validate_changeset(changeset, self._context, self._rule_config),  # type: ignore[arg-type]
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.plan_failed.emit(sr.error or "Cancelled")
+            return
+
+        # Stage 4: Preview
+        preview, sr = self._timed_stage(
+            PipelineStage.PREVIEW,
+            lambda: PreviewModel(changeset, self._context, validation),  # type: ignore[arg-type]
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.plan_failed.emit(sr.error or "Cancelled")
+            return
+
+        result = PlanResult(
+            changeset=changeset,
+            validation=validation,
+            preview=preview,
+            stages=stages,
+        )
+        self.plan_succeeded.emit(result)
+
+    # ── Apply pipeline ─────────────────────────────────────────
+
+    def _run_apply(self) -> None:
+        assert self._changeset is not None
+        assert self._dxf_path is not None
+        assert self._rule_config is not None
+        assert self._rev_config is not None
+        stages: list[StageResult] = []
+
+        # Stage 1: Edit engine
+        engine, sr = self._timed_stage(
+            PipelineStage.EDIT_ENGINE,
+            lambda: self._do_apply_engine(),
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.apply_failed.emit(sr.error or "Cancelled")
+            return
+
+        engine_obj, results = engine
+
+        # Stage 2: Save
+        _, sr = self._timed_stage(
+            PipelineStage.SAVE,
+            lambda: engine_obj.save(self._output_path),
+        )
+        stages.append(sr)
+        if not sr.success or self._cancelled:
+            self.apply_failed.emit(sr.error or "Cancelled")
+            return
+
+        # Stage 3: Revision notes
+        note_text = ""
+        if self._rev_config.enabled:
+            note_text, sr = self._timed_stage(
+                PipelineStage.REVISION_NOTES,
+                lambda: insert_revision_note(
+                    self._output_path,
+                    self._output_path,
+                    results,
+                    self._rev_config,  # type: ignore[arg-type]
+                ),
+            )
+            stages.append(sr)
+            if not sr.success:
+                # Non-fatal: revision note failure doesn't block apply
+                logger.warning("Revision note failed: %s", sr.error)
+
+        result = ApplyResult(
+            applied_changes=results,
+            output_path=self._output_path,
+            note_text=note_text,
+            engine_doc=engine_obj.doc,
+            stages=stages,
+        )
+        self.apply_succeeded.emit(result)
+
+    def _do_apply_engine(self):
+        """Create EditEngine and apply changeset. Returns (engine, results)."""
+        engine = EditEngine(self._dxf_path)  # type: ignore[arg-type]
+        results = engine.apply_changeset(self._changeset)  # type: ignore[arg-type]
+        return engine, results
+
+    # ── Timing helper ──────────────────────────────────────────
+
+    def _timed_stage(self, stage: PipelineStage, func):
+        """Run *func*, emit stage signals, and return (result, StageResult)."""
+        self.stage_started.emit(stage.value)
+        t0 = time.monotonic()
+        try:
+            result = func()
+            duration_ms = (time.monotonic() - t0) * 1000
+            sr = StageResult(stage=stage, duration_ms=duration_ms)
+            self.stage_finished.emit(stage.value, duration_ms)
+            return result, sr
+        except Exception as exc:
+            duration_ms = (time.monotonic() - t0) * 1000
+            sr = StageResult(
+                stage=stage,
+                duration_ms=duration_ms,
+                success=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            self.stage_finished.emit(stage.value, duration_ms)
+            return None, sr

--- a/tests/gui/__init__.py
+++ b/tests/gui/__init__.py
@@ -1,0 +1,1 @@
+"""GUI tests — require PySide6 and QT_QPA_PLATFORM=offscreen."""

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -1,0 +1,33 @@
+"""GUI test fixtures — offscreen QApplication."""
+
+from __future__ import annotations
+
+import os
+
+# Must be set before any Qt import
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest  # noqa: E402
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip GUI tests when PySide6 is not installed."""
+    try:
+        import PySide6  # noqa: F401
+    except ImportError:
+        skip = pytest.mark.skip(reason="PySide6 not installed")
+        for item in items:
+            if "gui" in item.keywords:
+                item.add_marker(skip)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Provide a QApplication instance (one per module)."""
+    pytest.importorskip("PySide6")
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app

--- a/tests/gui/test_gui_plan.py
+++ b/tests/gui/test_gui_plan.py
@@ -1,0 +1,76 @@
+"""GUI plan/apply tests — load fixture DXF, run plan via PipelineWorker."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.gui
+class TestGuiPlanWorkflow:
+    """Test plan workflow through PipelineWorker in headless mode."""
+
+    def test_plan_via_worker(self, qapp, sample_dxf, rule_config):
+        """Run plan pipeline via worker and verify result signals."""
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker, PlanResult
+
+        context = load_dxf(sample_dxf)
+        worker = PipelineWorker()
+        worker.setup_plan("Move the column at grid C-4 two feet east", context, rule_config)
+
+        results = []
+        errors = []
+        worker.plan_succeeded.connect(lambda r: results.append(r))
+        worker.plan_failed.connect(lambda e: errors.append(e))
+        worker.start()
+        assert worker.wait(10000), "Worker timed out"
+
+        assert len(errors) == 0, f"Plan failed: {errors}"
+        assert len(results) == 1
+        result = results[0]
+        assert isinstance(result, PlanResult)
+        assert result.changeset.op_count > 0
+        assert len(result.stages) == 4  # build_context, planner, validate, preview
+
+    def test_apply_via_worker(self, qapp, sample_dxf, rule_config, tmp_path):
+        """Run full plan+apply pipeline via workers."""
+        from pathlib import Path
+
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+        from cad_dxf_agent.ui.pipeline_worker import ApplyResult, PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        output_path = str(tmp_path / "output.dxf")
+        rev_config = RevisionNoteConfig(enabled=True, layer_name="AI_REV_NOTES")
+
+        # Plan first
+        plan_worker = PipelineWorker()
+        plan_worker.setup_plan("Move the column at grid C-4 two feet east", context, rule_config)
+        plan_results = []
+        plan_worker.plan_succeeded.connect(lambda r: plan_results.append(r))
+        plan_worker.start()
+        assert plan_worker.wait(10000)
+        assert len(plan_results) == 1
+
+        changeset = plan_results[0].changeset
+
+        # Apply
+        apply_worker = PipelineWorker()
+        apply_worker.setup_apply(changeset, sample_dxf, output_path, rule_config, rev_config)
+        apply_results = []
+        apply_errors = []
+        apply_worker.apply_succeeded.connect(lambda r: apply_results.append(r))
+        apply_worker.apply_failed.connect(lambda e: apply_errors.append(e))
+        apply_worker.start()
+        assert apply_worker.wait(10000)
+
+        assert len(apply_errors) == 0, f"Apply failed: {apply_errors}"
+        assert len(apply_results) == 1
+        result = apply_results[0]
+        assert isinstance(result, ApplyResult)
+        assert result.output_path == output_path
+        assert len(result.stages) >= 2  # edit_engine, save (+ optional revision_notes)
+
+        # Verify output file exists
+        assert Path(output_path).exists()

--- a/tests/gui/test_gui_startup.py
+++ b/tests/gui/test_gui_startup.py
@@ -1,0 +1,46 @@
+"""GUI startup tests — headless MainWindow instantiation."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.gui
+class TestMainWindowStartup:
+    """Verify MainWindow can be created and has correct initial state."""
+
+    def test_window_creates(self, qapp):
+        from cad_dxf_agent.ui.main_window import MainWindow
+
+        win = MainWindow()
+        assert win.windowTitle() == "CAD DXF Agent — Structural Drawing Editor"
+
+    def test_initial_button_states(self, qapp):
+        from cad_dxf_agent.ui.main_window import MainWindow
+
+        win = MainWindow()
+        assert win.btn_plan.isEnabled() is False
+        assert win.btn_apply.isEnabled() is False
+        assert win.btn_undo.isEnabled() is False
+        assert win.btn_redo.isEnabled() is False
+        assert win.btn_timings.isEnabled() is False
+
+    def test_progress_bar_hidden(self, qapp):
+        from cad_dxf_agent.ui.main_window import MainWindow
+
+        win = MainWindow()
+        assert win.progress_bar.isHidden() is True
+        assert win.lbl_stage.isHidden() is True
+
+    def test_status_bar_labels(self, qapp):
+        from cad_dxf_agent.ui.main_window import MainWindow
+
+        win = MainWindow()
+        assert "Entities: -" in win.lbl_entity_count.text()
+        assert "Layers: -" in win.lbl_layer_count.text()
+
+    def test_no_worker_on_init(self, qapp):
+        from cad_dxf_agent.ui.main_window import MainWindow
+
+        win = MainWindow()
+        assert win._worker is None

--- a/tests/integration/test_pipeline_worker.py
+++ b/tests/integration/test_pipeline_worker.py
@@ -1,0 +1,170 @@
+"""Integration tests for PipelineWorker — signal sequence, cancellation, plan+apply."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+try:
+    import PySide6  # noqa: F401
+
+    HAS_PYSIDE6 = True
+except ImportError:
+    HAS_PYSIDE6 = False
+
+pytestmark = pytest.mark.skipif(not HAS_PYSIDE6, reason="PySide6 not installed")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Provide a QApplication instance."""
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.mark.integration
+class TestPipelineWorkerPlan:
+    """Test PipelineWorker plan mode."""
+
+    def test_plan_emits_stage_signals(self, qapp, sample_dxf, rule_config):
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        worker = PipelineWorker()
+        worker.setup_plan("Move column east", context, rule_config)
+
+        started = []
+        finished = []
+        worker.stage_started.connect(lambda s: started.append(s))
+        worker.stage_finished.connect(lambda s, d: finished.append((s, d)))
+        worker.start()
+        assert worker.wait(10000)
+
+        assert len(started) == 4
+        assert len(finished) == 4
+        assert started[0] == "Build Context"
+        assert started[1] == "Run Planner"
+        assert started[2] == "Validate"
+        assert started[3] == "Preview"
+
+        # All durations should be non-negative
+        for _name, dur in finished:
+            assert dur >= 0
+
+    def test_plan_result_has_stages(self, qapp, sample_dxf, rule_config):
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        worker = PipelineWorker()
+        worker.setup_plan("Delete the line", context, rule_config)
+
+        results = []
+        worker.plan_succeeded.connect(lambda r: results.append(r))
+        worker.start()
+        assert worker.wait(10000)
+        assert len(results) == 1
+
+        plan = results[0]
+        assert len(plan.stages) == 4
+        assert all(s.success for s in plan.stages)
+        assert all(s.duration_ms >= 0 for s in plan.stages)
+
+
+@pytest.mark.integration
+class TestPipelineWorkerApply:
+    """Test PipelineWorker apply mode."""
+
+    def test_apply_produces_output_file(self, qapp, sample_dxf, rule_config, tmp_path):
+        from pathlib import Path
+
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        output = str(tmp_path / "result.dxf")
+        rev_config = RevisionNoteConfig(enabled=False)
+
+        # Plan
+        plan_w = PipelineWorker()
+        plan_w.setup_plan("Move column east", context, rule_config)
+        plan_results = []
+        plan_w.plan_succeeded.connect(lambda r: plan_results.append(r))
+        plan_w.start()
+        assert plan_w.wait(10000)
+
+        cs = plan_results[0].changeset
+
+        # Apply
+        apply_w = PipelineWorker()
+        apply_w.setup_apply(cs, sample_dxf, output, rule_config, rev_config)
+        apply_results = []
+        apply_w.apply_succeeded.connect(lambda r: apply_results.append(r))
+        apply_w.start()
+        assert apply_w.wait(10000)
+
+        assert len(apply_results) == 1
+        assert Path(output).exists()
+        assert apply_results[0].engine_doc is not None
+
+    def test_apply_with_revision_notes(self, qapp, sample_dxf, rule_config, tmp_path):
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        output = str(tmp_path / "noted.dxf")
+        rev_config = RevisionNoteConfig(enabled=True, layer_name="AI_REV_NOTES")
+
+        # Plan
+        plan_w = PipelineWorker()
+        plan_w.setup_plan("Move column east", context, rule_config)
+        plan_results = []
+        plan_w.plan_succeeded.connect(lambda r: plan_results.append(r))
+        plan_w.start()
+        assert plan_w.wait(10000)
+
+        cs = plan_results[0].changeset
+
+        # Apply with notes
+        apply_w = PipelineWorker()
+        apply_w.setup_apply(cs, sample_dxf, output, rule_config, rev_config)
+        apply_results = []
+        apply_w.apply_succeeded.connect(lambda r: apply_results.append(r))
+        apply_w.start()
+        assert apply_w.wait(10000)
+
+        assert len(apply_results) == 1
+        # Should have 3 stages: edit_engine, save, revision_notes
+        assert len(apply_results[0].stages) == 3
+        assert apply_results[0].note_text != ""
+
+
+@pytest.mark.integration
+class TestPipelineWorkerCancellation:
+    """Test cancellation between stages."""
+
+    def test_cancel_before_start_is_noop(self, qapp, sample_dxf, rule_config):
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+        context = load_dxf(sample_dxf)
+        worker = PipelineWorker()
+        worker.setup_plan("Move column", context, rule_config)
+        worker.cancel()  # Should not raise
+
+        # Start anyway — cancelled flag is reset in run()
+        results = []
+        worker.plan_succeeded.connect(lambda r: results.append(r))
+        worker.start()
+        assert worker.wait(10000)
+        assert len(results) == 1  # Should succeed since cancel flag is reset


### PR DESCRIPTION
## Summary
- **PipelineWorker QThread** (`pipeline_worker.py`): Runs plan/apply stages off the main thread with stage-level signals, timing, and cancellation support
- **MainWindow rewired**: Replaced blocking pipeline calls with async worker; added progress bar, stage labels, and a Timings dialog with copy-to-clipboard
- **GUI + integration tests**: 12 new tests (7 GUI, 5 integration) that skip gracefully when PySide6 is not installed
- **CI gui-test job**: Dedicated job with PySide6 + headless Qt on Ubuntu

## Test plan
- [x] All 296 existing unit tests pass (no pipeline module changes)
- [x] All 35 existing integration/smoke tests pass
- [x] New GUI tests (7) skip correctly without PySide6
- [x] New integration tests (5) skip correctly without PySide6
- [x] Lint clean (`ruff check src/ tests/`)
- [x] Format clean (`ruff format --check src/ tests/`)
- [x] Type check clean (`mypy src/`)
- [ ] CI gui-test job runs with PySide6 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added non-blocking operations for plan and apply workflows—UI remains responsive during processing.
  * Added progress bar and stage indicator to display current operation progress in real-time.
  * Added "Timings" button in the toolbar to view performance metrics for each operation stage.

* **Tests**
  * Added comprehensive GUI test suite for application startup and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->