### PR TITLE
feat: Phase 02 — planner hardening, drawing stats, deterministic planner

### DIFF
--- a/src/cad_dxf_agent/core/context_builder.py
+++ b/src/cad_dxf_agent/core/context_builder.py
@@ -11,9 +11,11 @@ for prompt construction without sending the entire entity list.
 from __future__ import annotations
 
 from collections import Counter
+from pathlib import Path
 from typing import Any
 
-from ..models.cad_schema import DrawingContext, EntityRef, EntityType
+from ..models.cad_schema import DrawingContext, EntityRef, EntityType, Point2D
+from ..models.stats_schema import DrawingStats
 from .entity_index import EntityIndex
 
 
@@ -126,6 +128,117 @@ def token_economy_summary(context: DrawingContext) -> dict[str, Any]:
         "top_text_labels": text_labels[:10],
         "protected_layers": context.get_protected_layers(),
     }
+
+
+def drawing_stats(
+    context: DrawingContext,
+    *,
+    protected_layers: list[str] | None = None,
+) -> DrawingStats:
+    """Compute drawing statistics from a DrawingContext.
+
+    Args:
+        context: Loaded drawing context.
+        protected_layers: Override protected layer names (defaults to context layers).
+    """
+    summary = token_economy_summary(context)
+
+    # Protected layers from context
+    if protected_layers is None:
+        protected_layers = context.get_protected_layers()
+    protected_upper = {p.upper() for p in protected_layers}
+
+    editable_count = sum(1 for e in context.entities if e.layer.upper() not in protected_upper)
+
+    # Bounding box from entities with insert points
+    bbox = _compute_bounding_box(context.entities)
+
+    # Coverage: supported entities / (supported + unsupported types seen)
+    total_types_seen = len(summary["counts_by_type"]) + len(context.unsupported_entity_types)
+    coverage = (
+        len(summary["counts_by_type"]) / total_types_seen * 100 if total_types_seen > 0 else 100.0
+    )
+
+    # File size
+    file_path = Path(context.file_path)
+    file_size = file_path.stat().st_size if file_path.exists() else 0
+
+    return DrawingStats(
+        file_name=file_path.name,
+        file_size_bytes=file_size,
+        dxf_version=context.metadata.get("dxf_version", "unknown"),
+        entity_count=context.entity_count,
+        editable_entity_count=editable_count,
+        layer_count=summary["layer_count"],
+        layout_count=len(context.layouts),
+        block_count=summary["block_count"],
+        counts_by_type=summary["counts_by_type"],
+        counts_by_layer=summary["counts_by_layer"],
+        protected_layers=list(protected_layers),
+        unsupported_types=context.unsupported_entity_types,
+        coverage_pct=round(coverage, 1),
+        load_warnings=context.load_warnings,
+        bounding_box=bbox,
+    )
+
+
+def support_report(stats: DrawingStats) -> str:
+    """Format drawing stats as a copyable text block for support tickets."""
+    lines = [
+        "Drawing Support Report",
+        "=" * 40,
+        f"File: {stats.file_name}",
+        f"Size: {stats.file_size_bytes:,} bytes",
+        f"DXF Version: {stats.dxf_version}",
+        "",
+        f"Entities: {stats.editable_entity_count} editable / {stats.entity_count} total",
+        f"Layers: {stats.layer_count}",
+        f"Layouts: {stats.layout_count}",
+        f"Blocks: {stats.block_count}",
+        f"Type Coverage: {stats.coverage_pct}%",
+        "",
+        "Entity Types:",
+    ]
+    for etype, count in sorted(stats.counts_by_type.items()):
+        lines.append(f"  {etype}: {count}")
+
+    lines.append("")
+    lines.append("Layers:")
+    for layer, count in sorted(stats.counts_by_layer.items()):
+        is_prot = layer.upper() in {p.upper() for p in stats.protected_layers}
+        prot = " (PROTECTED)" if is_prot else ""
+        lines.append(f"  {layer}: {count}{prot}")
+
+    if stats.unsupported_types:
+        lines.append("")
+        lines.append(f"Unsupported Types: {', '.join(stats.unsupported_types)}")
+
+    if stats.load_warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for w in stats.load_warnings:
+            lines.append(f"  [{w.severity.upper()}] {w.message}")
+
+    if stats.bounding_box:
+        mn, mx = stats.bounding_box
+        lines.append("")
+        lines.append(f"Bounding Box: ({mn.x:.1f}, {mn.y:.1f}) to ({mx.x:.1f}, {mx.y:.1f})")
+
+    return "\n".join(lines)
+
+
+def _compute_bounding_box(
+    entities: list[EntityRef],
+) -> tuple[Point2D, Point2D] | None:
+    """Compute axis-aligned bounding box from entity insert points."""
+    points = [e.insert_point for e in entities if e.insert_point is not None]
+    if not points:
+        return None
+    min_x = min(p.x for p in points)
+    min_y = min(p.y for p in points)
+    max_x = max(p.x for p in points)
+    max_y = max(p.y for p in points)
+    return Point2D(x=min_x, y=min_y), Point2D(x=max_x, y=max_y)
 
 
 # --- Internal helpers ---

--- a/src/cad_dxf_agent/core/dxf_reader.py
+++ b/src/cad_dxf_agent/core/dxf_reader.py
@@ -14,6 +14,7 @@ from ..models.cad_schema import (
     EntityType,
     LayerRule,
     LayoutInfo,
+    LoadWarning,
     Point2D,
 )
 from ..otel import get_tracer
@@ -87,6 +88,11 @@ def load_dxf(file_path: str | Path) -> DrawingContext:
                 ", ".join(sorted(unsupported)),
             )
 
