### PR TITLE
fix(web): surface silent render failures

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -179,8 +179,10 @@ async def upload(
         render_result = render_dxf_to_png(dxf_path, session_dir / "original.png")
         if render_result.success:
             session.original_render = render_result.output_path
+        else:
+            logger.warning("Original render returned failure: %s", render_result.error)
     except Exception as e:
-        logger.warning("Original render failed (non-fatal): %s", e)
+        logger.warning("Original render failed (non-fatal): %s", e, exc_info=True)
 
     return {
         "session_id": session.session_id,
@@ -298,12 +300,18 @@ async def apply_changes(body: ApplyRequest, user: dict = Depends(get_user)):
             )
             if render_result.success:
                 session.edited_render = render_result.output_path
+            else:
+                logger.warning("Edited render returned failure: %s", render_result.error)
+                session.edited_render = None
         except Exception as e:
-            logger.warning("Edited render failed (non-fatal): %s", e)
+            logger.warning("Edited render failed (non-fatal): %s", e, exc_info=True)
+            session.edited_render = None
 
+        render_available = session.edited_render is not None and session.edited_render.exists()
         success_count = sum(1 for r in results if r.success)
         return {
             "message": f"Applied {success_count}/{len(results)} operations.",
+            "render_available": render_available,
             "results": [
                 {"success": r.success, "message": r.message if hasattr(r, "message") else ""}
                 for r in results

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -25,8 +25,8 @@ export function useSession() {
         const blob = await getRenderBlob(data.session_id, 'original');
         const url = URL.createObjectURL(blob);
         setPreviewUrls((prev) => ({ ...prev, original: url }));
-      } catch {
-        // Render not available yet — that's ok
+      } catch (renderErr) {
+        console.warn('[cad] Original render fetch failed:', renderErr.message);
       }
       setMessages([{ role: 'system', text: `Loaded ${file.name} (${data.file_info.entity_count} entities, ${data.file_info.layer_count} layers)` }]);
       setOperations([]);
@@ -82,8 +82,12 @@ export function useSession() {
         const blob = await getRenderBlob(sessionId, 'edited');
         const url = URL.createObjectURL(blob);
         setPreviewUrls((prev) => ({ ...prev, edited: url }));
-      } catch {
-        // Edited render not available — that's ok
+      } catch (renderErr) {
+        console.warn('[cad] Edited render fetch failed:', renderErr.message);
+        setMessages((prev) => [...prev, {
+          role: 'system',
+          text: 'Preview not available — download the edited DXF to view.',
+        }]);
       }
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- **Frontend:** Replace bare `catch {}` in `useSession.js` with `console.warn('[cad] ...')` logging so render fetch errors appear in devtools instead of vanishing silently. Edited render failure also shows a user-facing message ("Preview not available — download the edited DXF to view.")
- **Backend:** Log `render_result.error` when renderer returns `success=False`, add `exc_info=True` for full stack traces in Cloud Run logs, and return `render_available` boolean in the `/api/apply` response

## Test plan
- [x] `pytest tests/web/ -v` — 75/75 pass
- [x] `npm run build` — frontend compiles cleanly
- [ ] Deploy to staging, open browser devtools Console, upload DXF → verify `[cad]` log messages appear
- [ ] Plan + Apply → check if edited preview renders; if not, console shows the reason and chat shows fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging and handling when original or edited previews fail.
  * When preview fetch fails, users now see a system message recommending downloading the edited DXF.

* **New Features**
  * Preview availability is now reported back so the app can indicate whether an edited render is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->