### PR TITLE
fix: handle pymupdf 1.27 quad item API change

### DIFF
--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -326,24 +326,22 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                             msp.add_lwpolyline(pts, dxfattribs={"layer": layer})
                     total += 1
 
-                elif kind == "qu":  # Quadratic Bezier
-                    p1, p2, p3 = item[1], item[2], item[3]
-                    # Promote to cubic: C0=P0, C1=P0+2/3*(P1-P0), C2=P2+2/3*(P1-P2), C3=P2
-                    c1_x = p1.x + 2 / 3 * (p2.x - p1.x)
-                    c1_y = p1.y + 2 / 3 * (p2.y - p1.y)
-                    c2_x = p3.x + 2 / 3 * (p2.x - p3.x)
-                    c2_y = p3.y + 2 / 3 * (p2.y - p3.y)
-
-                    class _Pt:
-                        def __init__(self, x, y):
-                            self.x = x
-                            self.y = y
-
-                    pts = _bezier_to_points(
-                        p1, _Pt(c1_x, c1_y), _Pt(c2_x, c2_y), p3, page_height, segments=8
-                    )
+                elif kind == "qu":  # Quad (quadrilateral)
+                    # pymupdf >=1.27: ('qu', Quad_object) — Quad[0..3] are Points
+                    # pymupdf <1.27:  ('qu', Point, Point, Point, Point)
+                    if len(item) == 2:
+                        quad = item[1]
+                        pts = [
+                            (float(quad[k].x), page_height - float(quad[k].y))
+                            for k in range(4)
+                        ]
+                    else:
+                        pts = [
+                            (float(item[k].x), page_height - float(item[k].y))
+                            for k in range(1, len(item))
+                        ]
                     if len(pts) >= 2:
-                        msp.add_lwpolyline(pts, dxfattribs={"layer": layer})
+                        msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
                     total += 1
 
         # Extract text blocks from the page


### PR DESCRIPTION
## Summary
- pymupdf 1.27 changed `qu` drawing items from `('qu', Point, Point, Point, Point)` to `('qu', Quad_object)` — crashes with `tuple index out of range`
- Fixes the handler to support both old and new APIs via `len(item)` check
- Corrects the geometry: `qu` is a quadrilateral (closed polyline), not a quadratic bezier as the old code assumed

## Test plan
- [x] All 15 converter unit tests pass
- [x] All 8 conversion pipeline integration tests pass
- [x] Manual verification: 3 test PDFs convert successfully with pymupdf 1.27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF to DXF conversion robustness with improved handling of quadratic curves from PDF documents.
  * Quadratic paths are now correctly converted and rendered as closed polylines in DXF output.
  * Better compatibility across different library versions ensures more reliable PDF imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->