### PR TITLE
feat: add validator micro-benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Run tests with coverage
-        run: pytest --cov=cad_dxf_agent --cov-report=term-missing -v
+        run: pytest --cov=cad_dxf_agent --cov-report=term-missing -v --ignore=tests/benchmark
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: actions/upload-artifact@v6
@@ -75,6 +75,25 @@ jobs:
         run: pytest tests/gui/ -v -m gui
         env:
           QT_QPA_PLATFORM: offscreen
+
+  benchmark:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Run benchmarks
+        run: pytest tests/benchmark/ -v --benchmark-json=benchmark.json
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark-results
+          path: benchmark.json
 
   live-test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ build = [
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-benchmark>=5.0",
     "syrupy>=4.0",
     "ruff>=0.5",
     "mypy>=1.10",
@@ -120,6 +121,7 @@ markers = [
     "integration: integration tests (full pipeline, multi-module)",
     "live_api: tests that call real Gemini API (require ADC via gcloud auth)",
     "gui: GUI tests (require PySide6 and QT_QPA_PLATFORM=offscreen)",
+    "benchmark: performance micro-benchmarks (pytest-benchmark)",
 ]
 
 [tool.coverage.run]

--- a/tests/benchmark/test_validator_bench.py
+++ b/tests/benchmark/test_validator_bench.py
@@ -1,0 +1,190 @@
+"""Micro-benchmarks for validator pipeline.
+
+Uses pytest-benchmark to measure validation performance at different
+drawing scales. Run with: pytest tests/benchmark/ -v
+
+Benchmark results are printed to stdout. Use --benchmark-json=output.json
+to save results for CI regression tracking.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.semantic_model import build_planner_context
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.models.config_schema import RuleConfig
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+pytestmark = pytest.mark.benchmark
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+def _make_drawing(tmp_path: Path, entity_count: int) -> Path:
+    """Build a DXF with *entity_count* lines on STRUCTURAL."""
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+    doc.layers.add("STRUCTURAL", color=1)
+    doc.layers.add("NOTES", color=3)
+    doc.layers.add("TITLE", color=7)
+
+    for i in range(entity_count):
+        y = float(i)
+        msp.add_line((0, y), (100, y), dxfattribs={"layer": "STRUCTURAL"})
+
+    # Add some text entities for edit_text benchmarks
+    for i in range(min(entity_count // 10, 50)):
+        msp.add_text(
+            f"Label-{i}",
+            dxfattribs={"layer": "NOTES", "height": 2.0, "insert": (0, float(i) * 10)},
+        )
+
+    # Protected layer entities
+    msp.add_text("TITLE", dxfattribs={"layer": "TITLE", "height": 5.0, "insert": (0, -10)})
+
+    path = tmp_path / f"bench_{entity_count}.dxf"
+    doc.saveas(str(path))
+    return path
+
+
+@pytest.fixture
+def small_drawing(tmp_path):
+    """50 entities — typical small detail."""
+    return _make_drawing(tmp_path, 50)
+
+
+@pytest.fixture
+def medium_drawing(tmp_path):
+    """500 entities — typical floor plan."""
+    return _make_drawing(tmp_path, 500)
+
+
+@pytest.fixture
+def large_drawing(tmp_path):
+    """2000 entities — large structural sheet."""
+    return _make_drawing(tmp_path, 2000)
+
+
+def _make_changeset(context, op_count: int) -> ChangeSet:
+    """Build a changeset with *op_count* move operations targeting real handles."""
+    entities = [e for e in context.entities if e.layer.upper() != "TITLE"]
+    ops = []
+    for i in range(min(op_count, len(entities))):
+        ops.append(
+            EditOperation(
+                op_type=OpType.MOVE_ENTITY,
+                target_handle=entities[i].handle,
+                params={"dx": 1.0, "dy": 0.0},
+            )
+        )
+    return ChangeSet(prompt="benchmark", operations=ops)
+
+
+# ── Benchmarks: validate_changeset ────────────────────────────
+
+
+class TestValidatorBenchSmall:
+    """Benchmarks on a 50-entity drawing."""
+
+    def test_validate_single_op(self, small_drawing, benchmark):
+        ctx = load_dxf(small_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 1)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_10_ops(self, small_drawing, benchmark):
+        ctx = load_dxf(small_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 10)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+
+class TestValidatorBenchMedium:
+    """Benchmarks on a 500-entity drawing."""
+
+    def test_validate_single_op(self, medium_drawing, benchmark):
+        ctx = load_dxf(medium_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 1)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_10_ops(self, medium_drawing, benchmark):
+        ctx = load_dxf(medium_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 10)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_50_ops(self, medium_drawing, benchmark):
+        ctx = load_dxf(medium_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 50)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+
+class TestValidatorBenchLarge:
+    """Benchmarks on a 2000-entity drawing."""
+
+    def test_validate_single_op(self, large_drawing, benchmark):
+        ctx = load_dxf(large_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 1)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_10_ops(self, large_drawing, benchmark):
+        ctx = load_dxf(large_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 10)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_50_ops(self, large_drawing, benchmark):
+        ctx = load_dxf(large_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 50)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+    def test_validate_100_ops(self, large_drawing, benchmark):
+        ctx = load_dxf(large_drawing)
+        rules = RuleConfig()
+        cs = _make_changeset(ctx, 100)
+        benchmark(validate_changeset, cs, ctx, rules)
+
+
+# ── Benchmarks: build_planner_context ─────────────────────────
+
+
+class TestContextBuildBench:
+    """Benchmark the semantic model context builder at different scales."""
+
+    def test_build_context_small(self, small_drawing, benchmark):
+        ctx = load_dxf(small_drawing)
+        benchmark(build_planner_context, ctx)
+
+    def test_build_context_medium(self, medium_drawing, benchmark):
+        ctx = load_dxf(medium_drawing)
+        benchmark(build_planner_context, ctx)
+
+    def test_build_context_large(self, large_drawing, benchmark):
+        ctx = load_dxf(large_drawing)
+        benchmark(build_planner_context, ctx)
+
+
+# ── Benchmarks: load_dxf ─────────────────────────────────────
+
+
+class TestLoadDxfBench:
+    """Benchmark DXF loading at different scales."""
+
+    def test_load_small(self, small_drawing, benchmark):
+        benchmark(load_dxf, small_drawing)
+
+    def test_load_medium(self, medium_drawing, benchmark):
+        benchmark(load_dxf, medium_drawing)
+
+    def test_load_large(self, large_drawing, benchmark):
+        benchmark(load_dxf, large_drawing)


### PR DESCRIPTION
## Summary
- Add `pytest-benchmark` to dev deps and `benchmark` marker
- 15 micro-benchmarks across 3 pipeline stages (`validate_changeset`, `build_planner_context`, `load_dxf`) at 3 scales (50/500/2000 entities)
- New CI `benchmark` job on push to main — runs benchmarks and uploads JSON artifact
- Regular test runs exclude `tests/benchmark/` to avoid slowdown

## Bead
- `cad-uao.4.2` — Validator micro-benchmarks in CI

## Local results (representative)
| Stage | 50 ent | 500 ent | 2000 ent |
|-------|--------|---------|----------|
| validate (1 op) | ~22 us | ~179 us | ~564 us |
| validate (50 ops) | — | ~207 us | ~789 us |
| build_context | ~67 us | ~854 us | ~5.8 ms |
| load_dxf | ~11 ms | ~55 ms | ~228 ms |

## Test plan
- [x] 15 benchmark tests pass locally
- [x] 432 non-benchmark tests pass (12 skipped)
- [x] Lint clean
- [x] Snapshots stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive performance benchmarking suite to measure validator operations, context building, and DXF file loading across small, medium, and large drawing sizes with varying operation counts.

* **Chores**
  * Enhanced CI/CD pipeline with automated benchmark execution on main branch following test completion, with results stored as artifacts for performance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->