### PR TITLE
feat: semantic DXF validation in E2E + GUI tests

### DIFF
--- a/tests/gui/test_gui_plan.py
+++ b/tests/gui/test_gui_plan.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ezdxf
 import pytest
 
+WORKER_TIMEOUT_MS = 10_000
+
 
 def _extract_dxf_summary(path: str) -> dict:
     """Extract entity counts, INSERT positions, and TEXT values from a DXF file."""
@@ -45,7 +47,7 @@ def _run_plan_apply(qapp, sample_dxf, rule_config, prompt, output_path):
     plan_worker.plan_succeeded.connect(lambda r: plan_results.append(r))
     plan_worker.plan_failed.connect(lambda e: plan_errors.append(e))
     plan_worker.start()
-    assert plan_worker.wait(10000), "Plan worker timed out"
+    assert plan_worker.wait(WORKER_TIMEOUT_MS), "Plan worker timed out"
     qapp.processEvents()
     assert len(plan_errors) == 0, f"Plan failed: {plan_errors}"
     assert len(plan_results) == 1
@@ -59,7 +61,7 @@ def _run_plan_apply(qapp, sample_dxf, rule_config, prompt, output_path):
     apply_worker.apply_succeeded.connect(lambda r: apply_results.append(r))
     apply_worker.apply_failed.connect(lambda e: apply_errors.append(e))
     apply_worker.start()
-    assert apply_worker.wait(10000), "Apply worker timed out"
+    assert apply_worker.wait(WORKER_TIMEOUT_MS), "Apply worker timed out"
     qapp.processEvents()
     assert len(apply_errors) == 0, f"Apply failed: {apply_errors}"
     assert len(apply_results) == 1
@@ -84,7 +86,7 @@ class TestGuiPlanWorkflow:
         worker.plan_succeeded.connect(lambda r: results.append(r))
         worker.plan_failed.connect(lambda e: errors.append(e))
         worker.start()
-        assert worker.wait(10000), "Worker timed out"
+        assert worker.wait(WORKER_TIMEOUT_MS), "Worker timed out"
         qapp.processEvents()  # flush queued cross-thread signals
 
         assert len(errors) == 0, f"Plan failed: {errors}"
@@ -112,7 +114,7 @@ class TestGuiPlanWorkflow:
         plan_results = []
         plan_worker.plan_succeeded.connect(lambda r: plan_results.append(r))
         plan_worker.start()
-        assert plan_worker.wait(10000)
+        assert plan_worker.wait(WORKER_TIMEOUT_MS)
         qapp.processEvents()  # flush queued cross-thread signals
         assert len(plan_results) == 1
 
@@ -126,7 +128,7 @@ class TestGuiPlanWorkflow:
         apply_worker.apply_succeeded.connect(lambda r: apply_results.append(r))
         apply_worker.apply_failed.connect(lambda e: apply_errors.append(e))
         apply_worker.start()
-        assert apply_worker.wait(10000)
+        assert apply_worker.wait(WORKER_TIMEOUT_MS)
         qapp.processEvents()  # flush queued cross-thread signals
 
         assert len(apply_errors) == 0, f"Apply failed: {apply_errors}"

--- a/tests/gui/test_gui_plan.py
+++ b/tests/gui/test_gui_plan.py
@@ -2,7 +2,68 @@
 
 from __future__ import annotations
 
+import ezdxf
 import pytest
