### PR TITLE
fix(ops): dedicated Cloud Run SA + OTEL observability

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -43,11 +43,14 @@ jobs:
             CAD_LLM_PROVIDER=gemini
             CAD_GCP_PROJECT=${{ env.GCP_PROJECT }}
             CAD_WEB_CORS_ORIGIN=https://cad-dxf-agent.web.app
+            OTEL_ENABLED=1
+            OTEL_EXPORTER=gcp-trace
           flags: |
             --allow-unauthenticated
             --memory=1Gi
             --cpu=1
             --timeout=300
+            --service-account=cad-dxf-web-run@${{ env.GCP_PROJECT }}.iam.gserviceaccount.com
 
       - name: Show backend URL
         run: echo "Backend deployed to ${{ steps.deploy.outputs.url }}"

--- a/web/backend/Dockerfile
+++ b/web/backend/Dockerfile
@@ -25,4 +25,4 @@ COPY web/backend/ ./web/backend/
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["uvicorn", "web.backend.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "web.backend.main:app", "--host", "0.0.0.0", "--port", "8080", "--log-level", "info"]

--- a/web/backend/cloudbuild.yaml
+++ b/web/backend/cloudbuild.yaml
@@ -31,6 +31,8 @@ steps:
       - '1'
       - '--timeout'
       - '300'
+      - '--service-account'
+      - 'cad-dxf-web-run@$PROJECT_ID.iam.gserviceaccount.com'
       - '--set-env-vars'
       - 'CAD_LLM_PROVIDER=gemini,CAD_GCP_PROJECT=$PROJECT_ID,OTEL_ENABLED=1,OTEL_EXPORTER=gcp-trace'
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -40,6 +40,8 @@ session_mgr = SessionManager()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
     from cad_dxf_agent.otel import init_otel
 
     init_otel(service_name="cad-dxf-web")


### PR DESCRIPTION
## Summary

- **IAM**: Replace Compute Engine default SA with dedicated `cad-dxf-web-run` runtime SA (least-privilege: `aiplatform.user` + `cloudtrace.agent`)
- **OTEL**: Add missing `OTEL_ENABLED` + `OTEL_EXPORTER` env vars to GitHub Actions deploy workflow
- **Logging**: Configure Python root logger to INFO level so OTEL init messages appear in Cloud Run logs

## What changed

| File | Change |
|------|--------|
| `web/backend/cloudbuild.yaml` | `--service-account` flag for Cloud Build deploys |
| `.github/workflows/deploy-web.yml` | `--service-account` flag + OTEL env vars for CI deploys |
| `web/backend/main.py` | `logging.basicConfig(level=INFO)` in lifespan |
| `web/backend/Dockerfile` | `--log-level info` on uvicorn CMD |

## IAM changes (already applied)

- Created `cad-dxf-web-run@cad-dxf-agent.iam.gserviceaccount.com` with `aiplatform.user` + `cloudtrace.agent`
- Granted CI SA (`cad-dxf-agent-ci`) `run.admin`, `iam.serviceAccountUser`, `storage.admin`, `artifactregistry.writer`
- Compute Engine default SA roles to be revoked after merge

## Verification

- Cloud Run service confirmed using new SA: `cad-dxf-web-run@cad-dxf-agent.iam.gserviceaccount.com`
- Health check: `{"status":"ok","service":"cad-dxf-web"}`
- **10/10 E2E Playwright tests pass** (upload-dxf, upload-pdf, upload-errors, edit-flow move/delete/rename)
- OTEL logs: `OTel: using Google Cloud Trace exporter` + `OpenTelemetry tracing initialized`
- Cloud Trace: traces reaching API (5 found, no PermissionDenied errors)

## Test plan

- [x] `gcloud run services describe` confirms new SA
- [x] Health check passes
- [x] E2E Playwright tests: 10/10 pass
- [x] OTEL init messages visible in Cloud Run logs
- [x] No trace permission errors in logs
- [ ] CI pipeline runs clean on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)