### PR TITLE
feat(otel): add Google Cloud Trace exporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ All settings via environment variables (`.env` file, `.gitignore`d):
 | `CAD_REVISION_NOTES_ENABLED` | `true` | Insert revision notes after edits |
 | `CAD_REVISION_NOTES_LAYER` | `AI_REV_NOTES` | Layer name for revision notes |
 | `OTEL_ENABLED` | _(unset)_ | Enable OpenTelemetry tracing (`1`, `true`, `yes`) |
-| `OTEL_EXPORTER` | `console` | Span exporter: `console` or `otlp` |
+| `OTEL_EXPORTER` | `console` | Span exporter: `console`, `otlp`, or `gcp-trace` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP collector endpoint (e.g., `http://localhost:4317`) |
 
 ### Observability (OpenTelemetry)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ otel = [
     "opentelemetry-exporter-otlp>=1.21",
     "opentelemetry-semantic-conventions>=0.42b0",
 ]
+gcp-trace = [
+    "opentelemetry-exporter-gcp-trace>=1.6",
+    "opentelemetry-api>=1.21",
+    "opentelemetry-sdk>=1.21",
+]
 convert = [
     "pymupdf>=1.24",
     "Pillow>=10.0",

--- a/src/cad_dxf_agent/otel.py
+++ b/src/cad_dxf_agent/otel.py
@@ -51,7 +51,18 @@ def init_otel(service_name: str = "cad-dxf-agent") -> None:
     resource = Resource.create({"service.name": service_name})
     provider = TracerProvider(resource=resource)
 
-    if settings.otel_endpoint:
+    if settings.otel_exporter == "gcp-trace":
+        try:
+            from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+
+            exporter = CloudTraceSpanExporter()
+            logger.info("OTel: using Google Cloud Trace exporter")
+        except ImportError:
+            logger.warning(
+                "OTel: gcp-trace exporter not installed, falling back to console"
+            )
+            exporter = ConsoleSpanExporter()
+    elif settings.otel_endpoint:
         try:
             from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
                 OTLPSpanExporter,

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -34,7 +34,7 @@ class Settings:
 
         # OpenTelemetry
         self.otel_enabled: bool = os.getenv("OTEL_ENABLED", "").lower() in ("1", "true", "yes")
-        self.otel_exporter: str = os.getenv("OTEL_EXPORTER", "console")
+        self.otel_exporter: str = os.getenv("OTEL_EXPORTER", "console")  # console|otlp|gcp-trace
         self.otel_endpoint: str | None = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 
         # Logging

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -99,6 +99,56 @@ class TestBuildContextSpan:
         assert attrs["cad.entities.count"] == sample_context.entity_count
 
 
+class TestGcpTraceExporter:
+    def test_gcp_trace_exporter_selected(self, monkeypatch):
+        """When OTEL_EXPORTER=gcp-trace and package available, uses GCP exporter."""
+        import sys
+        import types
+        import unittest.mock
+
+        import cad_dxf_agent.otel as otel_mod
+
+        reset_otel()
+        monkeypatch.setenv("OTEL_ENABLED", "true")
+        monkeypatch.setenv("OTEL_EXPORTER", "gcp-trace")
+
+        # Mock the CloudTraceSpanExporter module
+        mock_exporter = unittest.mock.MagicMock()
+        mock_module = types.ModuleType("opentelemetry.exporter.cloud_trace")
+        mock_module.CloudTraceSpanExporter = lambda: mock_exporter  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "opentelemetry.exporter.cloud_trace", mock_module)
+
+        # Fresh settings with env vars applied
+        from cad_dxf_agent.settings import Settings
+
+        monkeypatch.setattr("cad_dxf_agent.settings.settings", Settings())
+
+        otel_mod.init_otel(service_name="test-gcp")
+        assert otel_mod._provider is not None
+        reset_otel()
+
+    def test_gcp_trace_fallback_when_not_installed(self, monkeypatch):
+        """When OTEL_EXPORTER=gcp-trace but package missing, falls back to console."""
+        import sys
+
+        import cad_dxf_agent.otel as otel_mod
+
+        reset_otel()
+        monkeypatch.setenv("OTEL_ENABLED", "true")
+        monkeypatch.setenv("OTEL_EXPORTER", "gcp-trace")
+
+        # Block the import so it raises ImportError
+        monkeypatch.setitem(sys.modules, "opentelemetry.exporter.cloud_trace", None)
+
+        from cad_dxf_agent.settings import Settings
+
+        monkeypatch.setattr("cad_dxf_agent.settings.settings", Settings())
+
+        otel_mod.init_otel(service_name="test-gcp-fallback")
+        assert otel_mod._provider is not None  # console fallback still initializes
+        reset_otel()
+
+
 class TestOtelDisabled:
     def test_no_spans_when_disabled(self, sample_dxf, otel_disabled):
         """When OTel is not initialized, no spans should be created."""

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-aiplatform>=1.60.0
 matplotlib>=3.8
 opentelemetry-api>=1.21
 opentelemetry-sdk>=1.21
+opentelemetry-exporter-gcp-trace>=1.6


### PR DESCRIPTION
## Summary
- Add `gcp-trace` option to `OTEL_EXPORTER` — uses `opentelemetry-exporter-gcp-trace` with ADC (zero config on Cloud Run)
- Graceful fallback to console exporter if package not installed
- Add `gcp-trace` optional dependency group in `pyproject.toml`
- Add `opentelemetry-exporter-gcp-trace` to `web/backend/requirements.txt`
- Update `CLAUDE.md` config table to document `gcp-trace` value
- Add inline comment on `settings.py` documenting valid exporter values

## Test plan
- [x] `pytest tests/unit/test_otel.py -v` — 7/7 pass (2 new GCP exporter tests)
- [x] `pytest tests/unit/ tests/web/ tests/integration/ -v` — 518 pass, 5 skip
- [x] `mypy src/` — clean
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Google Cloud Trace as a telemetry data exporter option.

* **Documentation**
  * Updated environment variable documentation to reflect the new exporter option.

* **Tests**
  * Added test coverage for GCP trace exporter selection and fallback behavior.

* **Chores**
  * Added OpenTelemetry dependencies required for GCP trace support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->