### PR TITLE
feat: chat UX improvements — suggestions, history, smart prompts

### DIFF
--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -64,7 +64,12 @@ class AgentProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False  # Uses GCP credentials
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Run the tool-use agent loop to produce a ChangeSet."""
         with tracer.start_as_current_span("cad.agent_plan") as span:
             span.set_attribute("cad.agent.model", self._model_name)
@@ -402,7 +407,12 @@ class MockAgentProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Simulate agent tool-use with deterministic tool calls."""
         from ..models.cad_schema import (
             DrawingContext,

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -82,7 +82,8 @@ class AgentProvider(PlannerProvider):
 
             # Run the agent loop
             model = self._get_model()
-            chat = model.start_chat()
+            chat_history = self._build_chat_history(conversation_history)
+            chat = model.start_chat(history=chat_history)
 
             # Per-turn timeout: total timeout / max turns
             per_turn_timeout = max(settings.planner_timeout // MAX_AGENT_TURNS, 5)
@@ -248,6 +249,21 @@ class AgentProvider(PlannerProvider):
                 ) from err
 
         return self._model
+
+    @staticmethod
+    def _build_chat_history(conversation_history: list[dict] | None) -> list:
+        """Convert conversation_history dicts to Vertex AI Content objects."""
+        if not conversation_history:
+            return []
+        from vertexai.generative_models import Content, Part
+
+        return [
+            Content(
+                role="user" if entry.get("role") == "user" else "model",
+                parts=[Part.from_text(entry.get("text", ""))],
+            )
+            for entry in conversation_history
+        ]
 
     def _build_initial_prompt(self, prompt: str, drawing_context: dict) -> str:
         """Build the initial message with compact context and optional vision.

--- a/src/cad_dxf_agent/llm/gemini_key_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_key_provider.py
@@ -37,7 +37,12 @@ class GeminiKeyProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return True
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         with tracer.start_as_current_span("cad.gemini_key_plan") as span:
             span.set_attribute("cad.gemini.model", self._model_name)
 
@@ -45,7 +50,11 @@ class GeminiKeyProvider(PlannerProvider):
             context_json = json.dumps(drawing_context, indent=2, default=str)
             text_prompt = format_planner_prompt(prompt, context_json)
 
-            raw_response = model.generate_content(text_prompt).text
+            # Use chat session for multi-turn, plain generate for single-turn
+            if conversation_history:
+                raw_response = self._chat_generate(model, conversation_history, text_prompt)
+            else:
+                raw_response = model.generate_content(text_prompt).text
             span.set_attribute("cad.gemini.response_length", len(raw_response))
 
             try:
@@ -70,6 +79,18 @@ class GeminiKeyProvider(PlannerProvider):
                 span.set_attribute("cad.ops.count", changeset.op_count)
                 span.set_attribute("cad.gemini.retried", True)
                 return changeset
+
+    def _chat_generate(self, model, conversation_history: list[dict], text_prompt: str) -> str:
+        """Send message via chat session with prior conversation history."""
+        history = []
+        for entry in conversation_history:
+            role = "user" if entry.get("role") == "user" else "model"
+            history.append({"role": role, "parts": [entry.get("text", "")]})
+
+        chat = model.start_chat(history=history)
+        response = chat.send_message(text_prompt)
+        text: str = response.text
+        return text
 
     def _get_model(self):
         if self._model is not None:

--- a/src/cad_dxf_agent/llm/gemini_key_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_key_provider.py
@@ -82,10 +82,13 @@ class GeminiKeyProvider(PlannerProvider):
 
     def _chat_generate(self, model, conversation_history: list[dict], text_prompt: str) -> str:
         """Send message via chat session with prior conversation history."""
-        history = []
-        for entry in conversation_history:
-            role = "user" if entry.get("role") == "user" else "model"
-            history.append({"role": role, "parts": [entry.get("text", "")]})
+        history = [
+            {
+                "role": "user" if e.get("role") == "user" else "model",
+                "parts": [e.get("text", "")],
+            }
+            for e in conversation_history
+        ]
 
         chat = model.start_chat(history=history)
         response = chat.send_message(text_prompt)

--- a/src/cad_dxf_agent/llm/gemini_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_provider.py
@@ -59,6 +59,7 @@ class GeminiProvider(PlannerProvider):
         self,
         prompt: str,
         drawing_context: dict,
+        conversation_history: list[dict] | None = None,
         image_path: str | Path | None = None,
     ) -> ChangeSet:
         """Generate a ChangeSet from prompt + drawing context + optional image.
@@ -66,6 +67,7 @@ class GeminiProvider(PlannerProvider):
         Args:
             prompt: User's natural-language edit request.
             drawing_context: JSON-serializable drawing context.
+            conversation_history: Optional prior conversation turns for multi-turn context.
             image_path: Optional path to a PNG render of the drawing.
 
         Returns:
@@ -78,8 +80,11 @@ class GeminiProvider(PlannerProvider):
             model = self._get_model()
             contents = self._build_contents(prompt, drawing_context, image_path)
 
-            # First attempt
-            raw_response = self._call_gemini(model, contents)
+            # Use chat session for multi-turn, plain generate for single-turn
+            if conversation_history:
+                raw_response = self._call_gemini_chat(model, conversation_history, contents)
+            else:
+                raw_response = self._call_gemini(model, contents)
             span.set_attribute("cad.gemini.response_length", len(raw_response))
 
             try:
@@ -178,6 +183,34 @@ class GeminiProvider(PlannerProvider):
         parts.append(text_prompt)
 
         return parts
+
+    def _call_gemini_chat(
+        self, model, conversation_history: list[dict], current_contents: list
+    ) -> str:
+        """Call Gemini via chat session with prior conversation history.
+
+        Converts conversation_history entries to Gemini Content objects,
+        starts a chat with that history, then sends the current message.
+        """
+        from vertexai.generative_models import Content, Part  # type: ignore[import-untyped]
+
+        history = []
+        for entry in conversation_history:
+            role = "user" if entry.get("role") == "user" else "model"
+            history.append(
+                Content(role=role, parts=[Part.from_text(entry.get("text", ""))])
+            )
+
+        chat = model.start_chat(history=history)
+        response = chat.send_message(current_contents)
+
+        try:
+            text: str = response.text
+        except ValueError as e:
+            raise ValueError(f"Gemini response blocked: {e}") from e
+        if not text:
+            raise ValueError("Gemini returned empty response")
+        return text
 
     def _call_gemini(self, model, contents: list) -> str:
         """Call Gemini and return the text response.

--- a/src/cad_dxf_agent/llm/gemini_provider.py
+++ b/src/cad_dxf_agent/llm/gemini_provider.py
@@ -194,12 +194,13 @@ class GeminiProvider(PlannerProvider):
         """
         from vertexai.generative_models import Content, Part  # type: ignore[import-untyped]
 
-        history = []
-        for entry in conversation_history:
-            role = "user" if entry.get("role") == "user" else "model"
-            history.append(
-                Content(role=role, parts=[Part.from_text(entry.get("text", ""))])
+        history = [
+            Content(
+                role="user" if e.get("role") == "user" else "model",
+                parts=[Part.from_text(e.get("text", ""))],
             )
+            for e in conversation_history
+        ]
 
         chat = model.start_chat(history=history)
         response = chat.send_message(current_contents)

--- a/src/cad_dxf_agent/llm/mock_provider.py
+++ b/src/cad_dxf_agent/llm/mock_provider.py
@@ -24,7 +24,12 @@ class MockProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Return mock operations based on simple keyword matching in the prompt.
 
         This is NOT a real planner. It exists so the full pipeline can be tested

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -232,7 +232,8 @@ def run_planner(
                             break
                         corrective = _format_validation_feedback(prompt, result.blockers)
                         changeset = _call_with_timeout(
-                            provider, corrective, drawing_context, timeout
+                            provider, corrective, drawing_context, timeout,
+                            conversation_history,
                         )
 
                 span.set_attribute("cad.ops.count", changeset.op_count)

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -103,10 +103,13 @@ def _call_with_timeout(
     prompt: str,
     drawing_context: dict,
     timeout: int,
+    conversation_history: list[dict] | None = None,
 ) -> ChangeSet:
     """Call provider.plan() with a wall-clock timeout."""
     with ThreadPoolExecutor(max_workers=1) as pool:
-        future = pool.submit(provider.plan, prompt, drawing_context)
+        future = pool.submit(
+            provider.plan, prompt, drawing_context, conversation_history
+        )
         try:
             return future.result(timeout=timeout)
         except FuturesTimeoutError as exc:
@@ -138,6 +141,7 @@ def run_planner(
     image_path: Path | None = None,
     context: DrawingContext | None = None,
     rule_config: RuleConfig | None = None,
+    conversation_history: list[dict] | None = None,
 ) -> ChangeSet:
     """Run the planner to generate a changeset from a user prompt.
 
@@ -198,7 +202,9 @@ def run_planner(
 
         for attempt in range(1, max_retries + 1):
             try:
-                changeset = _call_with_timeout(provider, prompt, drawing_context, timeout)
+                changeset = _call_with_timeout(
+                    provider, prompt, drawing_context, timeout, conversation_history
+                )
                 span.set_attribute("cad.planner.attempt", attempt)
                 logger.info(
                     "Planner returned %d operation(s) on attempt %d for prompt: %s",

--- a/src/cad_dxf_agent/llm/prompt_templates.py
+++ b/src/cad_dxf_agent/llm/prompt_templates.py
@@ -3,16 +3,26 @@
 from __future__ import annotations
 
 SYSTEM_PROMPT = """You are a CAD editing planner. Given a drawing context and a user request,
-return a JSON array of structured edit operations.
+return a JSON object with structured edit operations.
+
+SUPPORTED OPERATIONS (these are the ONLY things you can do):
+- move_entity: Move an entity by (dx, dy) in drawing units
+- edit_text: Change the text content of a TEXT or MTEXT entity
+- delete_entity: Remove an entity from the drawing
+- add_block: Insert a named block reference at a position
+
+LIMITATIONS (be upfront about these):
+- You CANNOT rotate, mirror, scale, or stretch entities
+- You CANNOT create freeform geometry (lines, arcs, polylines)
+- You CANNOT modify dimensions, hatches, or viewport settings
+- You CANNOT edit entities on protected layers (TITLE, TITLEBLOCK, SEAL, REVISION)
 
 RULES:
-- You may ONLY return operations of these types: move_entity, edit_text, delete_entity, add_block
-- You must reference entities by their handle
-- You must NEVER target entities on protected layers
+- Reference entities by their handle from the drawing context
 - All coordinates are in drawing units
-- Return ONLY valid JSON matching the operations schema
+- NEVER target entities on protected layers
 
-OPERATIONS SCHEMA:
+RESPONSE FORMAT — always return valid JSON:
 {{
   "operations": [
     {{
@@ -22,7 +32,8 @@ OPERATIONS SCHEMA:
       "params": {{}}
     }}
   ],
-  "revision_label": "brief description of changes"
+  "revision_label": "brief description of changes",
+  "message": "optional explanation to show the user"
 }}
 
 PARAMS BY OP TYPE:
@@ -31,6 +42,23 @@ PARAMS BY OP TYPE:
 - delete_entity: {{}}
 - add_block: {{"block_name": "str", "insert_point": {{"x": n, "y": n}},
   "scale": n, "rotation": n}}
+
+WHEN THE USER ASKS A QUESTION OR REQUESTS SOMETHING UNSUPPORTED:
+- Set "operations" to []
+- Put a helpful explanation in "message"
+- Describe what you CAN do if relevant
+
+EXAMPLE — unsupported request:
+User: "Rotate the north wall 45 degrees"
+Response:
+{{"operations": [], "message": "I cannot rotate entities. I can move, \
+edit text, delete, or add blocks. Try moving the wall instead."}}
+
+EXAMPLE — question:
+User: "What layers are in this drawing?"
+Response:
+{{"operations": [], "message": "This drawing has layers: STRUCTURAL \
+(42 entities), FOUNDATION (18 entities), TITLE (protected)."}}
 """
 
 AGENT_SYSTEM_PROMPT = """You are a structural engineering CAD editing assistant. You help

--- a/src/cad_dxf_agent/llm/providers.py
+++ b/src/cad_dxf_agent/llm/providers.py
@@ -11,12 +11,19 @@ class PlannerProvider(ABC):
     """Abstract base class for LLM planner providers."""
 
     @abstractmethod
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Generate a structured changeset from a user prompt and drawing context.
 
         Args:
             prompt: The user's natural-language edit request.
             drawing_context: JSON-serializable drawing context from semantic_model.
+            conversation_history: Optional prior conversation turns for multi-turn context.
+                Each entry: {"role": "user"|"model", "text": "..."}.
 
         Returns:
             A validated ChangeSet with structured operations.

--- a/src/cad_dxf_agent/llm/proxy_client.py
+++ b/src/cad_dxf_agent/llm/proxy_client.py
@@ -59,7 +59,12 @@ class ProxyAgentProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False  # Uses license key, not API key
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Run tool-use agent loop through the Cloud Run proxy."""
         with tracer.start_as_current_span("cad.proxy_agent_plan") as span:
             span.set_attribute("cad.agent.model", self._model_name)

--- a/src/cad_dxf_agent/llm/proxy_client.py
+++ b/src/cad_dxf_agent/llm/proxy_client.py
@@ -75,8 +75,15 @@ class ProxyAgentProvider(PlannerProvider):
             # Build initial prompt
             initial_prompt = self._build_initial_prompt(prompt, drawing_context)
 
-            # Conversation history for the proxy
-            contents: list[dict[str, Any]] = [{"role": "user", "parts": [{"text": initial_prompt}]}]
+            # Build conversation contents (prior history + current prompt)
+            contents: list[dict[str, Any]] = []
+            if conversation_history:
+                for entry in conversation_history:
+                    contents.append({
+                        "role": entry.get("role", "user"),
+                        "parts": [{"text": entry.get("text", "")}],
+                    })
+            contents.append({"role": "user", "parts": [{"text": initial_prompt}]})
 
             # Build tool declarations for the proxy
             tool_declarations = [

--- a/src/cad_dxf_agent/llm/response_parser.py
+++ b/src/cad_dxf_agent/llm/response_parser.py
@@ -50,4 +50,5 @@ def parse_planner_response(raw_response: str, prompt: str = "") -> ChangeSet:
         operations=ops,
         prompt=data.get("prompt", prompt),
         revision_label=data.get("revision_label"),
+        message=data.get("message"),
     )

--- a/src/cad_dxf_agent/models/ops_schema.py
+++ b/src/cad_dxf_agent/models/ops_schema.py
@@ -46,6 +46,10 @@ class ChangeSet(BaseModel):
     operations: list[EditOperation] = Field(default_factory=list)
     prompt: str = ""
     revision_label: str | None = None
+    message: str | None = Field(
+        default=None,
+        description="Optional message from the LLM (e.g. explanation when no ops are returned)",
+    )
     planner_trace: Any = Field(default=None, exclude=True)
 
     @property

--- a/tests/helpers/scripted_provider.py
+++ b/tests/helpers/scripted_provider.py
@@ -42,7 +42,12 @@ class ScriptedAgentProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         """Execute scripted tool calls through the real ToolExecutor."""
         context = _reconstruct_context(drawing_context)
         executor = ToolExecutor(context, settings.protected_layers)

--- a/tests/unit/test_planner_retry.py
+++ b/tests/unit/test_planner_retry.py
@@ -27,7 +27,12 @@ class FailNTimesProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         self._attempts += 1
         if self._attempts <= self._fail_count:
             raise ValueError(f"Simulated failure #{self._attempts}")
@@ -45,7 +50,12 @@ class AlwaysFailProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         raise RuntimeError("Permanent failure")
 
 

--- a/tests/unit/test_planner_retry.py
+++ b/tests/unit/test_planner_retry.py
@@ -27,7 +27,7 @@ class FailNTimesProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
         self._attempts += 1
         if self._attempts <= self._fail_count:
             raise ValueError(f"Simulated failure #{self._attempts}")
@@ -45,7 +45,7 @@ class AlwaysFailProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
         raise RuntimeError("Permanent failure")
 
 

--- a/tests/unit/test_planner_timeout.py
+++ b/tests/unit/test_planner_timeout.py
@@ -27,7 +27,7 @@ class SlowProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
         time.sleep(self._delay)
         return ChangeSet(prompt=prompt)
 
@@ -43,7 +43,7 @@ class FastProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict) -> ChangeSet:
+    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
         return ChangeSet(prompt=prompt, operations=[])
 
 

--- a/tests/unit/test_planner_timeout.py
+++ b/tests/unit/test_planner_timeout.py
@@ -27,7 +27,12 @@ class SlowProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         time.sleep(self._delay)
         return ChangeSet(prompt=prompt)
 
@@ -43,7 +48,12 @@ class FastProvider(PlannerProvider):
     def requires_api_key(self) -> bool:
         return False
 
-    def plan(self, prompt: str, drawing_context: dict, conversation_history: list[dict] | None = None) -> ChangeSet:
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
         return ChangeSet(prompt=prompt, operations=[])
 
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -239,15 +239,20 @@ async def plan(body: PlanRequest, user: dict = Depends(get_user)):
             summary_parts.append(op_info["description"])
         summary = "; ".join(summary_parts) if summary_parts else "No operations planned."
 
+        # Use LLM message if available and no operations were planned
+        llm_message = getattr(changeset, "message", None)
+
         # Track conversation history for multi-turn context (cap at 10 entries)
+        history_text = llm_message if llm_message else summary
         session.conversation_history.append({"role": "user", "text": body.prompt})
-        session.conversation_history.append({"role": "model", "text": summary})
+        session.conversation_history.append({"role": "model", "text": history_text})
         if len(session.conversation_history) > 10:
             session.conversation_history = session.conversation_history[-10:]
 
         return {
             "operations": operations,
             "summary": summary,
+            "message": llm_message,
             "validation": {
                 "blockers": [{"message": b.message} for b in validation.blockers],
                 "warnings": [{"message": w.message} for w in validation.warnings],

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -33,6 +33,11 @@ from .session import Session, SessionManager
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_CONVERSATION_HISTORY = 10  # Max user+model entries kept per session
+
+# ---------------------------------------------------------------------------
 # Session manager (singleton)
 # ---------------------------------------------------------------------------
 session_mgr = SessionManager()
@@ -246,8 +251,8 @@ async def plan(body: PlanRequest, user: dict = Depends(get_user)):
         history_text = llm_message if llm_message else summary
         session.conversation_history.append({"role": "user", "text": body.prompt})
         session.conversation_history.append({"role": "model", "text": history_text})
-        if len(session.conversation_history) > 10:
-            session.conversation_history = session.conversation_history[-10:]
+        if len(session.conversation_history) > MAX_CONVERSATION_HISTORY:
+            session.conversation_history = session.conversation_history[-MAX_CONVERSATION_HISTORY:]
 
         return {
             "operations": operations,

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -215,6 +215,7 @@ async def plan(body: PlanRequest, user: dict = Depends(get_user)):
             drawing_context=planner_context,
             context=session.context,
             rule_config=rule_config,
+            conversation_history=session.conversation_history or None,
         )
         session.changeset = changeset
 
@@ -237,6 +238,12 @@ async def plan(body: PlanRequest, user: dict = Depends(get_user)):
         for op_info in operations:
             summary_parts.append(op_info["description"])
         summary = "; ".join(summary_parts) if summary_parts else "No operations planned."
+
+        # Track conversation history for multi-turn context (cap at 10 entries)
+        session.conversation_history.append({"role": "user", "text": body.prompt})
+        session.conversation_history.append({"role": "model", "text": summary})
+        if len(session.conversation_history) > 10:
+            session.conversation_history = session.conversation_history[-10:]
 
         return {
             "operations": operations,

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -32,6 +32,7 @@ class Session:
     changeset: object | None = None
     context: object | None = None
     file_info: dict = field(default_factory=dict)
+    conversation_history: list[dict] = field(default_factory=list)
 
 
 class SessionManager:

--- a/web/frontend/src/components/ChatPanel.jsx
+++ b/web/frontend/src/components/ChatPanel.jsx
@@ -1,5 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
 
+const SUGGESTIONS = [
+  'Move column A1 24 feet east',
+  'Delete the north elevation note',
+  'Rename label FOOTING F1 to FOOTING F2',
+  'Add a column mark at grid B3',
+];
+
 export default function ChatPanel({ messages, onSend, loading, disabled }) {
   const [input, setInput] = useState('');
   const messagesEndRef = useRef(null);
@@ -39,9 +46,22 @@ export default function ChatPanel({ messages, onSend, loading, disabled }) {
           <div className="chat__empty">
             <p className="chat__empty-title">Describe your edit</p>
             <p className="chat__empty-text">
-              Upload a file, then tell the AI what to change.
-              For example: &ldquo;Move the north wall 6 inches south&rdquo;
+              I can move entities, edit text, delete elements, and add blocks.
             </p>
+            {!disabled && (
+              <div className="chat__suggestions">
+                {SUGGESTIONS.map((text) => (
+                  <button
+                    key={text}
+                    type="button"
+                    className="chat__suggestion"
+                    onClick={() => setInput(text)}
+                  >
+                    {text}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         ) : (
           messages.map((msg, i) => (
@@ -66,7 +86,7 @@ export default function ChatPanel({ messages, onSend, loading, disabled }) {
             value={input}
             onChange={handleInput}
             onKeyDown={handleKeyDown}
-            placeholder={disabled ? 'Upload a file first...' : 'Describe the edit...'}
+            placeholder={disabled ? 'Upload a file first...' : 'e.g. Move the north wall 6 inches south'}
             disabled={disabled || loading}
             rows={1}
             aria-label="Edit description"

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import { uploadFile, planEdit, applyChanges, downloadFile, getRenderBlob } from '../lib/api';
 
+const NO_CHANGES_MESSAGE = "I couldn't plan any changes. Try being more specific about which element to edit.";
+
 export function useSession() {
   const [sessionId, setSessionId] = useState(null);
   const [fileInfo, setFileInfo] = useState(null);
@@ -57,7 +59,7 @@ export function useSession() {
       if (ops.length === 0 && data.message) {
         aiText = data.message;
       } else if (ops.length === 0) {
-        aiText = "I couldn't plan any changes. Try being more specific about which element to edit.";
+        aiText = NO_CHANGES_MESSAGE;
       } else {
         aiText = data.summary || `${ops.length} operation(s) planned.`;
       }

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -51,7 +51,17 @@ export function useSession() {
       setOperations(ops);
       setSelectedOps(ops.map((_, i) => i));
       setValidation(data.validation || null);
-      setMessages((prev) => [...prev, { role: 'ai', text: data.summary || `${ops.length} operation(s) planned.` }]);
+
+      // Determine AI response text
+      let aiText;
+      if (ops.length === 0 && data.message) {
+        aiText = data.message;
+      } else if (ops.length === 0) {
+        aiText = "I couldn't plan any changes. Try being more specific about which element to edit.";
+      } else {
+        aiText = data.summary || `${ops.length} operation(s) planned.`;
+      }
+      setMessages((prev) => [...prev, { role: 'ai', text: aiText }]);
 
       if (data.preview_url) {
         setPreviewUrls((prev) => ({ ...prev, edited: data.preview_url }));

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -250,6 +250,34 @@
   max-width: 320px;
 }
 
+.chat__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  justify-content: center;
+  max-width: 400px;
+}
+
+.chat__suggestion {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-body);
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.chat__suggestion:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-light);
+}
+
 .chat__input-area {
   padding: var(--space-3) var(--space-4);
   border-top: 1px solid var(--border-default);


### PR DESCRIPTION
## Summary

- **Suggestion buttons**: 4 clickable pill-shaped prompt suggestions (one per supported op type) in the chat empty state. Buttons fill the textarea on click so users can edit before sending. Hidden when no file is loaded.
- **Conversation history**: Multi-turn context threaded through the planner pipeline. Session tracks up to 10 user/model entries. Gemini providers use `start_chat(history=...)` when history is present. Users can now say "move it further" and the LLM knows what "it" is.
- **Smart system prompt**: Expanded with explicit supported/unsupported operations, boundary statements, and few-shot examples. LLM can now return `{"operations": [], "message": "..."}` for helpful explanations instead of garbage when asked questions or given unsupported requests.

## Test plan

- [x] `npm run build` — frontend compiles
- [x] `ruff check src/ tests/` — lint clean
- [x] `mypy src/` — no type errors
- [x] 528 tests pass (unit + integration + web), 0 failures
- [ ] Manual: upload DXF → see suggestion buttons → click one → textarea fills → send
- [ ] Manual: multi-turn — "move column A1 east" → apply → "move it further" → LLM references A1
- [ ] Manual: "what can you do?" → LLM responds with capabilities, 0 ops
- [ ] Manual: "rotate everything" → LLM explains limitation, suggests alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-turn conversation support: chat history is preserved and sent to the planner
  * AI response messages: planners can return an optional explanatory "message" alongside operations
  * Chat suggestions: quick-access suggestion chips in the chat UI

* **Improvements**
  * Expanded system prompt and response schema with clearer operation taxonomy and guidance for unsupported requests
  * UI/UX tweaks: updated empty-state text, input placeholder, and no-op messaging logic
* **Chores**
  * Session history capped and surfaced in responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->