### PR TITLE
fix: enable OpenTelemetry tracing in production

### DIFF
--- a/web/backend/cloudbuild.yaml
+++ b/web/backend/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
       - '--timeout'
       - '300'
       - '--set-env-vars'
-      - 'CAD_LLM_PROVIDER=gemini,CAD_GCP_PROJECT=$PROJECT_ID'
+      - 'CAD_LLM_PROVIDER=gemini,CAD_GCP_PROJECT=$PROJECT_ID,OTEL_ENABLED=1,OTEL_EXPORTER=gcp-trace'
 
 images:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/cad-dxf-agent/web-backend:$SHORT_SHA'


### PR DESCRIPTION
## Summary
- Add `OTEL_ENABLED=1,OTEL_EXPORTER=gcp-trace` to Cloud Run env vars in `cloudbuild.yaml`
- The otel module and `opentelemetry-exporter-gcp-trace` package were already installed — tracing was silently disabled because the env vars were never set
- Cloud Run provides ADC automatically, so no credentials config needed

## Test plan
- [x] Verified `gcp-trace` exporter is in `web/backend/requirements.txt`
- [x] Verified `init_otel()` is called in web backend lifespan
- [ ] After deploy: check Google Cloud Trace console for `cad-dxf-web` spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to enable OpenTelemetry tracing for enhanced observability and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->