+
+
+def _extract_dxf_summary(path: str) -> dict:
+    """Extract entity counts, INSERT positions, and TEXT values from a DXF file."""
+    doc = ezdxf.readfile(path)
+    msp = doc.modelspace()
+    entities = list(msp)
+    inserts = []
+    texts = []
+    for e in entities:
+        if e.dxftype() == "INSERT":
+            pos = e.dxf.insert
+            inserts.append((round(pos.x, 2), round(pos.y, 2)))
+        elif e.dxftype() in ("TEXT", "MTEXT"):
+            t = e.dxf.text if e.dxftype() == "TEXT" else e.text
+            texts.append(t)
+    return {
+        "count": len(entities),
+        "inserts": inserts,
+        "insert_count": len(inserts),
+        "texts": texts,
+        "text_count": len(texts),
+    }
+
+
+def _run_plan_apply(qapp, sample_dxf, rule_config, prompt, output_path):
+    """Helper: plan + apply via PipelineWorker, return output path."""
+    from cad_dxf_agent.core.dxf_reader import load_dxf
+    from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+    from cad_dxf_agent.ui.pipeline_worker import PipelineWorker
+
+    context = load_dxf(sample_dxf)
+    rev_config = RevisionNoteConfig(enabled=True, layer_name="AI_REV_NOTES")
+
+    # Plan
+    plan_worker = PipelineWorker()
+    plan_worker.setup_plan(prompt, context, rule_config)
+    plan_results, plan_errors = [], []
+    plan_worker.plan_succeeded.connect(lambda r: plan_results.append(r))
+    plan_worker.plan_failed.connect(lambda e: plan_errors.append(e))
+    plan_worker.start()
+    assert plan_worker.wait(10000), "Plan worker timed out"
+    qapp.processEvents()
+    assert len(plan_errors) == 0, f"Plan failed: {plan_errors}"
+    assert len(plan_results) == 1
+
+    # Apply
+    apply_worker = PipelineWorker()
+    apply_worker.setup_apply(
+        plan_results[0].changeset, sample_dxf, output_path, rule_config, rev_config
+    )
+    apply_results, apply_errors = [], []
+    apply_worker.apply_succeeded.connect(lambda r: apply_results.append(r))
+    apply_worker.apply_failed.connect(lambda e: apply_errors.append(e))
+    apply_worker.start()
+    assert apply_worker.wait(10000), "Apply worker timed out"
+    qapp.processEvents()
+    assert len(apply_errors) == 0, f"Apply failed: {apply_errors}"
+    assert len(apply_results) == 1
+    return apply_results[0]
 
 
 @pytest.mark.gui
@@ -77,3 +138,63 @@ class TestGuiPlanWorkflow:
 
         # Verify output file exists
         assert Path(output_path).exists()
+
+
+@pytest.mark.gui
+class TestGuiSemanticValidation:
+    """Verify PipelineWorker produces correct DXF output — same checks as E2E tests."""
+
+    def test_move_changes_position(self, qapp, sample_dxf, rule_config, tmp_path):
+        """Move preserves entity count but changes at least one INSERT position."""
+        output_path = str(tmp_path / "move_output.dxf")
+        _run_plan_apply(
+            qapp, sample_dxf, rule_config,
+            "Move the column at grid C-4 two feet east", output_path,
+        )
+
+        orig = _extract_dxf_summary(str(sample_dxf))
+        edited = _extract_dxf_summary(output_path)
+
+        # Move preserves entity and INSERT counts
+        assert edited["count"] == orig["count"]
+        assert edited["insert_count"] == orig["insert_count"]
+        # At least one INSERT position must differ
+        assert set(edited["inserts"]) != set(orig["inserts"]), \
+            "Move should change at least one INSERT position"
+
+    def test_delete_removes_entity(self, qapp, sample_dxf, rule_config, tmp_path):
+        """Delete reduces total entity count."""
+        output_path = str(tmp_path / "delete_output.dxf")
+        _run_plan_apply(
+            qapp, sample_dxf, rule_config,
+            "Delete the first column mark", output_path,
+        )
+
+        orig = _extract_dxf_summary(str(sample_dxf))
+        edited = _extract_dxf_summary(output_path)
+
+        assert edited["count"] < orig["count"]
+        fewer_inserts = edited["insert_count"] < orig["insert_count"]
+        fewer_texts = edited["text_count"] < orig["text_count"]
+        assert fewer_inserts or fewer_texts, \
+            "Delete should remove at least one INSERT or TEXT"
+
+    def test_edit_text_changes_content(self, qapp, sample_dxf, rule_config, tmp_path):
+        """edit_text preserves entity count but changes text content."""
+        output_path = str(tmp_path / "edittext_output.dxf")
+        _run_plan_apply(
+            qapp, sample_dxf, rule_config,
+            "Rename the text label to UPDATED", output_path,
+        )
+
+        orig = _extract_dxf_summary(str(sample_dxf))
+        edited = _extract_dxf_summary(output_path)
+
+        # edit_text doesn't add or delete entities
+        assert edited["count"] == orig["count"]
+        # At least one TEXT value differs
+        assert set(edited["texts"]) != set(orig["texts"]), \
+            "edit_text should change at least one TEXT value"
+        # The word "UPDATED" should appear somewhere
+        assert any("UPDATED" in t.upper() for t in edited["texts"]), \
+            'Edited text should contain "UPDATED"'