+        # Generate load-time warnings
+        warnings = _generate_load_warnings(
+            entities, layers, sorted(unsupported), settings.protected_layers
+        )
+
         ctx = DrawingContext(
             file_path=str(file_path),
             entities=entities,
@@ -94,6 +100,7 @@ def load_dxf(file_path: str | Path) -> DrawingContext:
             blocks=blocks,
             layouts=layout_infos,
             unsupported_entity_types=sorted(unsupported),
+            load_warnings=warnings,
             metadata={
                 "dxf_version": doc.dxfversion,
                 "encoding": doc.encoding,
@@ -243,6 +250,66 @@ def _parse_entity(
         block_name=block_name,
         attributes=attributes,
     )
+
+
+def _generate_load_warnings(
+    entities: list[EntityRef],
+    layers: list[LayerRule],
+    unsupported_types: list[str],
+    protected_layer_names: list[str],
+) -> list[LoadWarning]:
+    """Generate actionable warnings based on loading results."""
+    warnings: list[LoadWarning] = []
+
+    # EMPTY_DRAWING: no supported entities at all
+    if not entities:
+        warnings.append(
+            LoadWarning(
+                code="EMPTY_DRAWING",
+                message="Drawing has 0 supported entities.",
+                severity="error",
+            )
+        )
+        return warnings  # No point checking further
+
+    # UNSUPPORTED_TYPES: some entity types were skipped
+    if unsupported_types:
+        warnings.append(
+            LoadWarning(
+                code="UNSUPPORTED_TYPES",
+                message=(
+                    f"{len(unsupported_types)} entity type(s) skipped: "
+                    f"{', '.join(unsupported_types)}. These cannot be edited."
+                ),
+                severity="info",
+                details={"types": unsupported_types},
+            )
+        )
+
+    # ALL_PROTECTED: every entity is on a protected layer
+    protected_upper = {p.upper() for p in protected_layer_names}
+    editable = [e for e in entities if e.layer.upper() not in protected_upper]
+    if not editable:
+        warnings.append(
+            LoadWarning(
+                code="ALL_PROTECTED",
+                message="All entities are on protected layers. No editable entities.",
+                severity="warning",
+            )
+        )
+
+    # LARGE_DRAWING: many entities may cause large LLM context
+    if len(entities) >= 500:
+        warnings.append(
+            LoadWarning(
+                code="LARGE_DRAWING",
+                message=f"Drawing has {len(entities)} entities. LLM context may be large.",
+                severity="info",
+                details={"entity_count": len(entities)},
+            )
+        )
+
+    return warnings
 
 
 def _build_layer_rules(doc: ezdxf.document.Drawing) -> list[LayerRule]:

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -77,6 +77,9 @@ class AgentProvider(PlannerProvider):
             model = self._get_model()
             chat = model.start_chat()
 
+            # Per-turn timeout: total timeout / max turns
+            per_turn_timeout = max(settings.planner_timeout // MAX_AGENT_TURNS, 5)
+
             # Send initial message
             response = chat.send_message(initial_prompt)
             turns = 0
@@ -84,6 +87,13 @@ class AgentProvider(PlannerProvider):
             while turns < MAX_AGENT_TURNS:
                 # Check if Gemini wants to call tools
                 function_calls = _extract_function_calls(response)
+                text_parts = _extract_text(response)
+
+                # Fail-fast: no tool calls AND no text → abort
+                if not function_calls and not text_parts:
+                    logger.warning("Agent returned empty response on turn %d, aborting", turns)
+                    break
+
                 if not function_calls:
                     # No more tool calls — agent is done
                     break
@@ -117,8 +127,21 @@ class AgentProvider(PlannerProvider):
                         }
                     )
 
-                # Send results back to Gemini
-                response = self._send_tool_results(chat, tool_results)
+                # Send results back to Gemini with per-turn timeout
+                from concurrent.futures import ThreadPoolExecutor
+                from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+                from .errors import PlannerTimeoutError
+
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(self._send_tool_results, chat, tool_results)
+                    try:
+                        response = future.result(timeout=per_turn_timeout)
+                    except FuturesTimeoutError as exc:
+                        raise PlannerTimeoutError(
+                            per_turn_timeout,
+                            f"Agent turn {turns} timed out after {per_turn_timeout}s",
+                        ) from exc
 
             span.set_attribute("cad.agent.turns", turns)
             span.set_attribute("cad.agent.ops_count", len(executor.operations))
@@ -137,12 +160,13 @@ class AgentProvider(PlannerProvider):
             )
 
     def _get_model(self):
-        """Lazy-initialize the Gemini model with tool declarations."""
+        """Lazy-initialize the Gemini model with tool declarations and GenerationConfig."""
         if self._model is None:
             try:
                 import vertexai
                 from vertexai.generative_models import (
                     FunctionDeclaration,
+                    GenerationConfig,
                     GenerativeModel,
                     Tool,
                 )
@@ -164,10 +188,18 @@ class AgentProvider(PlannerProvider):
                     )
                 tools = [Tool(function_declarations=declarations)]
 
