### PR TITLE
feat: add max_snapshots cap to EditHistory

### DIFF
--- a/src/cad_dxf_agent/core/edit_history.py
+++ b/src/cad_dxf_agent/core/edit_history.py
@@ -24,11 +24,12 @@ class EditHistory:
     restored document.
     """
 
-    def __init__(self, initial_path: str | Path) -> None:
+    def __init__(self, initial_path: str | Path, max_snapshots: int = 0) -> None:
         self._initial_path = Path(initial_path)
         self._snapshots: list[bytes] = []
         self._cursor: int = -1  # Points to current snapshot; -1 = initial
         self._labels: list[str] = []
+        self._max_snapshots = max_snapshots
 
         # Capture the initial state
         doc = ezdxf.readfile(str(self._initial_path))
@@ -38,6 +39,7 @@ class EditHistory:
         """Capture current document state as a new snapshot.
 
         Discards any redo history beyond the current cursor position.
+        Evicts the oldest snapshot when max_snapshots is exceeded.
         """
         # Truncate redo stack
         self._snapshots = self._snapshots[: self._cursor + 1]
@@ -47,6 +49,14 @@ class EditHistory:
         self._snapshots.append(snapshot)
         self._labels.append(label)
         self._cursor = len(self._snapshots) - 1
+
+        # Evict oldest if over cap (0 = unlimited)
+        if self._max_snapshots > 0 and len(self._snapshots) > self._max_snapshots:
+            excess = len(self._snapshots) - self._max_snapshots
+            self._snapshots = self._snapshots[excess:]
+            self._labels = self._labels[excess:]
+            self._cursor -= excess
+            logger.debug("Evicted %d oldest snapshot(s), cap=%d", excess, self._max_snapshots)
 
         logger.debug(
             "Snapshot pushed [%d]: %s (%d bytes)",

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -70,6 +70,9 @@ class Settings:
         self.proxy_url: str | None = os.getenv("CAD_PROXY_URL")
         self.license_key: str | None = os.getenv("CAD_LICENSE_KEY")
 
+        # Edit history
+        self.max_undo_snapshots: int = int(os.getenv("CAD_MAX_UNDO_SNAPSHOTS", "50"))
+
         # Local API
         self.api_host: str = os.getenv("CAD_API_HOST", "127.0.0.1")
         self.api_port: int = int(os.getenv("CAD_API_PORT", "8321"))

--- a/src/cad_dxf_agent/ui/main_window.py
+++ b/src/cad_dxf_agent/ui/main_window.py
@@ -391,7 +391,7 @@ class MainWindow(QMainWindow):
 
             self._dxf_path = file_path
             self._context = load_dxf(self._dxf_path)
-            self._history = EditHistory(self._dxf_path)
+            self._history = EditHistory(self._dxf_path, max_snapshots=settings.max_undo_snapshots)
 
             # Update UI
             self.lbl_file.setText(f"{self._dxf_path.name} ({self._context.entity_count} entities)")

--- a/tests/unit/test_edit_history.py
+++ b/tests/unit/test_edit_history.py
@@ -134,3 +134,62 @@ class TestEditHistory:
         msp = doc.modelspace()
         texts = [e.dxf.text for e in msp if e.dxftype() == "TEXT"]
         assert "ORIGINAL" in texts
+
+
+class TestEditHistoryMaxSnapshots:
+    def test_unlimited_by_default(self, dxf_file):
+        """Default max_snapshots=0 means no eviction."""
+        history = EditHistory(dxf_file)
+        for i in range(10):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+        assert history.depth == 10
+
+    def test_cap_evicts_oldest(self, dxf_file):
+        """When cap is hit, oldest snapshots are evicted."""
+        history = EditHistory(dxf_file, max_snapshots=3)
+        for i in range(5):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+        assert history.depth == 3
+        assert history.current_label == "edit 4"
+
+    def test_cap_preserves_undo(self, dxf_file):
+        """After eviction, remaining snapshots are still undoable."""
+        history = EditHistory(dxf_file, max_snapshots=3)
+        for i in range(5):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+
+        # Should be able to undo 3 times (3 snapshots → initial)
+        for _ in range(3):
+            result = history.undo()
+            assert result is not None
+        # Now at initial
+        assert history.current_label == "initial"
+        assert history.undo() is None
+
+    def test_cap_of_one(self, dxf_file):
+        """Edge case: max_snapshots=1 keeps only the latest."""
+        history = EditHistory(dxf_file, max_snapshots=1)
+        for i in range(4):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+        assert history.depth == 1
+        assert history.current_label == "edit 3"
+
+    def test_cap_with_undo_and_new_push(self, dxf_file):
+        """Undo then push respects the cap after truncation."""
+        history = EditHistory(dxf_file, max_snapshots=3)
+        for i in range(3):
+            doc = ezdxf.readfile(str(dxf_file))
+            history.push(doc, f"edit {i}")
+        assert history.depth == 3
+
+        # Undo once, then push a new edit
+        history.undo()
+        doc = ezdxf.readfile(str(dxf_file))
+        history.push(doc, "edit new")
+        # Redo was truncated: edit 0, edit 1, edit new = 3 (at cap)
+        assert history.depth == 3
+        assert history.current_label == "edit new"


### PR DESCRIPTION
## Summary
- Add `max_snapshots` parameter to `EditHistory` — evicts oldest snapshots when cap is exceeded
- New `CAD_MAX_UNDO_SNAPSHOTS` env var (default 50, 0 = unlimited)
- Wired into `MainWindow` via `settings.max_undo_snapshots`
- 5 new tests covering eviction, edge cases (cap=1), undo after eviction, truncation + cap interaction

## Bead
- `cad-uao.4.1` — Add max_snapshots cap to EditHistory

## Test plan
- [x] 414 tests pass (379 unit + 31 integration + 4 smoke)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] Snapshots stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo/redo history depth is now configurable with a default limit of 50 snapshots, optimizing memory usage based on user needs
  * Automatic cleanup mechanism removes oldest snapshots when the configured maximum is exceeded while preserving full undo/redo functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->