### PR TITLE
feat(otel): wire OpenTelemetry init in web backend

### DIFF
--- a/tests/web/test_web_otel.py
+++ b/tests/web/test_web_otel.py
@@ -1,0 +1,85 @@
+"""Tests that OTel spans fire through web backend endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from starlette.testclient import TestClient
+
+from cad_dxf_agent.otel import init_otel_testing, reset_otel
+
+
+@pytest.fixture()
+def otel_client(auth_user, sample_dxf_bytes):
+    """TestClient with OTel wired to an in-memory exporter."""
+    exporter = InMemorySpanExporter()
+    init_otel_testing(exporter)
+
+    from web.backend.main import app, get_user
+
+    async def _override():
+        return auth_user
+
+    app.dependency_overrides[get_user] = _override
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c, exporter
+
+    app.dependency_overrides.clear()
+    reset_otel()
+    exporter.shutdown()
+
+
+@pytest.mark.web
+class TestWebOtelSpans:
+    def test_upload_plan_produces_pipeline_spans(self, otel_client, sample_dxf_bytes):
+        """Upload + plan should produce pipeline spans."""
+        client, exporter = otel_client
+
+        # Upload
+        resp = client.post(
+            "/api/upload",
+            files={"file": ("test.dxf", sample_dxf_bytes, "application/octet-stream")},
+        )
+        assert resp.status_code == 200
+        session_id = resp.json()["session_id"]
+
+        # Plan
+        resp = client.post(
+            "/api/plan",
+            json={"session_id": session_id, "prompt": "Move the column east by 2 feet"},
+        )
+        assert resp.status_code == 200
+
+        spans = exporter.get_finished_spans()
+        span_names = {s.name for s in spans}
+        assert "cad.load_dxf" in span_names
+        assert "cad.build_context" in span_names
+        assert "cad.run_planner" in span_names
+        assert "cad.validate" in span_names
+
+
+@pytest.mark.web
+class TestWebOtelDisabled:
+    def test_endpoints_work_without_otel(self, sample_dxf_bytes, auth_user):
+        """Web endpoints must work when OTel is not initialized."""
+        reset_otel()
+
+        from web.backend.main import app, get_user
+
+        async def _override():
+            return auth_user
+
+        app.dependency_overrides[get_user] = _override
+        try:
+            with TestClient(app, raise_server_exceptions=False) as c:
+                resp = c.get("/api/health")
+                assert resp.status_code == 200
+
+                resp = c.post(
+                    "/api/upload",
+                    files={"file": ("test.dxf", sample_dxf_bytes, "application/octet-stream")},
+                )
+                assert resp.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+            reset_otel()

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -40,6 +40,9 @@ session_mgr = SessionManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from cad_dxf_agent.otel import init_otel
+
+    init_otel(service_name="cad-dxf-web")
     logger.info("CAD DXF Web Backend starting")
     yield
     logger.info("CAD DXF Web Backend shutting down")

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -9,3 +9,5 @@ numpy>=1.26
 httpx>=0.27
 google-cloud-aiplatform>=1.60.0
 matplotlib>=3.8
+opentelemetry-api>=1.21
+opentelemetry-sdk>=1.21


### PR DESCRIPTION
## Summary
- Call `init_otel(service_name="cad-dxf-web")` in FastAPI lifespan startup, lighting up all 7 existing pipeline spans for web requests when `OTEL_ENABLED=true`
- Add `opentelemetry-api` and `opentelemetry-sdk` to `web/backend/requirements.txt`
- Add `tests/web/test_web_otel.py` with 2 tests: spans propagate through upload→plan flow, and endpoints work with OTel disabled

## Test plan
- [x] `pytest tests/web/test_web_otel.py -v` — 2/2 pass
- [x] `pytest tests/unit/test_otel.py -v` — 5/5 pass (no regressions)
- [x] `pytest tests/web/ -v` — 72/72 pass (full web suite)
- [x] `mypy src/` — clean
- [x] `ruff check` — clean
- [x] Full test suite — 575 pass, 15 skip (1 pre-existing live API timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled OpenTelemetry integration for detailed operation tracing and monitoring.

* **Tests**
  * Added tests verifying trace generation for file upload, planning, and processing operations.
  * Added tests ensuring endpoints function correctly with tracing disabled.

* **Chores**
  * Added OpenTelemetry SDK and API library dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->