+                gen_config = GenerationConfig(
+                    temperature=settings.llm_temperature,
+                    top_p=settings.llm_top_p,
+                    top_k=settings.llm_top_k,
+                    max_output_tokens=settings.llm_max_output_tokens,
+                )
+
                 self._model = GenerativeModel(
                     self._model_name,
                     system_instruction=AGENT_SYSTEM_PROMPT,
                     tools=tools,
+                    generation_config=gen_config,
                 )
             except ImportError as err:
                 raise ImportError(
@@ -467,3 +499,16 @@ def _extract_function_calls(response) -> list[dict[str, Any]]:
     except (AttributeError, TypeError):
         pass
     return calls
+
+
+def _extract_text(response) -> list[str]:
+    """Extract text parts from a Gemini response (for fail-fast detection)."""
+    texts = []
+    try:
+        for candidate in response.candidates:
+            for part in candidate.content.parts:
+                if hasattr(part, "text") and part.text:
+                    texts.append(part.text)
+    except (AttributeError, TypeError):
+        pass
+    return texts

--- a/src/cad_dxf_agent/llm/deterministic_planner.py
+++ b/src/cad_dxf_agent/llm/deterministic_planner.py
@@ -1,0 +1,100 @@
+"""Deterministic planner — handles obvious operations without calling LLM.
+
+Pattern-matches simple, unambiguous prompts like:
+  - "delete entity {handle}"
+  - "move {handle} by (dx, dy)"
+  - "change text of {handle} to '{new_text}'"
+
+Returns None when the prompt doesn't match any pattern (fall through to LLM).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from ..models.ops_schema import ChangeSet, EditOperation, OpType
+
+logger = logging.getLogger(__name__)
+
+# Patterns for deterministic operations
+_DELETE_PATTERN = re.compile(
+    r"delete\s+entity\s+([A-Fa-f0-9]+)",
+    re.IGNORECASE,
+)
+_MOVE_PATTERN = re.compile(
+    r"move\s+([A-Fa-f0-9]+)\s+by\s*\(\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\)",
+    re.IGNORECASE,
+)
+_EDIT_TEXT_PATTERN = re.compile(
+    r"change\s+text\s+of\s+([A-Fa-f0-9]+)\s+to\s+['\"](.+?)['\"]",
+    re.IGNORECASE,
+)
+
+
+def deterministic_plan(prompt: str, drawing_context: dict) -> ChangeSet | None:
+    """Try to produce a ChangeSet without calling the LLM.
+
+    Returns a ChangeSet for obvious operations, or None if the prompt
+    doesn't match any deterministic pattern.
+    """
+    # Collect known handles from the drawing context
+    known_handles = {e["handle"] for e in drawing_context.get("entities", []) if "handle" in e}
+
+    # Try delete pattern
+    m = _DELETE_PATTERN.search(prompt)
+    if m:
+        handle = m.group(1).upper()
+        if handle in known_handles:
+            logger.info("Deterministic delete: handle=%s", handle)
+            return ChangeSet(
+                prompt=prompt,
+                operations=[
+                    EditOperation(
+                        op_type=OpType.DELETE_ENTITY,
+                        target_handle=handle,
+                    )
+                ],
+                revision_label=f"Deterministic delete: {handle}",
+            )
+
+    # Try move pattern
+    m = _MOVE_PATTERN.search(prompt)
+    if m:
+        handle = m.group(1).upper()
+        dx = float(m.group(2))
+        dy = float(m.group(3))
+        if handle in known_handles:
+            logger.info("Deterministic move: handle=%s dx=%.1f dy=%.1f", handle, dx, dy)
+            return ChangeSet(
+                prompt=prompt,
+                operations=[
+                    EditOperation(
+                        op_type=OpType.MOVE_ENTITY,
+                        target_handle=handle,
+                        params={"dx": dx, "dy": dy},
+                    )
+                ],
+                revision_label=f"Deterministic move: {handle}",
+            )
+
+    # Try edit text pattern
+    m = _EDIT_TEXT_PATTERN.search(prompt)
+    if m:
+        handle = m.group(1).upper()
+        new_text = m.group(2)
+        if handle in known_handles:
+            logger.info("Deterministic edit_text: handle=%s", handle)
+            return ChangeSet(
+                prompt=prompt,
+                operations=[
+                    EditOperation(
+                        op_type=OpType.EDIT_TEXT,
+                        target_handle=handle,
+                        params={"new_text": new_text},
+                    )
+                ],
+                revision_label=f"Deterministic edit_text: {handle}",
+            )
+
+    return None

--- a/src/cad_dxf_agent/llm/errors.py
+++ b/src/cad_dxf_agent/llm/errors.py
@@ -1,0 +1,23 @@
+"""Planner error types for timeout and retry exhaustion."""
+
+from __future__ import annotations
+
+
+class PlannerTimeoutError(Exception):
+    """Raised when the planner exceeds its wall-clock timeout."""
+
+    def __init__(self, timeout_seconds: int, message: str | None = None) -> None:
+        self.timeout_seconds = timeout_seconds
+        super().__init__(message or f"Planner timed out after {timeout_seconds}s")
+
+
+class PlannerRetryExhaustedError(Exception):
+    """Raised when all planner retry attempts have failed."""
+
+    def __init__(self, attempts: int, last_error: Exception | None = None) -> None:
+        self.attempts = attempts
+        self.last_error = last_error
+        msg = f"Planner failed after {attempts} attempt(s)"
+        if last_error:
+            msg += f": {last_error}"
+        super().__init__(msg)

--- a/src/cad_dxf_agent/llm/gemini_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_provider.py
@@ -109,11 +109,12 @@ class GeminiProvider(PlannerProvider):
                 return changeset
 
     def _get_model(self):
-        """Lazy-initialize the Gemini model."""
+        """Lazy-initialize the Gemini model with GenerationConfig."""
         if self._model is None:
             try:
                 import vertexai  # type: ignore[import-untyped]
                 from vertexai.generative_models import (
+                    GenerationConfig,  # type: ignore[import-untyped]
                     GenerativeModel,  # type: ignore[import-untyped]
                 )
 
@@ -121,9 +122,18 @@ class GeminiProvider(PlannerProvider):
                     project=self._project,
                     location=self._location,
                 )
+
+                gen_config = GenerationConfig(
+                    temperature=settings.llm_temperature,
+                    top_p=settings.llm_top_p,
+                    top_k=settings.llm_top_k,
+                    max_output_tokens=settings.llm_max_output_tokens,
+                )
+
                 self._model = GenerativeModel(
                     self._model_name,
                     system_instruction=SYSTEM_PROMPT,
+                    generation_config=gen_config,
                 )
             except ImportError as err:
                 raise ImportError(

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 
 from ..models.ops_schema import ChangeSet
 from ..otel import get_tracer
 from ..settings import settings
+from .errors import PlannerRetryExhaustedError, PlannerTimeoutError
 from .mock_provider import MockProvider
 from .providers import PlannerProvider
 
@@ -70,12 +74,30 @@ def get_provider(provider_name: str | None = None) -> PlannerProvider:
     return MockProvider()
 
 
+def _call_with_timeout(
+    provider: PlannerProvider,
+    prompt: str,
+    drawing_context: dict,
+    timeout: int,
+) -> ChangeSet:
+    """Call provider.plan() with a wall-clock timeout."""
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(provider.plan, prompt, drawing_context)
+        try:
+            return future.result(timeout=timeout)
+        except FuturesTimeoutError as exc:
+            raise PlannerTimeoutError(timeout) from exc
+
+
 def run_planner(
     prompt: str,
     drawing_context: dict,
     provider: PlannerProvider | None = None,
 ) -> ChangeSet:
     """Run the planner to generate a changeset from a user prompt.
+
+    Tries deterministic planning first for obvious operations.
+    Falls back to the LLM provider with timeout and retry logic.
 
     Args:
         prompt: Natural-language edit request from the user.
@@ -84,20 +106,57 @@ def run_planner(
 
     Returns:
         Validated ChangeSet with structured operations.
+
+    Raises:
+        PlannerTimeoutError: If the planner exceeds wall-clock timeout.
+        PlannerRetryExhaustedError: If all retry attempts fail.
     """
     with tracer.start_as_current_span("cad.run_planner") as span:
         if provider is None:
             provider = get_provider()
 
+        # Try deterministic planner first (no LLM call needed)
+        from .deterministic_planner import deterministic_plan
+
+        det_result = deterministic_plan(prompt, drawing_context)
+        if det_result is not None:
+            span.set_attribute("cad.mode", "deterministic")
+            span.set_attribute("cad.ops.count", det_result.op_count)
+            logger.info(
+                "Deterministic plan used (%d ops) for prompt: %s",
+                det_result.op_count,
+                prompt[:80],
+            )
+            return det_result
+
         span.set_attribute("cad.mode", provider.name)
         logger.info("Running planner [%s] for prompt: %s", provider.name, prompt[:80])
 
-        changeset = provider.plan(prompt, drawing_context)
+        timeout = settings.planner_timeout
+        max_retries = settings.planner_max_retries
+        retry_delay = settings.planner_retry_delay
+        last_error: Exception | None = None
 
-        span.set_attribute("cad.ops.count", changeset.op_count)
-        logger.info(
-            "Planner returned %d operation(s) for prompt: %s",
-            changeset.op_count,
-            prompt[:80],
-        )
-        return changeset
+        for attempt in range(1, max_retries + 1):
+            try:
+                changeset = _call_with_timeout(provider, prompt, drawing_context, timeout)
+                span.set_attribute("cad.ops.count", changeset.op_count)
+                span.set_attribute("cad.planner.attempt", attempt)
+                logger.info(
+                    "Planner returned %d operation(s) on attempt %d for prompt: %s",
+                    changeset.op_count,
+                    attempt,
+                    prompt[:80],
+                )
+                return changeset
+            except PlannerTimeoutError:
+                raise  # Timeout is not retryable
+            except Exception as exc:
+                last_error = exc
+                logger.warning("Planner attempt %d/%d failed: %s", attempt, max_retries, exc)
+                if attempt < max_retries:
+                    delay = retry_delay * (2 ** (attempt - 1))
+                    logger.info("Retrying in %.1fs...", delay)
+                    time.sleep(delay)
+
+        raise PlannerRetryExhaustedError(max_retries, last_error)

--- a/src/cad_dxf_agent/models/cad_schema.py
+++ b/src/cad_dxf_agent/models/cad_schema.py
@@ -66,6 +66,15 @@ class LayoutInfo(BaseModel):
     entity_count: int = 0
 
 
+class LoadWarning(BaseModel):
+    """Warning generated during DXF loading."""
+
+    code: str
+    message: str
+    severity: str = "info"  # "info" | "warning" | "error"
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
 class DrawingContext(BaseModel):
     """Normalized context model for a loaded DXF drawing."""
 
@@ -75,6 +84,7 @@ class DrawingContext(BaseModel):
     blocks: list[str] = Field(default_factory=list)
     layouts: list[LayoutInfo] = Field(default_factory=list)
     unsupported_entity_types: list[str] = Field(default_factory=list)
+    load_warnings: list[LoadWarning] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @property

--- a/src/cad_dxf_agent/models/stats_schema.py
+++ b/src/cad_dxf_agent/models/stats_schema.py
@@ -1,0 +1,27 @@
+"""Drawing statistics schema for UI display and support reports."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .cad_schema import LoadWarning, Point2D
+
+
+class DrawingStats(BaseModel):
+    """Computed statistics for a loaded DXF drawing."""
+
+    file_name: str
+    file_size_bytes: int
+    dxf_version: str
+    entity_count: int
+    editable_entity_count: int
+    layer_count: int
+    layout_count: int
+    block_count: int
+    counts_by_type: dict[str, int] = Field(default_factory=dict)
+    counts_by_layer: dict[str, int] = Field(default_factory=dict)
+    protected_layers: list[str] = Field(default_factory=list)
+    unsupported_types: list[str] = Field(default_factory=list)
+    coverage_pct: float = 0.0
+    load_warnings: list[LoadWarning] = Field(default_factory=list)
+    bounding_box: tuple[Point2D, Point2D] | None = None

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -48,6 +48,17 @@ class Settings:
         self.render_dpi: int = int(os.getenv("CAD_RENDER_DPI", "150"))
         self.render_background: str = os.getenv("CAD_RENDER_BACKGROUND", "white")
 
+        # Planner timeout / retry
+        self.planner_timeout: int = int(os.getenv("CAD_PLANNER_TIMEOUT", "60"))
+        self.planner_max_retries: int = int(os.getenv("CAD_PLANNER_MAX_RETRIES", "2"))
+        self.planner_retry_delay: float = float(os.getenv("CAD_PLANNER_RETRY_DELAY", "1.0"))
+
+        # LLM generation parameters
+        self.llm_temperature: float = float(os.getenv("CAD_LLM_TEMPERATURE", "0.0"))
+        self.llm_top_p: float | None = float(v) if (v := os.getenv("CAD_LLM_TOP_P")) else None
+        self.llm_top_k: int | None = int(v) if (v := os.getenv("CAD_LLM_TOP_K")) else None
+        self.llm_max_output_tokens: int = int(os.getenv("CAD_LLM_MAX_OUTPUT_TOKENS", "4096"))
+
         # Gemini / Vertex AI (V2)
         self.gcp_project: str | None = os.getenv("CAD_GCP_PROJECT")
         self.gcp_location: str = os.getenv("CAD_GCP_LOCATION", "us-central1")

--- a/src/cad_dxf_agent/ui/main_window.py
+++ b/src/cad_dxf_agent/ui/main_window.py
@@ -163,6 +163,11 @@ class MainWindow(QMainWindow):
         self.btn_timings.clicked.connect(self._on_show_timings)
         toolbar.addWidget(self.btn_timings)
 
+        self.btn_stats = QPushButton("Stats")
+        self.btn_stats.setEnabled(False)
+        self.btn_stats.clicked.connect(self._on_show_stats)
+        toolbar.addWidget(self.btn_stats)
+
     # ── Main UI ───────────────────────────────────────────────────
 
     def _build_ui(self):
@@ -185,6 +190,13 @@ class MainWindow(QMainWindow):
         self.lbl_file = QLabel("No file loaded")
         file_row.addWidget(self.lbl_file, 1)
         left.addLayout(file_row)
+
+        # Load warnings (hidden by default)
+        self.txt_warnings = QTextEdit()
+        self.txt_warnings.setReadOnly(True)
+        self.txt_warnings.setMaximumHeight(80)
+        self.txt_warnings.hide()
+        left.addWidget(self.txt_warnings)
 
         # Layout selector
         layout_row = QHBoxLayout()
@@ -306,6 +318,31 @@ class MainWindow(QMainWindow):
         for cb in self._op_checkboxes:
             cb.setChecked(False)
 
+    def _show_load_warnings(self, warnings: list):
+        """Display load warnings in the warnings panel."""
+        if not warnings:
+            self.txt_warnings.hide()
+            return
+
+        color_map = {"info": "#2196F3", "warning": "#FF9800", "error": "#F44336"}
+        html_parts = []
+        has_error = False
+        for w in warnings:
+            color = color_map.get(w.severity, "#666")
+            label = w.severity.upper()
+            html_parts.append(
+                f'<span style="color:{color};font-weight:bold;">[{label}]</span> {w.message}'
+            )
+            if w.severity == "error":
+                has_error = True
+
+        self.txt_warnings.setHtml("<br>".join(html_parts))
+        self.txt_warnings.show()
+
+        # Error-level warnings disable the Plan button
+        if has_error:
+            self.btn_plan.setEnabled(False)
+
     # ── Event handlers ────────────────────────────────────────────
 
     def _on_open(self):
@@ -360,6 +397,7 @@ class MainWindow(QMainWindow):
             self.lbl_file.setText(f"{self._dxf_path.name} ({self._context.entity_count} entities)")
             self.btn_plan.setEnabled(True)
             self.btn_apply.setEnabled(False)
+            self.btn_stats.setEnabled(True)
             self._changeset = None
             self._preview = None
             self._clear_ops()
@@ -371,9 +409,20 @@ class MainWindow(QMainWindow):
                 self.cmb_layout.addItem(f"{layout.name} ({layout.entity_count})")
             self.cmb_layout.setEnabled(len(self._context.layouts) > 1)
 
-            # Update status bar
-            self.lbl_entity_count.setText(f"Entities: {self._context.entity_count}")
-            self.lbl_layer_count.setText(f"Layers: {len(self._context.layers)}")
+            # Update status bar with editable/total counts
+            protected_upper = {p.upper() for p in settings.protected_layers}
+            editable_count = sum(
+                1 for e in self._context.entities if e.layer.upper() not in protected_upper
+            )
+            total_layers = len(self._context.layers)
+            protected_count = sum(1 for lyr in self._context.layers if lyr.protected)
+            self.lbl_entity_count.setText(
+                f"Entities: {editable_count}/{self._context.entity_count}"
+            )
+            self.lbl_layer_count.setText(f"Layers: {total_layers - protected_count}/{total_layers}")
+
+            # Display load warnings
+            self._show_load_warnings(self._context.load_warnings)
 
             self._log_status(f"Loaded: {self._dxf_path.name}")
             if self._context.unsupported_entity_types:
@@ -585,6 +634,35 @@ class MainWindow(QMainWindow):
         btn_box = QDialogButtonBox()
         btn_copy = btn_box.addButton("Copy to Clipboard", QDialogButtonBox.ButtonRole.ActionRole)
         btn_copy.clicked.connect(lambda: QApplication.clipboard().setText(text))
+        btn_close = btn_box.addButton(QDialogButtonBox.StandardButton.Close)
+        btn_close.clicked.connect(dlg.close)
+        layout.addWidget(btn_box)
+
+        dlg.exec()
+
+    # ── Stats dialog ─────────────────────────────────────────
+
+    def _on_show_stats(self):
+        if not self._context:
+            return
+
+        from ..core.context_builder import drawing_stats, support_report
+
+        stats = drawing_stats(self._context, protected_layers=settings.protected_layers)
+        report_text = support_report(stats)
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Drawing Statistics")
+        dlg.setMinimumSize(500, 400)
+        layout = QVBoxLayout(dlg)
+
+        txt = QPlainTextEdit(report_text)
+        txt.setReadOnly(True)
+        layout.addWidget(txt)
+
+        btn_box = QDialogButtonBox()
+        btn_copy = btn_box.addButton("Copy Report", QDialogButtonBox.ButtonRole.ActionRole)
+        btn_copy.clicked.connect(lambda: QApplication.clipboard().setText(report_text))
         btn_close = btn_box.addButton(QDialogButtonBox.StandardButton.Close)
         btn_close.clicked.connect(dlg.close)
         layout.addWidget(btn_box)

--- a/tests/unit/test_deterministic_planner.py
+++ b/tests/unit/test_deterministic_planner.py
@@ -1,0 +1,104 @@
+"""Tests for the deterministic planner pattern matching."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.llm.deterministic_planner import deterministic_plan
+from cad_dxf_agent.models.ops_schema import OpType
+
+# Shared drawing context with known handles
+SAMPLE_CONTEXT = {
+    "entities": [
+        {"handle": "A1", "type": "LINE", "layer": "STRUCTURAL"},
+        {"handle": "B2", "type": "TEXT", "layer": "NOTES", "text": "Grid A"},
+        {"handle": "C3", "type": "INSERT", "layer": "STRUCTURAL", "block_name": "COLUMN"},
+    ],
+    "layers": [
+        {"name": "STRUCTURAL", "protected": False},
+        {"name": "NOTES", "protected": False},
+    ],
+    "blocks": ["COLUMN"],
+}
+
+
+class TestDeterministicDelete:
+    def test_delete_by_handle(self):
+        result = deterministic_plan("delete entity A1", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.op_count == 1
+        assert result.operations[0].op_type == OpType.DELETE_ENTITY
+        assert result.operations[0].target_handle == "A1"
+
+    def test_delete_case_insensitive(self):
+        result = deterministic_plan("Delete Entity a1", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.operations[0].target_handle == "A1"
+
+    def test_delete_unknown_handle_returns_none(self):
+        result = deterministic_plan("delete entity ZZ99", SAMPLE_CONTEXT)
+        assert result is None
+
+
+class TestDeterministicMove:
+    def test_move_by_offset(self):
+        result = deterministic_plan("move A1 by (10.5, -3.0)", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.op_count == 1
+        op = result.operations[0]
+        assert op.op_type == OpType.MOVE_ENTITY
+        assert op.target_handle == "A1"
+        assert op.params["dx"] == 10.5
+        assert op.params["dy"] == -3.0
+
+    def test_move_integer_offsets(self):
+        result = deterministic_plan("move B2 by (24, 0)", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.operations[0].params["dx"] == 24.0
+        assert result.operations[0].params["dy"] == 0.0
+
+    def test_move_unknown_handle_returns_none(self):
+        result = deterministic_plan("move ZZ by (1, 1)", SAMPLE_CONTEXT)
+        assert result is None
+
+
+class TestDeterministicEditText:
+    def test_edit_text_single_quotes(self):
+        result = deterministic_plan("change text of B2 to 'New Label'", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.op_count == 1
+        op = result.operations[0]
+        assert op.op_type == OpType.EDIT_TEXT
+        assert op.target_handle == "B2"
+        assert op.params["new_text"] == "New Label"
+
+    def test_edit_text_double_quotes(self):
+        result = deterministic_plan('change text of B2 to "Updated"', SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.operations[0].params["new_text"] == "Updated"
+
+    def test_edit_text_unknown_handle_returns_none(self):
+        result = deterministic_plan("change text of ZZ to 'test'", SAMPLE_CONTEXT)
+        assert result is None
+
+
+class TestDeterministicFallback:
+    def test_natural_language_returns_none(self):
+        result = deterministic_plan("move the footing near grid C-4 two feet east", SAMPLE_CONTEXT)
+        assert result is None
+
+    def test_empty_prompt_returns_none(self):
+        result = deterministic_plan("", SAMPLE_CONTEXT)
+        assert result is None
+
+    def test_complex_prompt_returns_none(self):
+        result = deterministic_plan("delete all lines on the STRUCTURAL layer", SAMPLE_CONTEXT)
+        assert result is None
+
+    def test_empty_context_returns_none(self):
+        result = deterministic_plan("delete entity A1", {"entities": []})
+        assert result is None
+
+    def test_revision_label_set(self):
+        result = deterministic_plan("delete entity A1", SAMPLE_CONTEXT)
+        assert result is not None
+        assert result.revision_label is not None
+        assert "Deterministic" in result.revision_label

--- a/tests/unit/test_drawing_stats.py
+++ b/tests/unit/test_drawing_stats.py
@@ -1,0 +1,87 @@
+"""Tests for drawing statistics computation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cad_dxf_agent.core.context_builder import drawing_stats
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.models.stats_schema import DrawingStats
+from tests.helpers.dxf_factory import (
+    create_empty_dxf,
+    create_minimal_dxf,
+    create_structural_drawing,
+)
+
+
+class TestDrawingStats:
+    def test_stats_from_structural_drawing(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert isinstance(stats, DrawingStats)
+        assert stats.file_name == "structural.dxf"
+        assert stats.file_size_bytes > 0
+        assert stats.dxf_version == "AC1032"  # R2018
+        assert stats.entity_count > 0
+        assert stats.editable_entity_count > 0
+        assert stats.editable_entity_count <= stats.entity_count
+        assert stats.layer_count > 0
+        assert stats.layout_count >= 1  # At least Model
+        assert stats.block_count >= 1  # COLUMN_MARK
+        assert len(stats.counts_by_type) > 0
+        assert len(stats.counts_by_layer) > 0
+        assert stats.coverage_pct > 0
+
+    def test_stats_protected_layers(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx, protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"])
+
+        assert "TITLE" in stats.protected_layers
+        assert stats.editable_entity_count < stats.entity_count
+
+    def test_stats_from_minimal_drawing(self, tmp_path: Path):
+        dxf_path = create_minimal_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert stats.entity_count == 1
+        assert stats.editable_entity_count == 1
+        assert stats.counts_by_type.get("LINE") == 1
+
+    def test_stats_from_empty_drawing(self, tmp_path: Path):
+        dxf_path = create_empty_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert stats.entity_count == 0
+        assert stats.editable_entity_count == 0
+        assert stats.coverage_pct == 100.0  # No types at all → 100%
+
+    def test_bounding_box_computed(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert stats.bounding_box is not None
+        mn, mx = stats.bounding_box
+        assert mn.x <= mx.x
+        assert mn.y <= mx.y
+
+    def test_bounding_box_none_for_empty(self, tmp_path: Path):
+        dxf_path = create_empty_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert stats.bounding_box is None
+
+    def test_load_warnings_propagated(self, tmp_path: Path):
+        dxf_path = create_empty_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+
+        assert len(stats.load_warnings) > 0
+        codes = [w.code for w in stats.load_warnings]
+        assert "EMPTY_DRAWING" in codes

--- a/tests/unit/test_generation_config.py
+++ b/tests/unit/test_generation_config.py
@@ -1,0 +1,99 @@
+"""Tests for LLM generation config settings flow."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+class TestGenerationConfigSettings:
+    """Verify generation config settings parse correctly from env vars."""
+
+    def test_default_temperature(self):
+        with patch.dict(os.environ, {}, clear=False):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_temperature == 0.0
+
+    def test_custom_temperature(self):
+        with patch.dict(os.environ, {"CAD_LLM_TEMPERATURE": "0.7"}):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_temperature == 0.7
+
+    def test_default_top_p_is_none(self):
+        with patch.dict(os.environ, {}, clear=False):
+            # Ensure CAD_LLM_TOP_P is not set
+            env = {k: v for k, v in os.environ.items() if k != "CAD_LLM_TOP_P"}
+            with patch.dict(os.environ, env, clear=True):
+                from cad_dxf_agent.settings import Settings
+
+                s = Settings()
+                assert s.llm_top_p is None
+
+    def test_custom_top_p(self):
+        with patch.dict(os.environ, {"CAD_LLM_TOP_P": "0.95"}):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_top_p == 0.95
+
+    def test_default_top_k_is_none(self):
+        env = {k: v for k, v in os.environ.items() if k != "CAD_LLM_TOP_K"}
+        with patch.dict(os.environ, env, clear=True):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_top_k is None
+
+    def test_custom_top_k(self):
+        with patch.dict(os.environ, {"CAD_LLM_TOP_K": "40"}):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_top_k == 40
+
+    def test_default_max_output_tokens(self):
+        with patch.dict(os.environ, {}, clear=False):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_max_output_tokens == 4096
+
+    def test_custom_max_output_tokens(self):
+        with patch.dict(os.environ, {"CAD_LLM_MAX_OUTPUT_TOKENS": "8192"}):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.llm_max_output_tokens == 8192
+
+
+class TestPlannerSettings:
+    """Verify planner timeout/retry settings parse correctly."""
+
+    def test_default_planner_timeout(self):
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.planner_timeout == 60
+
+    def test_custom_planner_timeout(self):
+        with patch.dict(os.environ, {"CAD_PLANNER_TIMEOUT": "120"}):
+            from cad_dxf_agent.settings import Settings
+
+            s = Settings()
+            assert s.planner_timeout == 120
+
+    def test_default_planner_max_retries(self):
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.planner_max_retries == 2
+
+    def test_default_planner_retry_delay(self):
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.planner_retry_delay == 1.0

--- a/tests/unit/test_load_warnings.py
+++ b/tests/unit/test_load_warnings.py
@@ -1,0 +1,87 @@
+"""Tests for actionable load-time warnings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from tests.helpers.dxf_factory import (
+    create_empty_dxf,
+    create_minimal_dxf,
+    create_structural_drawing,
+)
+
+
+class TestLoadWarnings:
+    def test_empty_drawing_produces_error_warning(self, tmp_path: Path):
+        """Empty DXF should produce EMPTY_DRAWING error-level warning."""
+        dxf_path = create_empty_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        assert len(ctx.load_warnings) >= 1
+        codes = [w.code for w in ctx.load_warnings]
+        assert "EMPTY_DRAWING" in codes
+        empty_w = next(w for w in ctx.load_warnings if w.code == "EMPTY_DRAWING")
+        assert empty_w.severity == "error"
+
+    def test_normal_drawing_no_error_warnings(self, tmp_path: Path):
+        """Normal structural drawing should not have error-level warnings."""
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        error_warnings = [w for w in ctx.load_warnings if w.severity == "error"]
+        assert len(error_warnings) == 0
+
+    def test_all_protected_warning(self, tmp_path: Path):
+        """Drawing with all entities on protected layers gets ALL_PROTECTED warning."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        doc.layers.add("TITLE", color=7)
+        msp.add_text("Title", dxfattribs={"layer": "TITLE", "height": 3.0, "insert": (0, 0)})
+        dxf_path = tmp_path / "all_protected.dxf"
+        doc.saveas(str(dxf_path))
+
+        ctx = load_dxf(dxf_path)
+        codes = [w.code for w in ctx.load_warnings]
+        assert "ALL_PROTECTED" in codes
+        prot_w = next(w for w in ctx.load_warnings if w.code == "ALL_PROTECTED")
+        assert prot_w.severity == "warning"
+
+    def test_unsupported_types_warning(self, tmp_path: Path):
+        """DXF with unsupported entity types should produce UNSUPPORTED_TYPES warning."""
+        import ezdxf
+
+        doc = ezdxf.new(dxfversion="R2018")
+        msp = doc.modelspace()
+        doc.layers.add("STRUCTURAL", color=1)
+        # Add a supported entity
+        msp.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+        # Add a 3DFACE entity (unsupported)
+        msp.add_3dface(
+            [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)],
+            dxfattribs={"layer": "STRUCTURAL"},
+        )
+        dxf_path = tmp_path / "mixed_types.dxf"
+        doc.saveas(str(dxf_path))
+
+        ctx = load_dxf(dxf_path)
+        codes = [w.code for w in ctx.load_warnings]
+        assert "UNSUPPORTED_TYPES" in codes
+        unsup_w = next(w for w in ctx.load_warnings if w.code == "UNSUPPORTED_TYPES")
+        assert unsup_w.severity == "info"
+        assert "3DFACE" in unsup_w.message
+
+    def test_minimal_drawing_no_warnings(self, tmp_path: Path):
+        """Minimal drawing with one line should produce no warnings."""
+        dxf_path = create_minimal_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        # Should have 0 or minimal warnings (no error/warning level)
+        serious = [w for w in ctx.load_warnings if w.severity in ("error", "warning")]
+        assert len(serious) == 0
+
+    def test_warnings_stored_on_context(self, tmp_path: Path):
+        """Load warnings should be stored on DrawingContext.load_warnings."""
+        dxf_path = create_empty_dxf(tmp_path)
+        ctx = load_dxf(dxf_path)
+        assert hasattr(ctx, "load_warnings")
+        assert isinstance(ctx.load_warnings, list)

--- a/tests/unit/test_planner_retry.py
+++ b/tests/unit/test_planner_retry.py
@@ -1,0 +1,91 @@
+"""Tests for planner retry with exponential backoff."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from cad_dxf_agent.llm.errors import PlannerRetryExhaustedError
+from cad_dxf_agent.llm.planner import run_planner
+from cad_dxf_agent.llm.providers import PlannerProvider
+from cad_dxf_agent.models.ops_schema import ChangeSet
+
+
+class FailNTimesProvider(PlannerProvider):
+    """Mock provider that fails N times then succeeds."""
+
+    def __init__(self, fail_count: int = 2) -> None:
+        self._fail_count = fail_count
+        self._attempts = 0
+
+    @property
+    def name(self) -> str:
+        return "fail-n-mock"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        self._attempts += 1
+        if self._attempts <= self._fail_count:
+            raise ValueError(f"Simulated failure #{self._attempts}")
+        return ChangeSet(prompt=prompt, operations=[])
+
+
+class AlwaysFailProvider(PlannerProvider):
+    """Mock provider that always fails."""
+
+    @property
+    def name(self) -> str:
+        return "always-fail"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        raise RuntimeError("Permanent failure")
+
+
+@patch("cad_dxf_agent.llm.planner.settings")
+class TestPlannerRetry:
+    def _setup_settings(self, mock_settings, max_retries=2, delay=0.0):
+        mock_settings.planner_timeout = 30
+        mock_settings.planner_max_retries = max_retries
+        mock_settings.planner_retry_delay = delay
+        mock_settings.llm_provider = "mock"
+
+    def test_succeeds_after_one_failure(self, mock_settings):
+        self._setup_settings(mock_settings, max_retries=2)
+        provider = FailNTimesProvider(fail_count=1)
+        result = run_planner("test", {}, provider=provider)
+        assert isinstance(result, ChangeSet)
+        assert provider._attempts == 2
+
+    def test_exhausts_retries(self, mock_settings):
+        self._setup_settings(mock_settings, max_retries=2)
+        provider = AlwaysFailProvider()
+        with pytest.raises(PlannerRetryExhaustedError) as exc_info:
+            run_planner("test", {}, provider=provider)
+        assert exc_info.value.attempts == 2
+        assert isinstance(exc_info.value.last_error, RuntimeError)
+
+    def test_single_retry_succeeds_on_first_try(self, mock_settings):
+        self._setup_settings(mock_settings, max_retries=1)
+        provider = FailNTimesProvider(fail_count=0)
+        result = run_planner("test", {}, provider=provider)
+        assert isinstance(result, ChangeSet)
+        assert provider._attempts == 1
+
+    def test_retry_exhausted_error_message(self, mock_settings):
+        err = PlannerRetryExhaustedError(3, ValueError("bad json"))
+        assert "3 attempt(s)" in str(err)
+        assert "bad json" in str(err)
+        assert err.attempts == 3
+
+    def test_retry_exhausted_error_no_last_error(self, mock_settings):
+        err = PlannerRetryExhaustedError(2)
+        assert "2 attempt(s)" in str(err)
+        assert err.last_error is None

--- a/tests/unit/test_planner_timeout.py
+++ b/tests/unit/test_planner_timeout.py
@@ -1,0 +1,84 @@
+"""Tests for planner timeout enforcement."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from cad_dxf_agent.llm.errors import PlannerTimeoutError
+from cad_dxf_agent.llm.planner import _call_with_timeout
+from cad_dxf_agent.llm.providers import PlannerProvider
+from cad_dxf_agent.models.ops_schema import ChangeSet
+
+
+class SlowProvider(PlannerProvider):
+    """Mock provider that sleeps longer than timeout."""
+
+    def __init__(self, delay: float = 5.0) -> None:
+        self._delay = delay
+
+    @property
+    def name(self) -> str:
+        return "slow-mock"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        time.sleep(self._delay)
+        return ChangeSet(prompt=prompt)
+
+
+class FastProvider(PlannerProvider):
+    """Mock provider that returns immediately."""
+
+    @property
+    def name(self) -> str:
+        return "fast-mock"
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+        return ChangeSet(prompt=prompt, operations=[])
+
+
+class TestPlannerTimeout:
+    def test_timeout_fires_on_slow_provider(self):
+        provider = SlowProvider(delay=10.0)
+        with pytest.raises(PlannerTimeoutError) as exc_info:
+            _call_with_timeout(provider, "test", {}, timeout=1)
+        assert exc_info.value.timeout_seconds == 1
+
+    def test_fast_provider_returns_normally(self):
+        provider = FastProvider()
+        result = _call_with_timeout(provider, "test", {}, timeout=5)
+        assert isinstance(result, ChangeSet)
+        assert result.prompt == "test"
+
+    def test_timeout_error_message(self):
+        err = PlannerTimeoutError(30)
+        assert "30s" in str(err)
+        assert err.timeout_seconds == 30
+
+    def test_timeout_error_custom_message(self):
+        err = PlannerTimeoutError(10, "custom message")
+        assert str(err) == "custom message"
+
+    @patch("cad_dxf_agent.llm.planner.settings")
+    def test_run_planner_uses_timeout_setting(self, mock_settings):
+        """Verify run_planner reads timeout from settings."""
+        mock_settings.planner_timeout = 60
+        mock_settings.planner_max_retries = 1
+        mock_settings.planner_retry_delay = 0.0
+        mock_settings.llm_provider = "mock"
+
+        from cad_dxf_agent.llm.planner import run_planner
+
+        # Should succeed with fast mock provider
+        result = run_planner("test prompt", {}, provider=FastProvider())
+        assert isinstance(result, ChangeSet)

--- a/tests/unit/test_support_report.py
+++ b/tests/unit/test_support_report.py
@@ -1,0 +1,83 @@
+"""Tests for support report formatting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cad_dxf_agent.core.context_builder import drawing_stats, support_report
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from tests.helpers.dxf_factory import create_structural_drawing
+
+
+class TestSupportReport:
+    def test_report_contains_file_info(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert "structural.dxf" in report
+        assert "DXF Version" in report
+        assert "bytes" in report
+
+    def test_report_contains_entity_counts(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert "Entities:" in report
+        assert "editable" in report
+        assert "total" in report
+
+    def test_report_contains_layer_info(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx, protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"])
+        report = support_report(stats)
+
+        assert "Layers:" in report
+        assert "PROTECTED" in report
+
+    def test_report_contains_entity_types(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert "Entity Types:" in report
+        assert "LINE" in report
+
+    def test_report_contains_bounding_box(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert "Bounding Box" in report
+
+    def test_report_contains_coverage(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert "Type Coverage:" in report
+        assert "%" in report
+
+    def test_report_is_multiline_string(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert isinstance(report, str)
+        assert len(report.splitlines()) > 10
+
+    def test_report_header(self, tmp_path: Path):
+        dxf_path = create_structural_drawing(tmp_path)
+        ctx = load_dxf(dxf_path)
+        stats = drawing_stats(ctx)
+        report = support_report(stats)
+
+        assert report.startswith("Drawing Support Report")


### PR DESCRIPTION
## Summary

- **Planner timeout + retries**: Wall-clock timeout via `ThreadPoolExecutor` (default 60s), exponential backoff retries (default 2 attempts), per-turn timeout in agent provider, fail-fast on empty responses
- **Model pinning + GenerationConfig**: Temperature pinned to 0.0 (deterministic), top_p/top_k/max_output_tokens configurable via env vars, `GenerationConfig` wired into both `GeminiProvider` and `AgentProvider`
- **Actionable load-time warnings**: `LoadWarning` model on `DrawingContext` — EMPTY_DRAWING (error), ALL_PROTECTED (warning), UNSUPPORTED_TYPES (info), LARGE_DRAWING (info). UI shows color-coded warnings panel; error-level disables Plan button
- **Drawing stats panel + support report**: `DrawingStats` model with entity/layer/type breakdowns, bounding box, coverage %. Stats toolbar button opens modal dialog with copyable support report. Status bar shows `editable/total` counts
- **Hybrid deterministic-first planner**: Regex pattern matching for `delete entity {handle}`, `move {handle} by (dx, dy)`, `change text of {handle} to '{text}'` — skips LLM entirely for obvious ops, falls through to provider for natural language

## Test plan

- [x] 57 new unit tests across 7 test files
- [x] 388 total tests passing, 5 skipped (display server)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy src/` clean
- [x] Smoke test passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drawing statistics and support report generation with detailed metrics including entity coverage, bounding boxes, and layer analysis.
  * Introduced load warnings with color-coded severity levels displayed on file import.
  * Added deterministic quick-planning for simple, unambiguous operations without invoking LLM.
  * Enhanced planner with timeout protection and automatic retry logic with exponential backoff.

* **UI Improvements**
  * New Stats button in toolbar displaying comprehensive drawing analysis in a dedicated dialog.
  * Warnings panel in left sidebar showing load-time issues with visual severity indicators.
  * Updated entity counts to distinguish editable entities from protected layer entities.

* **Configuration**
  * Added LLM generation parameters: temperature, top-p, top-k, and max output tokens.
  * Added planner timeout, retry, and delay settings for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->