--- a/web/frontend/e2e/edit-flow.spec.js
+++ b/web/frontend/e2e/edit-flow.spec.js
@@ -71,6 +71,33 @@ print(json.dumps({"original": orig, "edited": edited}))
   }
 }
 
+/**
+ * Apply changes and download the edited DXF file.
+ * Returns the local path where the downloaded file was saved.
+ */
+async function applyAndDownload(page, filenamePrefix = '') {
+  const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
+  await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
+  await applyBtn.click();
+
+  await expect(
+    page.locator('.preview__tab--active')
+  ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
+
+  const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
+  await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
+
+  const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
+  await downloadBtn.click();
+  const download = await downloadPromise;
+
+  const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
+  fs.mkdirSync(downloadDir, { recursive: true });
+  const savedPath = path.join(downloadDir, `${filenamePrefix}${download.suggestedFilename()}`);
+  await download.saveAs(savedPath);
+  return savedPath;
+}
+
 test.describe('Full Edit Flow', () => {
   test('upload → prompt "move" → see ops → apply → download valid edited DXF', async ({ page }) => {
     await page.goto('/');
@@ -106,42 +133,16 @@ test.describe('Full Edit Flow', () => {
     // AI message in chat
     await expect(page.locator('.message--ai').first()).toBeVisible();
 
-    // 4. Apply Changes (no download yet)
-    const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
-    await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
-    await applyBtn.click();
-
-    // 5. Verify Edited tab is active + image visible
-    await expect(
-      page.locator('.preview__tab--active')
-    ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
+    // 4. Apply + download + verify edited preview image
+    const savedPath = await applyAndDownload(page);
     await expect(
       page.locator('.preview__image-wrap img[alt="edited drawing preview"]')
     ).toBeVisible({ timeout: 10_000 });
 
-    // 6. Download via separate button
-    const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
-    await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
-
-    const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
-    await downloadBtn.click();
-
-    // 7. Verify download filename
-    const download = await downloadPromise;
-    const filename = download.suggestedFilename();
-    expect(filename).toMatch(/_edited\.dxf$/);
-
-    // 8. Save and validate the actual DXF content
-    const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
-    fs.mkdirSync(downloadDir, { recursive: true });
-    const savedPath = path.join(downloadDir, filename);
-    await download.saveAs(savedPath);
-
-    // File must be non-trivial size (not empty or error page)
+    // 5. Validate the actual DXF content
     const stat = fs.statSync(savedPath);
     expect(stat.size).toBeGreaterThan(1000); // real DXF is always > 1KB
 
-    // Validate with ezdxf — must be a parseable DXF with entities
     const result = validateDxf(savedPath);
     expect(result.valid, `DXF validation failed: ${result.error || 'unknown'}`).toBe(true);
     expect(result.entities).toBeGreaterThan(0);
@@ -161,7 +162,7 @@ test.describe('Full Edit Flow', () => {
     const allSame = [...editedPositions].every(p => origPositions.has(p));
     expect(allSame, 'Move should change at least one INSERT position').toBe(false);
 
-    console.log(`Downloaded DXF: ${filename}, ${stat.size} bytes, ${result.entities} entities, version ${result.version}`);
+    console.log(`Downloaded DXF: ${path.basename(savedPath)}, ${stat.size} bytes, ${result.entities} entities, version ${result.version}`);
     console.log(`Move validation: ${cmp.original.count} → ${cmp.edited.count} entities, position changed: ${!allSame}`);
   });
 
@@ -183,25 +184,7 @@ test.describe('Full Edit Flow', () => {
     await expect(page.locator('.op-item__type').first()).toBeVisible({ timeout: PLAN_TIMEOUT });
 
     // Apply + download
-    const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
-    await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
-    await applyBtn.click();
-
-    await expect(
-      page.locator('.preview__tab--active')
-    ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
-
-    const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
-    await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
-
-    const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
-    await downloadBtn.click();
-    const download = await downloadPromise;
-
-    const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
-    fs.mkdirSync(downloadDir, { recursive: true });
-    const savedPath = path.join(downloadDir, `delete_${download.suggestedFilename()}`);
-    await download.saveAs(savedPath);
+    const savedPath = await applyAndDownload(page, 'delete_');
 
     // Semantic validation: entity count decreased
     const originalPath = path.join(DXF_ZOO, 'r2000_blocks.dxf');
@@ -235,25 +218,7 @@ test.describe('Full Edit Flow', () => {
     await expect(page.locator('.message--ai').first()).toBeVisible();
 
     // Apply + download
-    const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
-    await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
-    await applyBtn.click();
-
-    await expect(
-      page.locator('.preview__tab--active')
-    ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
-
-    const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
-    await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
-
-    const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
-    await downloadBtn.click();
-    const download = await downloadPromise;
-
-    const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
-    fs.mkdirSync(downloadDir, { recursive: true });
-    const savedPath = path.join(downloadDir, `edittext_${download.suggestedFilename()}`);
-    await download.saveAs(savedPath);
+    const savedPath = await applyAndDownload(page, 'edittext_');
 
     // Semantic validation: text content changed
     const originalPath = path.join(DXF_ZOO, 'r2000_blocks.dxf');
@@ -264,7 +229,6 @@ test.describe('Full Edit Flow', () => {
     expect(cmp.edited.count).toBe(cmp.original.count);
     // At least one TEXT value differs
     const origTexts = new Set(cmp.original.texts);
-    const editedTexts = new Set(cmp.edited.texts);
     const textsIdentical = cmp.edited.texts.length === cmp.original.texts.length
       && cmp.edited.texts.every(t => origTexts.has(t));
     expect(textsIdentical, 'edit_text should change at least one TEXT value').toBe(false);

--- a/web/frontend/e2e/edit-flow.spec.js
+++ b/web/frontend/e2e/edit-flow.spec.js
@@ -36,6 +36,41 @@ except Exception as e:
   }
 }
 
+/**
+ * Compare two DXF files semantically using ezdxf.
+ * Returns entity counts, INSERT positions (as [x,y] rounded to 2dp), and TEXT values for both.
+ */
+function compareDxf(originalPath, editedPath) {
+  try {
+    const script = `
+import json, ezdxf
+
+def extract(path):
+    doc = ezdxf.readfile(path)
+    msp = doc.modelspace()
+    entities = list(msp)
+    inserts = []
+    texts = []
+    for e in entities:
+        if e.dxftype() == "INSERT":
+            pos = e.dxf.insert
+            inserts.append([round(pos.x, 2), round(pos.y, 2)])
+        elif e.dxftype() in ("TEXT", "MTEXT"):
+            t = e.dxf.text if e.dxftype() == "TEXT" else e.text
+            texts.append(t)
+    return {"count": len(entities), "inserts": inserts, "insert_count": len(inserts), "texts": texts, "text_count": len(texts)}
+
+orig = extract("${originalPath.replace(/\\/g, '\\\\')}")
+edited = extract("${editedPath.replace(/\\/g, '\\\\')}")
+print(json.dumps({"original": orig, "edited": edited}))
+`;
+    const out = execSync(`${PYTHON} -c '${script}'`, { encoding: 'utf-8', timeout: 10_000 });
+    return JSON.parse(out.trim());
+  } catch (e) {
+    return { error: e.message };
+  }
+}
+
 test.describe('Full Edit Flow', () => {
   test('upload → prompt "move" → see ops → apply → download valid edited DXF', async ({ page }) => {
     await page.goto('/');
@@ -111,11 +146,26 @@ test.describe('Full Edit Flow', () => {
     expect(result.valid, `DXF validation failed: ${result.error || 'unknown'}`).toBe(true);
     expect(result.entities).toBeGreaterThan(0);
 
-    // Original has 50 entities — edited should still have entities (move doesn't delete)
+    // Semantic validation: compare original vs edited DXF
+    const originalPath = path.join(DXF_ZOO, 'r2000_blocks.dxf');
+    const cmp = compareDxf(originalPath, savedPath);
+    expect(cmp.error).toBeUndefined();
+
+    // Move preserves entity count (doesn't add or delete)
+    expect(cmp.edited.count).toBe(cmp.original.count);
+    // Move preserves INSERT count
+    expect(cmp.edited.insert_count).toBe(cmp.original.insert_count);
+    // At least one INSERT position must differ (the moved entity)
+    const origPositions = new Set(cmp.original.inserts.map(p => p.join(',')));
+    const editedPositions = new Set(cmp.edited.inserts.map(p => p.join(',')));
+    const allSame = [...editedPositions].every(p => origPositions.has(p));
+    expect(allSame, 'Move should change at least one INSERT position').toBe(false);
+
     console.log(`Downloaded DXF: ${filename}, ${stat.size} bytes, ${result.entities} entities, version ${result.version}`);
+    console.log(`Move validation: ${cmp.original.count} → ${cmp.edited.count} entities, position changed: ${!allSame}`);
   });
 
-  test('upload → prompt "delete" → operations show type badges', async ({ page }) => {
+  test('upload → prompt "delete" → apply → download → fewer entities', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h2')).toContainText('Upload a drawing', { timeout: 15_000 });
 
@@ -131,9 +181,43 @@ test.describe('Full Edit Flow', () => {
 
     // Operation type badge visible
     await expect(page.locator('.op-item__type').first()).toBeVisible({ timeout: PLAN_TIMEOUT });
+
+    // Apply + download
+    const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
+    await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
+    await applyBtn.click();
+
+    await expect(
+      page.locator('.preview__tab--active')
+    ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
+
+    const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
+    await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
+
+    const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
+    await downloadBtn.click();
+    const download = await downloadPromise;
+
+    const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
+    fs.mkdirSync(downloadDir, { recursive: true });
+    const savedPath = path.join(downloadDir, `delete_${download.suggestedFilename()}`);
+    await download.saveAs(savedPath);
+
+    // Semantic validation: entity count decreased
+    const originalPath = path.join(DXF_ZOO, 'r2000_blocks.dxf');
+    const cmp = compareDxf(originalPath, savedPath);
+    expect(cmp.error).toBeUndefined();
+
+    expect(cmp.edited.count).toBeLessThan(cmp.original.count);
+    // LLM may delete the block INSERT or its TEXT label — either count should decrease
+    const fewerInserts = cmp.edited.insert_count < cmp.original.insert_count;
+    const fewerTexts = cmp.edited.text_count < cmp.original.text_count;
+    expect(fewerInserts || fewerTexts, 'Delete should remove at least one INSERT or TEXT').toBe(true);
+
+    console.log(`Delete validation: ${cmp.original.count} → ${cmp.edited.count} entities, inserts ${cmp.original.insert_count} → ${cmp.edited.insert_count}, texts ${cmp.original.text_count} → ${cmp.edited.text_count}`);
   });
 
-  test('upload → prompt "rename text" → edit_text op planned', async ({ page }) => {
+  test('upload → prompt "rename text" → apply → download → text changed', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('h2')).toContainText('Upload a drawing', { timeout: 15_000 });
 
@@ -149,5 +233,45 @@ test.describe('Full Edit Flow', () => {
 
     await expect(page.locator('.op-item').first()).toBeVisible({ timeout: PLAN_TIMEOUT });
     await expect(page.locator('.message--ai').first()).toBeVisible();
+
+    // Apply + download
+    const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
+    await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
+    await applyBtn.click();
+
+    await expect(
+      page.locator('.preview__tab--active')
+    ).toHaveText('Edited', { timeout: APPLY_TIMEOUT });
+
+    const downloadBtn = page.locator('button').filter({ hasText: 'Download Edited DXF' });
+    await expect(downloadBtn).toBeVisible({ timeout: 5_000 });
+
+    const downloadPromise = page.waitForEvent('download', { timeout: APPLY_TIMEOUT });
+    await downloadBtn.click();
+    const download = await downloadPromise;
+
+    const downloadDir = path.join(PROJECT_ROOT, 'web', 'frontend', 'test-results');
+    fs.mkdirSync(downloadDir, { recursive: true });
+    const savedPath = path.join(downloadDir, `edittext_${download.suggestedFilename()}`);
+    await download.saveAs(savedPath);
+
+    // Semantic validation: text content changed
+    const originalPath = path.join(DXF_ZOO, 'r2000_blocks.dxf');
+    const cmp = compareDxf(originalPath, savedPath);
+    expect(cmp.error).toBeUndefined();
+
+    // edit_text preserves entity count (no add/delete)
+    expect(cmp.edited.count).toBe(cmp.original.count);
+    // At least one TEXT value differs
+    const origTexts = new Set(cmp.original.texts);
+    const editedTexts = new Set(cmp.edited.texts);
+    const textsIdentical = cmp.edited.texts.length === cmp.original.texts.length
+      && cmp.edited.texts.every(t => origTexts.has(t));
+    expect(textsIdentical, 'edit_text should change at least one TEXT value').toBe(false);
+    // The word "UPDATED" should appear in some text entity (case-insensitive)
+    const hasUpdated = cmp.edited.texts.some(t => t.toUpperCase().includes('UPDATED'));
+    expect(hasUpdated, 'Edited text should contain "UPDATED"').toBe(true);
+
+    console.log(`Edit text validation: ${cmp.original.count} → ${cmp.edited.count} entities, texts changed: ${!textsIdentical}, has UPDATED: ${hasUpdated}`);
   });
 });

--- a/web/frontend/src/components/FileUpload.jsx
+++ b/web/frontend/src/components/FileUpload.jsx
@@ -86,6 +86,9 @@ export default function FileUpload({ onUpload, loading }) {
           aria-hidden="true"
         />
       </div>
+      <p className="upload-zone__hint">
+        Accepts .dxf and .pdf files. For .dwg files, export as DXF from your CAD software.
+      </p>
       {error && <p className="input-group__error mt-2" role="alert">{error}</p>}
     </div>
   );

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -204,6 +204,13 @@
   margin-top: var(--space-1);
 }
 
+.upload-zone__hint {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin-top: var(--space-2);
+  text-align: center;
+}
+
 /* Chat */
 .chat {
   display: flex;


### PR DESCRIPTION
## Summary
- E2E tests now verify edits actually happened (move moved, delete deleted, text changed) via `compareDxf` helper that loads both original and edited DXF with ezdxf
- GUI tests get matching semantic checks through the PipelineWorker/QThread path, ensuring the desktop app produces identical results
- DWG upload guidance note added to FileUpload component

## Test plan
- [x] E2E tests pass locally (3 passed, 27.7s, mock LLM)
- [x] Unit + integration tests pass (453 passed, 29s)
- [ ] GUI semantic tests run in CI gui-test job (PySide6 required)
- [ ] Production E2E run against real Gemini API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end semantic checks for move, delete, and edit-text flows, including automatic apply-and-download of edited DXF files for validation.

* **Style**
  * Enhanced upload zone styling to improve visibility and readability of file format information.

* **New UI**
  * Added a helpful hint under the upload area indicating accepted file types (.dxf, .pdf) and guidance for .dwg export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->