### PR TITLE
feat: deterministic DXF comparison engine (Phase 1)

### DIFF
--- a/src/cad_dxf_agent/core/comparison/__init__.py
+++ b/src/cad_dxf_agent/core/comparison/__init__.py
@@ -1,0 +1,18 @@
+"""DXF comparison engine — deterministic geometry diff between master and revision."""
+
+from .changelog import ChangeLog, generate_changelog
+from .classifier import classify_changes
+from .diff_overlay import write_diff_overlay
+from .engine import ComparisonEngine
+from .geometry import extract_snapshots
+from .matcher import match_entities
+
+__all__ = [
+    "ChangeLog",
+    "ComparisonEngine",
+    "classify_changes",
+    "extract_snapshots",
+    "generate_changelog",
+    "match_entities",
+    "write_diff_overlay",
+]

--- a/src/cad_dxf_agent/core/comparison/changelog.py
+++ b/src/cad_dxf_agent/core/comparison/changelog.py
@@ -1,0 +1,198 @@
+"""Change log generation — JSON and human-readable output."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, Field
+
+from ...models.comparison_schema import (
+    ChangeCategory,
+    ComparisonResult,
+    EntityChange,
+)
+
+
+class ChangeLogEntry(BaseModel):
+    """One entry in the change log."""
+
+    category: str
+    entity_type: str
+    layer: str
+    description: str
+    from_point: dict[str, float] | None = None
+    to_point: dict[str, float] | None = None
+
+
+class ChangeLog(BaseModel):
+    """Structured change log for a comparison result."""
+
+    generated_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    summary: dict[str, int] = Field(default_factory=dict)
+    entries: list[ChangeLogEntry] = Field(default_factory=list)
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize to JSON string."""
+        return self.model_dump_json(indent=indent)
+
+    def to_text(self) -> str:
+        """Generate human-readable change log."""
+        lines: list[str] = []
+        lines.append("=" * 60)
+        lines.append("CHANGE LOG")
+        lines.append(f"Generated: {self.generated_at}")
+        lines.append("=" * 60)
+        lines.append("")
+
+        # Summary
+        lines.append("SUMMARY")
+        lines.append("-" * 30)
+        for category, count in self.summary.items():
+            if count > 0:
+                lines.append(f"  {category.upper():12s}: {count}")
+        lines.append("")
+
+        # Group entries by category
+        by_category: dict[str, list[ChangeLogEntry]] = {}
+        for entry in self.entries:
+            by_category.setdefault(entry.category, []).append(entry)
+
+        for category in ("added", "removed", "modified", "moved"):
+            entries = by_category.get(category, [])
+            if not entries:
+                continue
+            lines.append(f"{category.upper()} ({len(entries)})")
+            lines.append("-" * 30)
+            for entry in entries:
+                lines.append(f"  - {entry.description}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+def generate_changelog(result: ComparisonResult) -> ChangeLog:
+    """Build a ChangeLog from a ComparisonResult.
+
+    Args:
+        result: The classified comparison result.
+
+    Returns:
+        ChangeLog with entries for every non-unchanged change.
+    """
+    entries: list[ChangeLogEntry] = []
+
+    for change in result.changes:
+        if change.category == ChangeCategory.UNCHANGED:
+            continue
+        entry = _build_entry(change)
+        entries.append(entry)
+
+    return ChangeLog(
+        summary=result.summary,
+        entries=entries,
+    )
+
+
+def _build_entry(change: EntityChange) -> ChangeLogEntry:
+    """Build a single change log entry."""
+    snap = change.revision_snapshot or change.master_snapshot
+    entity_type = snap.entity_type.value if snap else "UNKNOWN"
+    layer = snap.layer if snap else "UNKNOWN"
+
+    from_point = None
+    to_point = None
+
+    if change.category == ChangeCategory.ADDED:
+        assert change.revision_snapshot is not None
+        c = change.revision_snapshot.centroid
+        to_point = {"x": round(c.x, 4), "y": round(c.y, 4)}
+        desc = _describe_added(change)
+
+    elif change.category == ChangeCategory.REMOVED:
+        assert change.master_snapshot is not None
+        c = change.master_snapshot.centroid
+        from_point = {"x": round(c.x, 4), "y": round(c.y, 4)}
+        desc = _describe_removed(change)
+
+    elif change.category == ChangeCategory.MOVED:
+        assert change.master_snapshot is not None
+        assert change.revision_snapshot is not None
+        mc = change.master_snapshot.centroid
+        rc = change.revision_snapshot.centroid
+        from_point = {"x": round(mc.x, 4), "y": round(mc.y, 4)}
+        to_point = {"x": round(rc.x, 4), "y": round(rc.y, 4)}
+        desc = _describe_moved(change)
+
+    elif change.category == ChangeCategory.MODIFIED:
+        assert change.master_snapshot is not None
+        mc = change.master_snapshot.centroid
+        from_point = {"x": round(mc.x, 4), "y": round(mc.y, 4)}
+        desc = _describe_modified(change)
+
+    else:
+        desc = f"{entity_type} on {layer}: unknown change"
+
+    return ChangeLogEntry(
+        category=change.category.value,
+        entity_type=entity_type,
+        layer=layer,
+        description=desc,
+        from_point=from_point,
+        to_point=to_point,
+    )
+
+
+def _describe_added(change: EntityChange) -> str:
+    snap = change.revision_snapshot
+    assert snap is not None
+    c = snap.centroid
+    base = f"{snap.entity_type.value} added on layer {snap.layer} at ({c.x:.1f}, {c.y:.1f})"
+    if snap.text_content:
+        base += f' — text: "{snap.text_content}"'
+    if snap.block_name:
+        base += f" — block: {snap.block_name}"
+    return base
+
+
+def _describe_removed(change: EntityChange) -> str:
+    snap = change.master_snapshot
+    assert snap is not None
+    c = snap.centroid
+    base = f"{snap.entity_type.value} removed from layer {snap.layer} at ({c.x:.1f}, {c.y:.1f})"
+    if snap.text_content:
+        base += f' — text: "{snap.text_content}"'
+    if snap.block_name:
+        base += f" — block: {snap.block_name}"
+    return base
+
+
+def _describe_moved(change: EntityChange) -> str:
+    snap = change.master_snapshot
+    assert snap is not None
+    assert change.displacement is not None
+    c = snap.centroid
+    dx = change.displacement.x
+    dy = change.displacement.y
+    return (
+        f"{snap.entity_type.value} on layer {snap.layer} "
+        f"moved from ({c.x:.1f}, {c.y:.1f}) "
+        f"by ({dx:+.1f}, {dy:+.1f})"
+    )
+
+
+def _describe_modified(change: EntityChange) -> str:
+    snap = change.master_snapshot
+    assert snap is not None
+    c = snap.centroid
+    parts = [f"{snap.entity_type.value} on layer {snap.layer} modified at ({c.x:.1f}, {c.y:.1f})"]
+    if change.modifications:
+        if "text_content" in change.modifications:
+            tc = change.modifications["text_content"]
+            parts.append(f'text: "{tc["from"]}" → "{tc["to"]}"')
+        if "point_count" in change.modifications:
+            pc = change.modifications["point_count"]
+            parts.append(f"points: {pc['from']} → {pc['to']}")
+        if "radius" in change.modifications:
+            r = change.modifications["radius"]
+            parts.append(f"radius: {r['from']} → {r['to']}")
+    return " — ".join(parts)

--- a/src/cad_dxf_agent/core/comparison/classifier.py
+++ b/src/cad_dxf_agent/core/comparison/classifier.py
@@ -1,0 +1,200 @@
+"""Change classification — categorize matched entities as added/removed/modified/moved."""
+
+from __future__ import annotations
+
+import math
+
+from ...models.cad_schema import Point2D
+from ...models.comparison_schema import (
+    ChangeCategory,
+    ComparisonConfig,
+    ComparisonResult,
+    EntityChange,
+    GeometrySnapshot,
+    MatchResult,
+)
+
+
+def classify_changes(
+    match_result: MatchResult,
+    config: ComparisonConfig | None = None,
+) -> ComparisonResult:
+    """Classify every entity pair/orphan into a change category.
+
+    Args:
+        match_result: Output from the matcher step.
+        config: Comparison configuration.
+
+    Returns:
+        ComparisonResult with all changes classified and summary counts.
+    """
+    config = config or ComparisonConfig()
+    changes: list[EntityChange] = []
+
+    # Classify matched pairs
+    for m_snap, r_snap in match_result.pairs:
+        change = _classify_pair(m_snap, r_snap, config)
+        changes.append(change)
+
+    # Unmatched master → REMOVED
+    for m_snap in match_result.master_only:
+        changes.append(
+            EntityChange(
+                category=ChangeCategory.REMOVED,
+                master_snapshot=m_snap,
+                revision_snapshot=None,
+            )
+        )
+
+    # Unmatched revision → ADDED
+    for r_snap in match_result.revision_only:
+        changes.append(
+            EntityChange(
+                category=ChangeCategory.ADDED,
+                master_snapshot=None,
+                revision_snapshot=r_snap,
+            )
+        )
+
+    # Build summary
+    summary = {cat.value: 0 for cat in ChangeCategory}
+    for change in changes:
+        summary[change.category.value] += 1
+
+    return ComparisonResult(changes=changes, summary=summary, config=config)
+
+
+def _classify_pair(
+    m_snap: GeometrySnapshot,
+    r_snap: GeometrySnapshot,
+    config: ComparisonConfig,
+) -> EntityChange:
+    """Classify a single matched (master, revision) pair."""
+    displacement = Point2D(
+        x=r_snap.centroid.x - m_snap.centroid.x,
+        y=r_snap.centroid.y - m_snap.centroid.y,
+    )
+    dist = math.sqrt(displacement.x**2 + displacement.y**2)
+
+    points_match = _points_match(m_snap.points, r_snap.points, config.tolerance)
+    content_match = _content_matches(m_snap, r_snap)
+
+    if dist < config.move_threshold and points_match and content_match:
+        # Everything matches — UNCHANGED
+        return EntityChange(
+            category=ChangeCategory.UNCHANGED,
+            master_snapshot=m_snap,
+            revision_snapshot=r_snap,
+        )
+
+    if (
+        dist >= config.move_threshold
+        and _shape_matches_after_translation(
+            m_snap.points, r_snap.points, displacement, config.tolerance
+        )
+        and content_match
+    ):
+        # Same shape, shifted position — MOVED
+        return EntityChange(
+            category=ChangeCategory.MOVED,
+            master_snapshot=m_snap,
+            revision_snapshot=r_snap,
+            displacement=displacement,
+        )
+
+    # Something changed — MODIFIED
+    modifications = _describe_modifications(m_snap, r_snap)
+    return EntityChange(
+        category=ChangeCategory.MODIFIED,
+        master_snapshot=m_snap,
+        revision_snapshot=r_snap,
+        modifications=modifications,
+    )
+
+
+def _points_match(a: list[Point2D], b: list[Point2D], tolerance: float) -> bool:
+    """Check if two point lists match within tolerance (same count, pairwise)."""
+    if len(a) != len(b):
+        return False
+    for pa, pb in zip(a, b, strict=True):
+        if math.sqrt((pa.x - pb.x) ** 2 + (pa.y - pb.y) ** 2) > tolerance:
+            return False
+    return True
+
+
+def _shape_matches_after_translation(
+    master_pts: list[Point2D],
+    revision_pts: list[Point2D],
+    displacement: Point2D,
+    tolerance: float,
+) -> bool:
+    """Check if revision points match master points translated by displacement."""
+    if len(master_pts) != len(revision_pts):
+        return False
+    for mp, rp in zip(master_pts, revision_pts, strict=True):
+        translated_x = mp.x + displacement.x
+        translated_y = mp.y + displacement.y
+        dist = math.sqrt((translated_x - rp.x) ** 2 + (translated_y - rp.y) ** 2)
+        if dist > tolerance:
+            return False
+    return True
+
+
+def _content_matches(a: GeometrySnapshot, b: GeometrySnapshot) -> bool:
+    """Check if text content, block name, and key attributes match."""
+    if a.text_content != b.text_content:
+        return False
+    if a.block_name != b.block_name:
+        return False
+    # Check key attributes that affect identity (radius, angles, ratio)
+    for key in ("radius", "start_angle", "end_angle", "ratio"):
+        va = a.attributes.get(key)
+        vb = b.attributes.get(key)
+        if va != vb:
+            if isinstance(va, float) and isinstance(vb, float):
+                if abs(va - vb) > 1e-6:
+                    return False
+            else:
+                return False
+    return True
+
+
+def _describe_modifications(
+    m_snap: GeometrySnapshot, r_snap: GeometrySnapshot
+) -> dict[str, object]:
+    """Build a dict describing what changed between master and revision."""
+    mods: dict[str, object] = {}
+
+    if m_snap.text_content != r_snap.text_content:
+        mods["text_content"] = {
+            "from": m_snap.text_content,
+            "to": r_snap.text_content,
+        }
+
+    if m_snap.block_name != r_snap.block_name:
+        mods["block_name"] = {
+            "from": m_snap.block_name,
+            "to": r_snap.block_name,
+        }
+
+    if len(m_snap.points) != len(r_snap.points):
+        mods["point_count"] = {
+            "from": len(m_snap.points),
+            "to": len(r_snap.points),
+        }
+    else:
+        changed_points = []
+        for i, (mp, rp) in enumerate(zip(m_snap.points, r_snap.points, strict=True)):
+            dist = math.sqrt((mp.x - rp.x) ** 2 + (mp.y - rp.y) ** 2)
+            if dist > 1e-6:
+                changed_points.append(i)
+        if changed_points:
+            mods["changed_point_indices"] = changed_points
+
+    for key in ("radius", "start_angle", "end_angle", "ratio"):
+        va = m_snap.attributes.get(key)
+        vb = r_snap.attributes.get(key)
+        if va != vb:
+            mods[key] = {"from": va, "to": vb}
+
+    return mods

--- a/src/cad_dxf_agent/core/comparison/classifier.py
+++ b/src/cad_dxf_agent/core/comparison/classifier.py
@@ -116,8 +116,9 @@ def _points_match(a: list[Point2D], b: list[Point2D], tolerance: float) -> bool:
     """Check if two point lists match within tolerance (same count, pairwise)."""
     if len(a) != len(b):
         return False
+    tol_sq = tolerance * tolerance
     for pa, pb in zip(a, b, strict=True):
-        if math.sqrt((pa.x - pb.x) ** 2 + (pa.y - pb.y) ** 2) > tolerance:
+        if (pa.x - pb.x) ** 2 + (pa.y - pb.y) ** 2 > tol_sq:
             return False
     return True
 
@@ -131,11 +132,11 @@ def _shape_matches_after_translation(
     """Check if revision points match master points translated by displacement."""
     if len(master_pts) != len(revision_pts):
         return False
+    tol_sq = tolerance * tolerance
     for mp, rp in zip(master_pts, revision_pts, strict=True):
         translated_x = mp.x + displacement.x
         translated_y = mp.y + displacement.y
-        dist = math.sqrt((translated_x - rp.x) ** 2 + (translated_y - rp.y) ** 2)
-        if dist > tolerance:
+        if (translated_x - rp.x) ** 2 + (translated_y - rp.y) ** 2 > tol_sq:
             return False
     return True
 
@@ -151,8 +152,8 @@ def _content_matches(a: GeometrySnapshot, b: GeometrySnapshot) -> bool:
         va = a.attributes.get(key)
         vb = b.attributes.get(key)
         if va != vb:
-            if isinstance(va, float) and isinstance(vb, float):
-                if abs(va - vb) > 1e-6:
+            if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
+                if not math.isclose(va, vb, abs_tol=1e-6):
                     return False
             else:
                 return False

--- a/src/cad_dxf_agent/core/comparison/diff_overlay.py
+++ b/src/cad_dxf_agent/core/comparison/diff_overlay.py
@@ -1,0 +1,222 @@
+"""Diff overlay — write color-coded change layers to a DXF file."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import ezdxf
+
+from ...models.cad_schema import Point2D
+from ...models.comparison_schema import (
+    ChangeCategory,
+    ComparisonResult,
+    DiffOverlayLayers,
+    EntityChange,
+    GeometrySnapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def write_diff_overlay(
+    master_path: str | Path,
+    comparison_result: ComparisonResult,
+    output_path: str | Path,
+) -> Path:
+    """Write a diff overlay DXF based on comparison results.
+
+    Opens the master DXF, adds overlay layers, duplicates changed entities
+    onto the appropriate color-coded layer, and saves to output_path.
+
+    Args:
+        master_path: Path to the master DXF (used as the base).
+        comparison_result: Classified changes from the comparison engine.
+        output_path: Where to save the overlay DXF.
+
+    Returns:
+        Path to the saved overlay DXF.
+    """
+    master_path = Path(master_path)
+    output_path = Path(output_path)
+
+    doc = ezdxf.readfile(str(master_path))
+    msp = doc.modelspace()
+
+    # Create overlay layers
+    for layer_name, color_code in DiffOverlayLayers.ALL:
+        if layer_name not in doc.layers:
+            doc.layers.add(layer_name, color=color_code)
+
+    for change in comparison_result.changes:
+        if change.category == ChangeCategory.UNCHANGED:
+            continue
+
+        try:
+            _draw_change(msp, change)
+        except Exception:
+            logger.debug(
+                "Failed to draw overlay for %s change",
+                change.category.value,
+                exc_info=True,
+            )
+
+    doc.saveas(str(output_path))
+    return output_path
+
+
+def _draw_change(
+    msp: ezdxf.layouts.BaseLayout,
+    change: EntityChange,
+) -> None:
+    """Draw one change onto the appropriate overlay layer."""
+    category = change.category
+
+    if category == ChangeCategory.ADDED:
+        layer_name = DiffOverlayLayers.ADDED[0]
+        snap = change.revision_snapshot
+        if snap:
+            _draw_snapshot(msp, snap, layer_name)
+
+    elif category == ChangeCategory.REMOVED:
+        layer_name = DiffOverlayLayers.REMOVED[0]
+        snap = change.master_snapshot
+        if snap:
+            _draw_snapshot(msp, snap, layer_name)
+
+    elif category == ChangeCategory.MODIFIED:
+        layer_name = DiffOverlayLayers.MODIFIED[0]
+        # Draw both master (will appear as old) and revision (as new)
+        if change.master_snapshot:
+            _draw_snapshot(msp, change.master_snapshot, layer_name)
+        if change.revision_snapshot:
+            _draw_snapshot(msp, change.revision_snapshot, layer_name)
+
+    elif category == ChangeCategory.MOVED:
+        layer_name = DiffOverlayLayers.MOVED[0]
+        # Draw entity at new position
+        if change.revision_snapshot:
+            _draw_snapshot(msp, change.revision_snapshot, layer_name)
+        # Draw displacement arrow from old centroid to new centroid
+        if change.master_snapshot and change.revision_snapshot:
+            _draw_arrow(
+                msp,
+                change.master_snapshot.centroid,
+                change.revision_snapshot.centroid,
+                layer_name,
+            )
+
+
+def _draw_snapshot(
+    msp: ezdxf.layouts.BaseLayout,
+    snap: GeometrySnapshot,
+    layer: str,
+) -> None:
+    """Recreate entity geometry on the specified overlay layer."""
+    etype = snap.entity_type.value
+
+    if etype == "LINE" and len(snap.points) >= 2:
+        msp.add_line(
+            (snap.points[0].x, snap.points[0].y),
+            (snap.points[1].x, snap.points[1].y),
+            dxfattribs={"layer": layer},
+        )
+
+    elif etype == "LWPOLYLINE" and len(snap.points) >= 2:
+        pts = [(p.x, p.y) for p in snap.points]
+        msp.add_lwpolyline(pts, dxfattribs={"layer": layer})
+
+    elif etype in ("TEXT", "MTEXT") and snap.points:
+        text = snap.text_content or ""
+        if etype == "TEXT":
+            msp.add_text(
+                text,
+                dxfattribs={
+                    "layer": layer,
+                    "height": 1.0,
+                    "insert": (snap.points[0].x, snap.points[0].y),
+                },
+            )
+        else:
+            msp.add_mtext(
+                text,
+                dxfattribs={
+                    "layer": layer,
+                    "insert": (snap.points[0].x, snap.points[0].y),
+                    "char_height": 1.0,
+                },
+            )
+
+    elif etype == "INSERT" and snap.points:
+        # Can't copy block refs without the block def — draw a marker instead
+        p = snap.points[0]
+        _draw_marker(msp, p, layer, label=snap.block_name or "BLK")
+
+    elif etype == "CIRCLE" and snap.points:
+        radius = snap.attributes.get("radius", 1.0)
+        msp.add_circle(
+            (snap.points[0].x, snap.points[0].y),
+            radius=radius,
+            dxfattribs={"layer": layer},
+        )
+
+    elif etype == "ARC" and snap.points:
+        radius = snap.attributes.get("radius", 1.0)
+        start_angle = snap.attributes.get("start_angle", 0.0)
+        end_angle = snap.attributes.get("end_angle", 360.0)
+        msp.add_arc(
+            (snap.points[0].x, snap.points[0].y),
+            radius=radius,
+            start_angle=start_angle,
+            end_angle=end_angle,
+            dxfattribs={"layer": layer},
+        )
+
+    elif etype == "POLYLINE" and len(snap.points) >= 2:
+        # Approximate as LWPOLYLINE on the overlay
+        pts = [(p.x, p.y) for p in snap.points]
+        msp.add_lwpolyline(pts, dxfattribs={"layer": layer})
+
+    elif etype == "ELLIPSE" and snap.points:
+        ratio = snap.attributes.get("ratio", 0.5)
+        msp.add_ellipse(
+            center=(snap.points[0].x, snap.points[0].y),
+            major_axis=(5, 0, 0),
+            ratio=ratio,
+            dxfattribs={"layer": layer},
+        )
+
+    elif snap.points:
+        # Fallback: draw a marker at centroid
+        _draw_marker(msp, snap.centroid, layer, label=etype)
+
+
+def _draw_arrow(
+    msp: ezdxf.layouts.BaseLayout,
+    from_pt: Point2D,
+    to_pt: Point2D,
+    layer: str,
+) -> None:
+    """Draw a simple line from old position to new position."""
+    msp.add_line(
+        (from_pt.x, from_pt.y),
+        (to_pt.x, to_pt.y),
+        dxfattribs={"layer": layer},
+    )
+
+
+def _draw_marker(
+    msp: ezdxf.layouts.BaseLayout,
+    point: Point2D,
+    layer: str,
+    label: str = "X",
+    size: float = 1.0,
+) -> None:
+    """Draw an X marker with label at the given point."""
+    x, y = point.x, point.y
+    msp.add_line((x - size, y - size), (x + size, y + size), dxfattribs={"layer": layer})
+    msp.add_line((x - size, y + size), (x + size, y - size), dxfattribs={"layer": layer})
+    msp.add_text(
+        label,
+        dxfattribs={"layer": layer, "height": size * 0.8, "insert": (x + size * 1.2, y)},
+    )

--- a/src/cad_dxf_agent/core/comparison/diff_overlay.py
+++ b/src/cad_dxf_agent/core/comparison/diff_overlay.py
@@ -55,7 +55,7 @@ def write_diff_overlay(
         try:
             _draw_change(msp, change)
         except Exception:
-            logger.debug(
+            logger.warning(
                 "Failed to draw overlay for %s change",
                 change.category.value,
                 exc_info=True,
@@ -179,9 +179,10 @@ def _draw_snapshot(
 
     elif etype == "ELLIPSE" and snap.points:
         ratio = snap.attributes.get("ratio", 0.5)
+        major_axis = snap.attributes.get("major_axis", (5, 0, 0))
         msp.add_ellipse(
             center=(snap.points[0].x, snap.points[0].y),
-            major_axis=(5, 0, 0),
+            major_axis=major_axis,
             ratio=ratio,
             dxfattribs={"layer": layer},
         )

--- a/src/cad_dxf_agent/core/comparison/engine.py
+++ b/src/cad_dxf_agent/core/comparison/engine.py
@@ -1,0 +1,128 @@
+"""Comparison engine — top-level orchestrator for DXF comparison."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ...models.comparison_schema import ComparisonConfig, ComparisonResult
+from .changelog import ChangeLog, generate_changelog
+from .classifier import classify_changes
+from .diff_overlay import write_diff_overlay
+from .geometry import extract_snapshots
+from .matcher import match_entities
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ComparisonOutputs:
+    """Paths and data produced by the comparison engine."""
+
+    result: ComparisonResult
+    changelog: ChangeLog
+    diff_overlay_path: Path | None = None
+    master_path: Path = field(default_factory=lambda: Path())
+    revision_path: Path = field(default_factory=lambda: Path())
+
+
+class ComparisonEngine:
+    """Orchestrates the full comparison pipeline.
+
+    Usage::
+
+        engine = ComparisonEngine()
+        result = engine.compare("master.dxf", "revision.dxf")
+        outputs = engine.generate_outputs("master.dxf", result, output_dir)
+    """
+
+    def compare(
+        self,
+        master_path: str | Path,
+        revision_path: str | Path,
+        config: ComparisonConfig | None = None,
+    ) -> ComparisonResult:
+        """Run the full comparison pipeline: extract → match → classify.
+
+        Args:
+            master_path: Path to the master (original) DXF.
+            revision_path: Path to the revision (modified) DXF.
+            config: Optional comparison configuration.
+
+        Returns:
+            ComparisonResult with all classified changes.
+        """
+        config = config or ComparisonConfig()
+
+        logger.info("Extracting geometry from master: %s", Path(master_path).name)
+        master_snaps = extract_snapshots(master_path, config)
+
+        logger.info("Extracting geometry from revision: %s", Path(revision_path).name)
+        revision_snaps = extract_snapshots(revision_path, config)
+
+        logger.info(
+            "Matching entities: %d master, %d revision",
+            len(master_snaps),
+            len(revision_snaps),
+        )
+        match_result = match_entities(master_snaps, revision_snaps, config)
+
+        logger.info(
+            "Matched %d pairs, %d master-only, %d revision-only",
+            len(match_result.pairs),
+            len(match_result.master_only),
+            len(match_result.revision_only),
+        )
+        result = classify_changes(match_result, config)
+
+        logger.info("Classification: %s", result.summary)
+        return result
+
+    def generate_outputs(
+        self,
+        master_path: str | Path,
+        revision_path: str | Path,
+        result: ComparisonResult,
+        output_dir: str | Path,
+    ) -> ComparisonOutputs:
+        """Generate all output artifacts from a comparison result.
+
+        Args:
+            master_path: Path to the master DXF (base for overlay).
+            revision_path: Path to the revision DXF.
+            result: Classified comparison result.
+            output_dir: Directory for output files.
+
+        Returns:
+            ComparisonOutputs with paths to generated files.
+        """
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate change log
+        changelog = generate_changelog(result)
+
+        # Write change log files
+        changelog_json_path = output_dir / "changelog.json"
+        changelog_json_path.write_text(changelog.to_json())
+
+        changelog_text_path = output_dir / "changelog.txt"
+        changelog_text_path.write_text(changelog.to_text())
+
+        # Generate diff overlay DXF
+        overlay_target = output_dir / "diff_overlay.dxf"
+        diff_overlay_path: Path | None = overlay_target
+        try:
+            write_diff_overlay(master_path, result, overlay_target)
+        except Exception:
+            logger.error("Failed to generate diff overlay", exc_info=True)
+            diff_overlay_path = None
+
+        return ComparisonOutputs(
+            result=result,
+            changelog=changelog,
+            diff_overlay_path=diff_overlay_path,
+            master_path=Path(master_path),
+            revision_path=Path(revision_path),
+        )

--- a/src/cad_dxf_agent/core/comparison/geometry.py
+++ b/src/cad_dxf_agent/core/comparison/geometry.py
@@ -140,6 +140,8 @@ def _extract_one(
             center = entity.dxf.center
             points = [Point2D(x=center.x, y=center.y)]
             attributes["ratio"] = entity.dxf.ratio
+            major = entity.dxf.major_axis
+            attributes["major_axis"] = (major.x, major.y, major.z)
 
         elif dxf_type == "SPLINE":
             try:

--- a/src/cad_dxf_agent/core/comparison/geometry.py
+++ b/src/cad_dxf_agent/core/comparison/geometry.py
@@ -1,0 +1,210 @@
+"""Geometry extraction — reads ezdxf entities into GeometrySnapshot objects."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import ezdxf
+
+from ...models.cad_schema import EntityType, Point2D
+from ...models.comparison_schema import ComparisonConfig, GeometrySnapshot
+
+logger = logging.getLogger(__name__)
+
+# Entity types we know how to extract geometry from
+_EXTRACTABLE_TYPES = {t.value for t in EntityType}
+
+
+def extract_snapshots(
+    dxf_path: str | Path,
+    config: ComparisonConfig | None = None,
+) -> list[GeometrySnapshot]:
+    """Extract GeometrySnapshot objects from all model-space entities in a DXF.
+
+    Args:
+        dxf_path: Path to the DXF file.
+        config: Optional comparison config for layer/type filtering.
+
+    Returns:
+        List of GeometrySnapshot with full point data per entity.
+    """
+    config = config or ComparisonConfig()
+    dxf_path = Path(dxf_path)
+
+    if not dxf_path.exists():
+        raise FileNotFoundError(f"DXF file not found: {dxf_path}")
+
+    doc = ezdxf.readfile(str(dxf_path))
+    msp = doc.modelspace()
+
+    ignored_upper = {layer.upper() for layer in config.ignored_layers}
+    focus_types = (
+        {t.value for t in config.focus_entity_types} if config.focus_entity_types else None
+    )
+
+    snapshots: list[GeometrySnapshot] = []
+
+    for entity in msp:
+        dxf_type = entity.dxftype()
+
+        if dxf_type not in _EXTRACTABLE_TYPES:
+            continue
+
+        if focus_types and dxf_type not in focus_types:
+            continue
+
+        layer = entity.dxf.layer
+        if layer.upper() in ignored_upper:
+            continue
+
+        snap = _extract_one(entity, dxf_type)
+        if snap is not None:
+            snapshots.append(snap)
+
+    return snapshots
+
+
+def _extract_one(
+    entity: ezdxf.entities.DXFGraphic,
+    dxf_type: str,
+) -> GeometrySnapshot | None:
+    """Extract full geometry from a single ezdxf entity."""
+    handle = entity.dxf.handle
+    layer = entity.dxf.layer
+    points: list[Point2D] = []
+    text_content: str | None = None
+    block_name: str | None = None
+    attributes: dict[str, Any] = {}
+
+    try:
+        if dxf_type == "LINE":
+            start = entity.dxf.start
+            end = entity.dxf.end
+            points = [Point2D(x=start.x, y=start.y), Point2D(x=end.x, y=end.y)]
+
+        elif dxf_type == "LWPOLYLINE":
+            raw = list(entity.get_points(format="xy"))  # type: ignore[attr-defined]
+            points = [Point2D(x=p[0], y=p[1]) for p in raw]
+
+        elif dxf_type == "TEXT":
+            insert = entity.dxf.insert
+            points = [Point2D(x=insert.x, y=insert.y)]
+            text_content = entity.dxf.text
+
+        elif dxf_type == "MTEXT":
+            insert = entity.dxf.insert
+            points = [Point2D(x=insert.x, y=insert.y)]
+            text_content = entity.text  # type: ignore[attr-defined]
+
+        elif dxf_type == "INSERT":
+            insert = entity.dxf.insert
+            points = [Point2D(x=insert.x, y=insert.y)]
+            block_name = entity.dxf.name
+
+        elif dxf_type == "CIRCLE":
+            center = entity.dxf.center
+            points = [Point2D(x=center.x, y=center.y)]
+            attributes["radius"] = entity.dxf.radius
+
+        elif dxf_type == "ARC":
+            center = entity.dxf.center
+            points = [Point2D(x=center.x, y=center.y)]
+            attributes["radius"] = entity.dxf.radius
+            attributes["start_angle"] = entity.dxf.start_angle
+            attributes["end_angle"] = entity.dxf.end_angle
+
+        elif dxf_type == "POLYLINE":
+            try:
+                vertices = list(entity.vertices)  # type: ignore[attr-defined]
+                points = [Point2D(x=v.dxf.location.x, y=v.dxf.location.y) for v in vertices]
+            except Exception:
+                logger.debug("POLYLINE %s: vertex read failed", handle)
+                return None
+
+        elif dxf_type == "DIMENSION":
+            text_content = entity.dxf.get("text", "") or ""
+            try:
+                insert = entity.dxf.insert
+                points = [Point2D(x=insert.x, y=insert.y)]
+            except Exception:
+                try:
+                    defpoint = entity.dxf.defpoint
+                    points = [Point2D(x=defpoint.x, y=defpoint.y)]
+                except Exception:
+                    logger.debug("DIMENSION %s: no insert or defpoint", handle)
+                    return None
+
+        elif dxf_type == "ELLIPSE":
+            center = entity.dxf.center
+            points = [Point2D(x=center.x, y=center.y)]
+            attributes["ratio"] = entity.dxf.ratio
+
+        elif dxf_type == "SPLINE":
+            try:
+                ctrl = list(entity.control_points)  # type: ignore[attr-defined]
+                points = [Point2D(x=p[0], y=p[1]) for p in ctrl]
+            except Exception:
+                logger.debug("SPLINE %s: control point read failed", handle)
+                return None
+
+        elif dxf_type == "HATCH":
+            try:
+                paths = entity.paths  # type: ignore[attr-defined]
+                if paths:
+                    for path in paths:
+                        for v in getattr(path, "vertices", []):
+                            points.append(Point2D(x=v[0], y=v[1]))
+            except Exception:
+                logger.debug("HATCH %s: boundary read failed", handle)
+            if not points:
+                return None
+
+        elif dxf_type == "MLEADER":
+            try:
+                ctx = entity.context  # type: ignore[attr-defined]
+                if hasattr(ctx, "mtext") and ctx.mtext:
+                    text_content = ctx.mtext.default_content
+                    points = [Point2D(x=ctx.mtext.insert.x, y=ctx.mtext.insert.y)]
+            except Exception:
+                logger.debug("MLEADER %s: context read failed", handle)
+                return None
+
+        elif dxf_type == "LEADER":
+            try:
+                vertices = list(entity.vertices)  # type: ignore[attr-defined]
+                points = [Point2D(x=v.x, y=v.y) for v in vertices]
+            except Exception:
+                logger.debug("LEADER %s: vertex read failed", handle)
+                return None
+
+        elif dxf_type == "SOLID":
+            try:
+                for attr in ("vtx0", "vtx1", "vtx2", "vtx3"):
+                    vtx = getattr(entity.dxf, attr, None)
+                    if vtx is not None:
+                        points.append(Point2D(x=vtx.x, y=vtx.y))
+            except Exception:
+                logger.debug("SOLID %s: vertex read failed", handle)
+                return None
+
+        else:
+            return None
+
+    except Exception:
+        logger.debug("Failed to extract geometry from %s %s", dxf_type, handle)
+        return None
+
+    if not points:
+        return None
+
+    return GeometrySnapshot(
+        handle=handle,
+        entity_type=EntityType(dxf_type),
+        layer=layer,
+        points=points,
+        text_content=text_content,
+        block_name=block_name,
+        attributes=attributes,
+    )

--- a/src/cad_dxf_agent/core/comparison/matcher.py
+++ b/src/cad_dxf_agent/core/comparison/matcher.py
@@ -79,13 +79,17 @@ def match_entities(
 def _fingerprint(snap: GeometrySnapshot) -> str:
     """Compute a deterministic fingerprint for exact matching.
 
-    Includes: entity_type, layer, rounded sorted points, text, block_name.
+    Includes: entity_type, layer, rounded points, text, block_name.
+    Points are kept in original order for order-dependent shapes (LWPOLYLINE,
+    SPLINE, POLYLINE, LEADER, HATCH) and sorted only for LINE where
+    start/end are interchangeable.
     """
     # Round points to avoid floating-point noise
-    rounded_pts = []
-    for p in snap.points:
-        rounded_pts.append((round(p.x, 4), round(p.y, 4)))
-    rounded_pts.sort()
+    rounded_pts = [(round(p.x, 4), round(p.y, 4)) for p in snap.points]
+    # Only sort for LINE — start/end order is arbitrary.
+    # For LWPOLYLINE, SPLINE, etc., vertex order defines the shape.
+    if snap.entity_type.value == "LINE":
+        rounded_pts = sorted(rounded_pts)
 
     parts = [
         snap.entity_type.value,

--- a/src/cad_dxf_agent/core/comparison/matcher.py
+++ b/src/cad_dxf_agent/core/comparison/matcher.py
@@ -1,0 +1,196 @@
+"""Entity matching — fingerprint hash + greedy nearest-neighbor."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import defaultdict
+
+from ...models.cad_schema import Point2D
+from ...models.comparison_schema import (
+    ComparisonConfig,
+    GeometrySnapshot,
+    MatchResult,
+)
+
+
+def match_entities(
+    master_snaps: list[GeometrySnapshot],
+    revision_snaps: list[GeometrySnapshot],
+    config: ComparisonConfig | None = None,
+) -> MatchResult:
+    """Match entities between master and revision snapshots.
+
+    Step 1: Exact fingerprint matching (O(n) hash lookup).
+    Step 2: Greedy nearest-neighbor on centroids for leftovers.
+
+    Args:
+        master_snaps: Snapshots from the master DXF.
+        revision_snaps: Snapshots from the revision DXF.
+        config: Comparison configuration (tolerance, etc.).
+
+    Returns:
+        MatchResult with paired, master-only, and revision-only lists.
+    """
+    config = config or ComparisonConfig()
+
+    pairs: list[tuple[GeometrySnapshot, GeometrySnapshot]] = []
+
+    # --- Step 1: Fingerprint hash matching ---
+    revision_by_fp: dict[str, list[GeometrySnapshot]] = defaultdict(list)
+    for snap in revision_snaps:
+        fp = _fingerprint(snap)
+        revision_by_fp[fp].append(snap)
+
+    unmatched_master: list[GeometrySnapshot] = []
+
+    for m_snap in master_snaps:
+        fp = _fingerprint(m_snap)
+        candidates = revision_by_fp.get(fp)
+        if candidates:
+            r_snap = candidates.pop(0)
+            if not candidates:
+                del revision_by_fp[fp]
+            pairs.append((m_snap, r_snap))
+        else:
+            unmatched_master.append(m_snap)
+
+    # Collect unmatched revision snapshots
+    unmatched_revision: list[GeometrySnapshot] = []
+    for remaining in revision_by_fp.values():
+        unmatched_revision.extend(remaining)
+
+    # --- Step 2: Greedy nearest-neighbor on unmatched ---
+    if unmatched_master and unmatched_revision:
+        nn_pairs, still_master, still_revision = _greedy_nearest_neighbor(
+            unmatched_master, unmatched_revision, config.tolerance
+        )
+        pairs.extend(nn_pairs)
+        unmatched_master = still_master
+        unmatched_revision = still_revision
+
+    return MatchResult(
+        pairs=pairs,
+        master_only=unmatched_master,
+        revision_only=unmatched_revision,
+    )
+
+
+def _fingerprint(snap: GeometrySnapshot) -> str:
+    """Compute a deterministic fingerprint for exact matching.
+
+    Includes: entity_type, layer, rounded sorted points, text, block_name.
+    """
+    # Round points to avoid floating-point noise
+    rounded_pts = []
+    for p in snap.points:
+        rounded_pts.append((round(p.x, 4), round(p.y, 4)))
+    rounded_pts.sort()
+
+    parts = [
+        snap.entity_type.value,
+        snap.layer,
+        str(rounded_pts),
+        snap.text_content or "",
+        snap.block_name or "",
+    ]
+    raw = "|".join(parts)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _greedy_nearest_neighbor(
+    master_snaps: list[GeometrySnapshot],
+    revision_snaps: list[GeometrySnapshot],
+    tolerance: float,
+) -> tuple[
+    list[tuple[GeometrySnapshot, GeometrySnapshot]],
+    list[GeometrySnapshot],
+    list[GeometrySnapshot],
+]:
+    """Greedy nearest-neighbor matching on centroids within tolerance.
+
+    Groups by (entity_type, layer) first, then matches within each group.
+
+    Returns:
+        (pairs, remaining_master, remaining_revision)
+    """
+    pairs: list[tuple[GeometrySnapshot, GeometrySnapshot]] = []
+
+    # Group by (entity_type, layer)
+    master_groups: dict[tuple[str, str], list[GeometrySnapshot]] = defaultdict(list)
+    revision_groups: dict[tuple[str, str], list[GeometrySnapshot]] = defaultdict(list)
+
+    for snap in master_snaps:
+        key = (snap.entity_type.value, snap.layer)
+        master_groups[key].append(snap)
+
+    for snap in revision_snaps:
+        key = (snap.entity_type.value, snap.layer)
+        revision_groups[key].append(snap)
+
+    remaining_master: list[GeometrySnapshot] = []
+    remaining_revision: list[GeometrySnapshot] = []
+    matched_revision_keys: set[tuple[str, str]] = set()
+
+    for group_key, m_list in master_groups.items():
+        r_list = revision_groups.get(group_key)
+        if not r_list:
+            remaining_master.extend(m_list)
+            continue
+
+        matched_revision_keys.add(group_key)
+        g_pairs, g_m_left, g_r_left = _match_group(m_list, r_list, tolerance)
+        pairs.extend(g_pairs)
+        remaining_master.extend(g_m_left)
+        remaining_revision.extend(g_r_left)
+
+    # Revision groups with no master counterpart
+    for group_key, r_list in revision_groups.items():
+        if group_key not in matched_revision_keys:
+            remaining_revision.extend(r_list)
+
+    return pairs, remaining_master, remaining_revision
+
+
+def _match_group(
+    m_list: list[GeometrySnapshot],
+    r_list: list[GeometrySnapshot],
+    tolerance: float,
+) -> tuple[
+    list[tuple[GeometrySnapshot, GeometrySnapshot]],
+    list[GeometrySnapshot],
+    list[GeometrySnapshot],
+]:
+    """Match entities within a single (type, layer) group by centroid distance."""
+    pairs: list[tuple[GeometrySnapshot, GeometrySnapshot]] = []
+
+    # Build distance candidates
+    candidates: list[tuple[float, int, int]] = []
+    for mi, m_snap in enumerate(m_list):
+        for ri, r_snap in enumerate(r_list):
+            d = _centroid_distance(m_snap.centroid, r_snap.centroid)
+            if d <= tolerance:
+                candidates.append((d, mi, ri))
+
+    # Sort by distance (greedy: closest first)
+    candidates.sort(key=lambda x: x[0])
+
+    matched_m: set[int] = set()
+    matched_r: set[int] = set()
+
+    for _dist, mi, ri in candidates:
+        if mi in matched_m or ri in matched_r:
+            continue
+        pairs.append((m_list[mi], r_list[ri]))
+        matched_m.add(mi)
+        matched_r.add(ri)
+
+    m_left = [m_list[i] for i in range(len(m_list)) if i not in matched_m]
+    r_left = [r_list[i] for i in range(len(r_list)) if i not in matched_r]
+
+    return pairs, m_left, r_left
+
+
+def _centroid_distance(a: Point2D, b: Point2D) -> float:
+    """Euclidean distance between two points."""
+    return math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2)

--- a/src/cad_dxf_agent/models/comparison_schema.py
+++ b/src/cad_dxf_agent/models/comparison_schema.py
@@ -1,0 +1,130 @@
+"""Comparison schemas: geometry snapshots, matching, and diff classification."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, computed_field
+
+from .cad_schema import EntityType, Point2D
+
+
+class GeometrySnapshot(BaseModel):
+    """Full geometry capture of one entity from a DXF file."""
+
+    handle: str = Field(description="DXF entity handle (unique within its file)")
+    entity_type: EntityType
+    layer: str
+    points: list[Point2D] = Field(description="All defining points (ordered)")
+    text_content: str | None = None
+    block_name: str | None = None
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def centroid(self) -> Point2D:
+        """Mean of all defining points."""
+        if not self.points:
+            return Point2D(x=0.0, y=0.0)
+        cx = sum(p.x for p in self.points) / len(self.points)
+        cy = sum(p.y for p in self.points) / len(self.points)
+        return Point2D(x=cx, y=cy)
+
+
+class ComparisonConfig(BaseModel):
+    """Configuration for a DXF comparison run."""
+
+    tolerance: float = Field(
+        default=0.25,
+        description="Match threshold in drawing units (1/4 inch default)",
+    )
+    move_threshold: float = Field(
+        default=0.25,
+        description="Min displacement to classify as moved vs unchanged",
+    )
+    ignored_layers: list[str] = Field(default_factory=list)
+    focus_entity_types: list[EntityType] | None = Field(
+        default=None,
+        description="Restrict comparison to these types; None = all",
+    )
+
+
+class ChangeCategory(StrEnum):
+    """Classification of a single entity change."""
+
+    ADDED = "added"
+    REMOVED = "removed"
+    MODIFIED = "modified"
+    MOVED = "moved"
+    UNCHANGED = "unchanged"
+
+
+class EntityChange(BaseModel):
+    """One classified change between master and revision."""
+
+    category: ChangeCategory
+    master_snapshot: GeometrySnapshot | None = Field(
+        default=None, description="None for ADDED entities"
+    )
+    revision_snapshot: GeometrySnapshot | None = Field(
+        default=None, description="None for REMOVED entities"
+    )
+    displacement: Point2D | None = Field(default=None, description="dx, dy for MOVED entities")
+    modifications: dict[str, Any] | None = Field(
+        default=None, description="What changed for MODIFIED entities"
+    )
+
+
+class MatchResult(BaseModel):
+    """Output of the entity matching step."""
+
+    pairs: list[tuple[GeometrySnapshot, GeometrySnapshot]] = Field(
+        default_factory=list,
+        description="Matched (master, revision) pairs",
+    )
+    master_only: list[GeometrySnapshot] = Field(
+        default_factory=list,
+        description="Unmatched master entities (candidates for REMOVED)",
+    )
+    revision_only: list[GeometrySnapshot] = Field(
+        default_factory=list,
+        description="Unmatched revision entities (candidates for ADDED)",
+    )
+
+
+class ComparisonResult(BaseModel):
+    """Full result of comparing two DXF files."""
+
+    changes: list[EntityChange] = Field(default_factory=list)
+    summary: dict[str, int] = Field(
+        default_factory=lambda: {
+            "added": 0,
+            "removed": 0,
+            "modified": 0,
+            "moved": 0,
+            "unchanged": 0,
+        }
+    )
+    config: ComparisonConfig = Field(default_factory=ComparisonConfig)
+
+    @property
+    def total_changes(self) -> int:
+        """Count of non-unchanged changes."""
+        return (
+            self.summary.get("added", 0)
+            + self.summary.get("removed", 0)
+            + self.summary.get("modified", 0)
+            + self.summary.get("moved", 0)
+        )
+
+
+class DiffOverlayLayers:
+    """Layer name constants and DXF color codes for diff overlays."""
+
+    ADDED = ("AI_ADDED", 3)  # green
+    REMOVED = ("AI_REMOVED", 1)  # red
+    MODIFIED = ("AI_MODIFIED", 2)  # yellow
+    MOVED = ("AI_MOVED", 4)  # cyan
+
+    ALL = [ADDED, REMOVED, MODIFIED, MOVED]

--- a/tests/helpers/comparison_factory.py
+++ b/tests/helpers/comparison_factory.py
@@ -1,0 +1,201 @@
+"""Test DXF pair builders for comparison engine tests.
+
+Each function creates a pair of DXF files with known differences
+for deterministic testing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ezdxf
+
+
+def make_identical_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Two identical DXFs — zero changes expected."""
+    master = _build_base(tmp_path / "master.dxf")
+    revision = _build_base(tmp_path / "revision.dxf")
+    return master, revision
+
+
+def make_moved_entity_pair(tmp_path: Path, dx: float = 10.0, dy: float = 5.0) -> tuple[Path, Path]:
+    """Revision has one line moved by (dx, dy)."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    # Master: line at (0,0)-(10,0) + text at (20,20)
+    doc_m = ezdxf.new(dxfversion="R2018")
+    msp_m = doc_m.modelspace()
+    doc_m.layers.add("STRUCTURAL", color=1)
+    doc_m.layers.add("NOTES", color=3)
+    msp_m.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    msp_m.add_text("Label A", dxfattribs={"layer": "NOTES", "height": 2, "insert": (20, 20)})
+    doc_m.saveas(str(master))
+
+    # Revision: same line moved, text identical
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("STRUCTURAL", color=1)
+    doc_r.layers.add("NOTES", color=3)
+    msp_r.add_line((0 + dx, 0 + dy), (10 + dx, 0 + dy), dxfattribs={"layer": "STRUCTURAL"})
+    msp_r.add_text("Label A", dxfattribs={"layer": "NOTES", "height": 2, "insert": (20, 20)})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def make_added_removed_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Revision has one extra entity; master has one entity that revision lacks."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    doc_m = ezdxf.new(dxfversion="R2018")
+    msp_m = doc_m.modelspace()
+    doc_m.layers.add("STRUCTURAL", color=1)
+    doc_m.layers.add("NOTES", color=3)
+    # Shared: line at origin
+    msp_m.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    # Master-only: text that gets removed
+    msp_m.add_text("Old Note", dxfattribs={"layer": "NOTES", "height": 2, "insert": (50, 50)})
+    doc_m.saveas(str(master))
+
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("STRUCTURAL", color=1)
+    doc_r.layers.add("NOTES", color=3)
+    # Shared: same line
+    msp_r.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    # Revision-only: new text added
+    msp_r.add_text("New Note", dxfattribs={"layer": "NOTES", "height": 2, "insert": (80, 80)})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def make_modified_text_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Same text entity at same location with different content."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    doc_m = ezdxf.new(dxfversion="R2018")
+    msp_m = doc_m.modelspace()
+    doc_m.layers.add("NOTES", color=3)
+    msp_m.add_text("REV A", dxfattribs={"layer": "NOTES", "height": 2, "insert": (10, 10)})
+    doc_m.saveas(str(master))
+
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("NOTES", color=3)
+    msp_r.add_text("REV B", dxfattribs={"layer": "NOTES", "height": 2, "insert": (10, 10)})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def make_complex_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Mix of all change types: unchanged + moved + added + removed + modified."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    doc_m = ezdxf.new(dxfversion="R2018")
+    msp_m = doc_m.modelspace()
+    doc_m.layers.add("STRUCTURAL", color=1)
+    doc_m.layers.add("NOTES", color=3)
+
+    # Unchanged: line at (0,0)-(10,0)
+    msp_m.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    # Will be moved: line at (20,20)-(30,20)
+    msp_m.add_line((20, 20), (30, 20), dxfattribs={"layer": "STRUCTURAL"})
+    # Will be removed: text at (50,50)
+    msp_m.add_text("Remove Me", dxfattribs={"layer": "NOTES", "height": 2, "insert": (50, 50)})
+    # Will be modified: text at (80,80)
+    msp_m.add_text("Version 1", dxfattribs={"layer": "NOTES", "height": 2, "insert": (80, 80)})
+    # Will be modified: polyline
+    msp_m.add_lwpolyline(
+        [(100, 0), (110, 0), (110, 10), (100, 10)],
+        close=True,
+        dxfattribs={"layer": "STRUCTURAL"},
+    )
+    doc_m.saveas(str(master))
+
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("STRUCTURAL", color=1)
+    doc_r.layers.add("NOTES", color=3)
+
+    # Unchanged: same line
+    msp_r.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    # Moved: same line shifted by (5, 5)
+    msp_r.add_line((25, 25), (35, 25), dxfattribs={"layer": "STRUCTURAL"})
+    # (Remove Me text omitted — it's removed)
+    # Modified: text content changed
+    msp_r.add_text("Version 2", dxfattribs={"layer": "NOTES", "height": 2, "insert": (80, 80)})
+    # Modified: polyline with different vertices
+    msp_r.add_lwpolyline(
+        [(100, 0), (115, 0), (115, 15), (100, 15)],
+        close=True,
+        dxfattribs={"layer": "STRUCTURAL"},
+    )
+    # Added: new circle
+    msp_r.add_circle((200, 200), radius=5, dxfattribs={"layer": "STRUCTURAL"})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def make_circle_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """Master has a circle, revision has same circle with different radius."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    doc_m = ezdxf.new(dxfversion="R2018")
+    msp_m = doc_m.modelspace()
+    doc_m.layers.add("STRUCTURAL", color=1)
+    msp_m.add_circle((50, 50), radius=10, dxfattribs={"layer": "STRUCTURAL"})
+    doc_m.saveas(str(master))
+
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("STRUCTURAL", color=1)
+    msp_r.add_circle((50, 50), radius=15, dxfattribs={"layer": "STRUCTURAL"})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def make_empty_vs_populated(tmp_path: Path) -> tuple[Path, Path]:
+    """Master is empty, revision has entities (all added)."""
+    master = tmp_path / "master.dxf"
+    revision = tmp_path / "revision.dxf"
+
+    doc_m = ezdxf.new(dxfversion="R2018")
+    doc_m.saveas(str(master))
+
+    doc_r = ezdxf.new(dxfversion="R2018")
+    msp_r = doc_r.modelspace()
+    doc_r.layers.add("STRUCTURAL", color=1)
+    msp_r.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    msp_r.add_text("Hello", dxfattribs={"layer": "STRUCTURAL", "height": 2, "insert": (5, 5)})
+    doc_r.saveas(str(revision))
+
+    return master, revision
+
+
+def _build_base(path: Path) -> Path:
+    """Build a small DXF with reproducible entities."""
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+    doc.layers.add("STRUCTURAL", color=1)
+    doc.layers.add("NOTES", color=3)
+
+    msp.add_line((0, 0), (10, 0), dxfattribs={"layer": "STRUCTURAL"})
+    msp.add_line((0, 0), (0, 10), dxfattribs={"layer": "STRUCTURAL"})
+    msp.add_text("Test Note", dxfattribs={"layer": "NOTES", "height": 2, "insert": (5, 5)})
+    msp.add_lwpolyline(
+        [(20, 0), (30, 0), (30, 10), (20, 10)],
+        close=True,
+        dxfattribs={"layer": "STRUCTURAL"},
+    )
+
+    doc.saveas(str(path))
+    return path

--- a/tests/unit/test_comparison_changelog.py
+++ b/tests/unit/test_comparison_changelog.py
@@ -1,0 +1,110 @@
+"""Tests for comparison/changelog.py — change log generation."""
+
+from __future__ import annotations
+
+import json
+
+from cad_dxf_agent.core.comparison.changelog import ChangeLog, generate_changelog
+from cad_dxf_agent.core.comparison.classifier import classify_changes
+from cad_dxf_agent.core.comparison.geometry import extract_snapshots
+from cad_dxf_agent.core.comparison.matcher import match_entities
+from cad_dxf_agent.models.comparison_schema import ComparisonConfig
+from tests.helpers.comparison_factory import (
+    make_added_removed_pair,
+    make_complex_pair,
+    make_identical_pair,
+    make_modified_text_pair,
+    make_moved_entity_pair,
+)
+
+
+def _run_pipeline(master, revision, config=None):
+    config = config or ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+    m_snaps = extract_snapshots(master, config)
+    r_snaps = extract_snapshots(revision, config)
+    mr = match_entities(m_snaps, r_snaps, config)
+    return classify_changes(mr, config)
+
+
+class TestChangeLog:
+    def test_to_json_valid(self):
+        log = ChangeLog(summary={"added": 1, "removed": 0}, entries=[])
+        data = json.loads(log.to_json())
+        assert "summary" in data
+        assert "entries" in data
+        assert "generated_at" in data
+
+    def test_to_text_has_header(self):
+        log = ChangeLog(summary={"added": 1, "removed": 0}, entries=[])
+        text = log.to_text()
+        assert "CHANGE LOG" in text
+        assert "SUMMARY" in text
+
+    def test_round_trip(self):
+        log = ChangeLog(summary={"added": 2}, entries=[])
+        data = json.loads(log.to_json())
+        restored = ChangeLog(**data)
+        assert restored.summary["added"] == 2
+
+
+class TestGenerateChangelog:
+    def test_identical_files_empty_changelog(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        log = generate_changelog(result)
+        # Only unchanged — no entries
+        assert len(log.entries) == 0
+
+    def test_added_removed_has_entries(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        log = generate_changelog(result)
+        assert len(log.entries) >= 2  # at least 1 added + 1 removed
+        categories = {e.category for e in log.entries}
+        assert "added" in categories
+        assert "removed" in categories
+
+    def test_moved_entity_entry(self, tmp_path):
+        master, revision = make_moved_entity_pair(tmp_path, dx=5.0, dy=5.0)
+        config = ComparisonConfig(tolerance=20.0, move_threshold=0.25)
+        result = _run_pipeline(master, revision, config)
+        log = generate_changelog(result)
+        moved = [e for e in log.entries if e.category == "moved"]
+        assert len(moved) >= 1
+        for m in moved:
+            assert m.from_point is not None
+            assert m.to_point is not None
+
+    def test_modified_text_entry(self, tmp_path):
+        master, revision = make_modified_text_pair(tmp_path)
+        config = ComparisonConfig(tolerance=1.0)
+        result = _run_pipeline(master, revision, config)
+        log = generate_changelog(result)
+        modified = [e for e in log.entries if e.category == "modified"]
+        assert len(modified) >= 1
+        for m in modified:
+            assert "text" in m.description.lower() or "modified" in m.description.lower()
+
+    def test_entries_have_entity_type(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        log = generate_changelog(result)
+        for entry in log.entries:
+            assert entry.entity_type != "UNKNOWN"
+            assert entry.layer != "UNKNOWN"
+
+    def test_text_output_grouped(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        log = generate_changelog(result)
+        text = log.to_text()
+        # Text output should have category headers
+        assert "CHANGE LOG" in text
+
+    def test_json_output_parseable(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        log = generate_changelog(result)
+        data = json.loads(log.to_json())
+        assert isinstance(data["entries"], list)
+        assert isinstance(data["summary"], dict)

--- a/tests/unit/test_comparison_classifier.py
+++ b/tests/unit/test_comparison_classifier.py
@@ -1,0 +1,172 @@
+"""Tests for comparison/classifier.py — change classification."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.comparison.classifier import classify_changes
+from cad_dxf_agent.core.comparison.geometry import extract_snapshots
+from cad_dxf_agent.core.comparison.matcher import match_entities
+from cad_dxf_agent.models.cad_schema import EntityType, Point2D
+from cad_dxf_agent.models.comparison_schema import (
+    ChangeCategory,
+    ComparisonConfig,
+    GeometrySnapshot,
+    MatchResult,
+)
+from tests.helpers.comparison_factory import (
+    make_added_removed_pair,
+    make_circle_pair,
+    make_complex_pair,
+    make_empty_vs_populated,
+    make_identical_pair,
+    make_modified_text_pair,
+    make_moved_entity_pair,
+)
+
+
+class TestUnchangedClassification:
+    def test_identical_files_all_unchanged(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        mr = match_entities(m_snaps, r_snaps)
+        result = classify_changes(mr)
+        assert result.summary["unchanged"] == len(m_snaps)
+        assert result.summary["added"] == 0
+        assert result.summary["removed"] == 0
+
+    def test_empty_match_result(self):
+        mr = MatchResult()
+        result = classify_changes(mr)
+        assert result.total_changes == 0
+
+
+class TestMovedClassification:
+    def test_moved_entity(self, tmp_path):
+        master, revision = make_moved_entity_pair(tmp_path, dx=5.0, dy=5.0)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        # Use wider tolerance so the moved line matches via NN
+        config = ComparisonConfig(tolerance=20.0, move_threshold=0.25)
+        mr = match_entities(m_snaps, r_snaps, config)
+        result = classify_changes(mr, config)
+        moved = [c for c in result.changes if c.category == ChangeCategory.MOVED]
+        assert len(moved) >= 1
+        for m in moved:
+            assert m.displacement is not None
+            assert abs(m.displacement.x) > 0 or abs(m.displacement.y) > 0
+
+    def test_small_move_is_unchanged(self):
+        """Move smaller than threshold should be UNCHANGED."""
+        m_snap = GeometrySnapshot(
+            handle="A",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        r_snap = GeometrySnapshot(
+            handle="B",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0.01, y=0.01), Point2D(x=10.01, y=0.01)],
+        )
+        mr = MatchResult(pairs=[(m_snap, r_snap)])
+        config = ComparisonConfig(tolerance=0.25, move_threshold=0.25)
+        result = classify_changes(mr, config)
+        assert result.changes[0].category == ChangeCategory.UNCHANGED
+
+
+class TestAddedRemovedClassification:
+    def test_added_and_removed(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        mr = match_entities(m_snaps, r_snaps)
+        result = classify_changes(mr)
+        assert result.summary["removed"] >= 1
+        assert result.summary["added"] >= 1
+
+    def test_empty_master_all_added(self, tmp_path):
+        master, revision = make_empty_vs_populated(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        mr = match_entities(m_snaps, r_snaps)
+        result = classify_changes(mr)
+        assert result.summary["added"] >= 1
+        assert result.summary["removed"] == 0
+
+    def test_removed_entity_has_master_snapshot(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        mr = match_entities(m_snaps, r_snaps)
+        result = classify_changes(mr)
+        removed = [c for c in result.changes if c.category == ChangeCategory.REMOVED]
+        for r in removed:
+            assert r.master_snapshot is not None
+            assert r.revision_snapshot is None
+
+    def test_added_entity_has_revision_snapshot(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        mr = match_entities(m_snaps, r_snaps)
+        result = classify_changes(mr)
+        added = [c for c in result.changes if c.category == ChangeCategory.ADDED]
+        for a in added:
+            assert a.revision_snapshot is not None
+            assert a.master_snapshot is None
+
+
+class TestModifiedClassification:
+    def test_modified_text(self, tmp_path):
+        master, revision = make_modified_text_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        # Same position, different text — NN should match them
+        config = ComparisonConfig(tolerance=1.0)
+        mr = match_entities(m_snaps, r_snaps, config)
+        result = classify_changes(mr, config)
+        modified = [c for c in result.changes if c.category == ChangeCategory.MODIFIED]
+        assert len(modified) >= 1
+        for m in modified:
+            assert m.modifications is not None
+            assert "text_content" in m.modifications
+
+    def test_modified_circle_radius(self, tmp_path):
+        master, revision = make_circle_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        config = ComparisonConfig(tolerance=1.0)
+        mr = match_entities(m_snaps, r_snaps, config)
+        result = classify_changes(mr, config)
+        modified = [c for c in result.changes if c.category == ChangeCategory.MODIFIED]
+        assert len(modified) >= 1
+        for m in modified:
+            assert m.modifications is not None
+            assert "radius" in m.modifications
+
+
+class TestComplexClassification:
+    def test_all_categories_present(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        config = ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+        mr = match_entities(m_snaps, r_snaps, config)
+        result = classify_changes(mr, config)
+        categories = {c.category for c in result.changes}
+        # Should have at least added + removed
+        assert ChangeCategory.ADDED in categories
+        assert ChangeCategory.REMOVED in categories
+
+    def test_summary_counts_match_changes(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        config = ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+        mr = match_entities(m_snaps, r_snaps, config)
+        result = classify_changes(mr, config)
+        # Verify counts
+        for cat in ChangeCategory:
+            expected = sum(1 for c in result.changes if c.category == cat)
+            assert result.summary[cat.value] == expected

--- a/tests/unit/test_comparison_engine.py
+++ b/tests/unit/test_comparison_engine.py
@@ -1,0 +1,120 @@
+"""Tests for comparison/engine.py — full pipeline orchestrator."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cad_dxf_agent.core.comparison.engine import ComparisonEngine
+from cad_dxf_agent.models.comparison_schema import (
+    ChangeCategory,
+    ComparisonConfig,
+)
+from tests.helpers.comparison_factory import (
+    make_added_removed_pair,
+    make_circle_pair,
+    make_complex_pair,
+    make_empty_vs_populated,
+    make_identical_pair,
+    make_modified_text_pair,
+    make_moved_entity_pair,
+)
+
+
+class TestComparisonEngine:
+    def setup_method(self):
+        self.engine = ComparisonEngine()
+
+    def test_identical_files(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        result = self.engine.compare(master, revision)
+        assert result.total_changes == 0
+        assert result.summary["unchanged"] > 0
+
+    def test_moved_entity(self, tmp_path):
+        master, revision = make_moved_entity_pair(tmp_path, dx=5.0, dy=5.0)
+        config = ComparisonConfig(tolerance=20.0, move_threshold=0.25)
+        result = self.engine.compare(master, revision, config)
+        categories = {c.category for c in result.changes}
+        assert ChangeCategory.MOVED in categories
+
+    def test_added_removed(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = self.engine.compare(master, revision)
+        assert result.summary["added"] >= 1
+        assert result.summary["removed"] >= 1
+
+    def test_modified_text(self, tmp_path):
+        master, revision = make_modified_text_pair(tmp_path)
+        config = ComparisonConfig(tolerance=1.0)
+        result = self.engine.compare(master, revision, config)
+        modified = [c for c in result.changes if c.category == ChangeCategory.MODIFIED]
+        assert len(modified) >= 1
+
+    def test_modified_circle(self, tmp_path):
+        master, revision = make_circle_pair(tmp_path)
+        config = ComparisonConfig(tolerance=1.0)
+        result = self.engine.compare(master, revision, config)
+        modified = [c for c in result.changes if c.category == ChangeCategory.MODIFIED]
+        assert len(modified) >= 1
+
+    def test_empty_master(self, tmp_path):
+        master, revision = make_empty_vs_populated(tmp_path)
+        result = self.engine.compare(master, revision)
+        assert result.summary["added"] >= 1
+        assert result.summary["removed"] == 0
+
+    def test_complex(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        config = ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+        result = self.engine.compare(master, revision, config)
+        assert result.total_changes > 0
+
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            self.engine.compare(tmp_path / "nope.dxf", tmp_path / "nah.dxf")
+
+
+class TestComparisonEngineOutputs:
+    def setup_method(self):
+        self.engine = ComparisonEngine()
+
+    def test_generate_outputs(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        config = ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+        result = self.engine.compare(master, revision, config)
+        output_dir = tmp_path / "outputs"
+        outputs = self.engine.generate_outputs(master, revision, result, output_dir)
+
+        # Changelog
+        assert outputs.changelog is not None
+        assert len(outputs.changelog.entries) > 0
+
+        # Changelog files
+        assert (output_dir / "changelog.json").exists()
+        assert (output_dir / "changelog.txt").exists()
+
+        # Verify JSON is valid
+        data = json.loads((output_dir / "changelog.json").read_text())
+        assert "entries" in data
+
+        # Diff overlay DXF
+        assert outputs.diff_overlay_path is not None
+        assert outputs.diff_overlay_path.exists()
+
+    def test_generate_outputs_identical(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        result = self.engine.compare(master, revision)
+        output_dir = tmp_path / "outputs"
+        outputs = self.engine.generate_outputs(master, revision, result, output_dir)
+        assert outputs.changelog is not None
+        assert len(outputs.changelog.entries) == 0
+
+    def test_output_dir_created(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = self.engine.compare(master, revision)
+        output_dir = tmp_path / "nested" / "output" / "dir"
+        outputs = self.engine.generate_outputs(master, revision, result, output_dir)
+        assert output_dir.exists()
+        assert outputs.diff_overlay_path is not None

--- a/tests/unit/test_comparison_geometry.py
+++ b/tests/unit/test_comparison_geometry.py
@@ -1,0 +1,106 @@
+"""Tests for comparison/geometry.py — geometry extraction from DXF."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.comparison.geometry import extract_snapshots
+from cad_dxf_agent.models.cad_schema import EntityType
+from cad_dxf_agent.models.comparison_schema import ComparisonConfig
+from tests.helpers.comparison_factory import (
+    make_circle_pair,
+    make_complex_pair,
+    make_identical_pair,
+)
+
+
+class TestExtractSnapshots:
+    def test_basic_extraction(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        assert len(snaps) > 0
+
+    def test_line_has_two_points(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        lines = [s for s in snaps if s.entity_type == EntityType.LINE]
+        assert len(lines) >= 1
+        for line in lines:
+            assert len(line.points) == 2
+
+    def test_text_has_content(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        texts = [s for s in snaps if s.entity_type == EntityType.TEXT]
+        assert len(texts) >= 1
+        for text in texts:
+            assert text.text_content is not None
+            assert len(text.points) == 1
+
+    def test_lwpolyline_has_all_vertices(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        polys = [s for s in snaps if s.entity_type == EntityType.LWPOLYLINE]
+        assert len(polys) >= 1
+        for poly in polys:
+            assert len(poly.points) >= 2
+
+    def test_circle_has_radius(self, tmp_path):
+        master, _ = make_circle_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        circles = [s for s in snaps if s.entity_type == EntityType.CIRCLE]
+        assert len(circles) == 1
+        assert circles[0].attributes["radius"] == 10.0
+        assert circles[0].points[0].x == 50.0
+        assert circles[0].points[0].y == 50.0
+
+    def test_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            extract_snapshots(tmp_path / "nonexistent.dxf")
+
+    def test_ignored_layers(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        config = ComparisonConfig(ignored_layers=["NOTES"])
+        snaps = extract_snapshots(master, config)
+        for snap in snaps:
+            assert snap.layer != "NOTES"
+
+    def test_focus_entity_types(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        config = ComparisonConfig(focus_entity_types=[EntityType.LINE])
+        snaps = extract_snapshots(master, config)
+        for snap in snaps:
+            assert snap.entity_type == EntityType.LINE
+
+    def test_centroid_computed(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        for snap in snaps:
+            # Centroid should be finite
+            assert snap.centroid.x != float("inf")
+            assert snap.centroid.y != float("inf")
+
+    def test_handles_are_strings(self, tmp_path):
+        master, _ = make_identical_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        for snap in snaps:
+            assert isinstance(snap.handle, str)
+            assert len(snap.handle) > 0
+
+    def test_complex_drawing(self, tmp_path):
+        master, _ = make_complex_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        types = {s.entity_type for s in snaps}
+        assert EntityType.LINE in types
+        assert EntityType.TEXT in types
+        assert EntityType.LWPOLYLINE in types
+
+
+class TestExtractFromMixedDrawing:
+    """Test extraction from a drawing with multiple entity types."""
+
+    def test_all_entities_have_points(self, tmp_path):
+        master, _ = make_complex_pair(tmp_path)
+        snaps = extract_snapshots(master)
+        for snap in snaps:
+            assert len(snap.points) > 0, f"{snap.entity_type} has no points"

--- a/tests/unit/test_comparison_matcher.py
+++ b/tests/unit/test_comparison_matcher.py
@@ -1,0 +1,147 @@
+"""Tests for comparison/matcher.py — entity matching."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.comparison.geometry import extract_snapshots
+from cad_dxf_agent.core.comparison.matcher import match_entities
+from cad_dxf_agent.models.cad_schema import EntityType, Point2D
+from cad_dxf_agent.models.comparison_schema import (
+    ComparisonConfig,
+    GeometrySnapshot,
+)
+from tests.helpers.comparison_factory import (
+    make_added_removed_pair,
+    make_complex_pair,
+    make_identical_pair,
+    make_moved_entity_pair,
+)
+
+
+class TestFingerprintMatching:
+    """Exact fingerprint match tests."""
+
+    def test_identical_files_all_matched(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        result = match_entities(m_snaps, r_snaps)
+        assert len(result.pairs) == len(m_snaps)
+        assert len(result.master_only) == 0
+        assert len(result.revision_only) == 0
+
+    def test_empty_lists(self):
+        result = match_entities([], [])
+        assert len(result.pairs) == 0
+        assert len(result.master_only) == 0
+        assert len(result.revision_only) == 0
+
+    def test_master_only(self):
+        snap = GeometrySnapshot(
+            handle="A1",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        result = match_entities([snap], [])
+        assert len(result.pairs) == 0
+        assert len(result.master_only) == 1
+        assert len(result.revision_only) == 0
+
+    def test_revision_only(self):
+        snap = GeometrySnapshot(
+            handle="B1",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        result = match_entities([], [snap])
+        assert len(result.pairs) == 0
+        assert len(result.master_only) == 0
+        assert len(result.revision_only) == 1
+
+
+class TestNearestNeighborMatching:
+    """Greedy nearest-neighbor match tests."""
+
+    def test_moved_entity_matched(self, tmp_path):
+        """A moved entity should be matched via nearest-neighbor."""
+        master, revision = make_moved_entity_pair(tmp_path, dx=0.1, dy=0.1)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        result = match_entities(m_snaps, r_snaps)
+        # The slightly moved line should match via NN (within tolerance)
+        assert len(result.pairs) >= 1
+
+    def test_far_moved_entity_unmatched(self, tmp_path):
+        """Entity moved beyond tolerance should NOT match."""
+        master, revision = make_moved_entity_pair(tmp_path, dx=100, dy=100)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        config = ComparisonConfig(tolerance=0.25)
+        result = match_entities(m_snaps, r_snaps, config)
+        # The line should be unmatched (too far)
+        # At least some entities should be in master_only or revision_only
+        total_unmatched = len(result.master_only) + len(result.revision_only)
+        assert total_unmatched > 0
+
+    def test_different_types_not_matched(self):
+        """Entities of different types should never be paired."""
+        m_snap = GeometrySnapshot(
+            handle="A",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=5, y=5), Point2D(x=15, y=5)],
+        )
+        r_snap = GeometrySnapshot(
+            handle="B",
+            entity_type=EntityType.TEXT,
+            layer="S",
+            points=[Point2D(x=5, y=5)],
+            text_content="Hello",
+        )
+        result = match_entities([m_snap], [r_snap])
+        assert len(result.pairs) == 0
+        assert len(result.master_only) == 1
+        assert len(result.revision_only) == 1
+
+    def test_different_layers_not_matched(self):
+        """Same geometry on different layers should not match."""
+        m_snap = GeometrySnapshot(
+            handle="A",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        r_snap = GeometrySnapshot(
+            handle="B",
+            entity_type=EntityType.LINE,
+            layer="NOTES",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        result = match_entities([m_snap], [r_snap])
+        # Fingerprint includes layer, so these won't match
+        assert len(result.pairs) == 0
+
+
+class TestAddedRemovedPair:
+    def test_detects_added_and_removed(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        result = match_entities(m_snaps, r_snaps)
+        # One shared entity should match, rest should be orphans
+        assert len(result.pairs) >= 1
+        assert len(result.master_only) >= 1  # "Old Note" removed
+        assert len(result.revision_only) >= 1  # "New Note" added
+
+
+class TestComplexPair:
+    def test_complex_matching(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        m_snaps = extract_snapshots(master)
+        r_snaps = extract_snapshots(revision)
+        result = match_entities(m_snaps, r_snaps)
+        # Should have some pairs and some orphans
+        assert len(result.pairs) >= 1
+        total = len(result.pairs) + len(result.master_only) + len(result.revision_only)
+        assert total > 0

--- a/tests/unit/test_comparison_overlay.py
+++ b/tests/unit/test_comparison_overlay.py
@@ -1,0 +1,102 @@
+"""Tests for comparison/diff_overlay.py — DXF overlay generation."""
+
+from __future__ import annotations
+
+import ezdxf
+
+from cad_dxf_agent.core.comparison.classifier import classify_changes
+from cad_dxf_agent.core.comparison.diff_overlay import write_diff_overlay
+from cad_dxf_agent.core.comparison.geometry import extract_snapshots
+from cad_dxf_agent.core.comparison.matcher import match_entities
+from cad_dxf_agent.models.comparison_schema import (
+    ComparisonConfig,
+    DiffOverlayLayers,
+)
+from tests.helpers.comparison_factory import (
+    make_added_removed_pair,
+    make_complex_pair,
+    make_identical_pair,
+    make_moved_entity_pair,
+)
+
+
+def _run_pipeline(master, revision, config=None):
+    """Run extract → match → classify for test helpers."""
+    config = config or ComparisonConfig(tolerance=10.0, move_threshold=0.25)
+    m_snaps = extract_snapshots(master, config)
+    r_snaps = extract_snapshots(revision, config)
+    mr = match_entities(m_snaps, r_snaps, config)
+    return classify_changes(mr, config)
+
+
+class TestWriteDiffOverlay:
+    def test_creates_output_file(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "output" / "diff.dxf"
+        output.parent.mkdir()
+        path = write_diff_overlay(master, result, output)
+        assert path.exists()
+        assert path == output
+
+    def test_overlay_has_four_layers(self, tmp_path):
+        master, revision = make_complex_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        doc = ezdxf.readfile(str(output))
+        layer_names = {layer.dxf.name for layer in doc.layers}
+        for layer_name, _ in DiffOverlayLayers.ALL:
+            assert layer_name in layer_names
+
+    def test_added_entities_on_added_layer(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        doc = ezdxf.readfile(str(output))
+        msp = doc.modelspace()
+        added_entities = [e for e in msp if e.dxf.layer == "AI_ADDED"]
+        assert len(added_entities) >= 1
+
+    def test_removed_entities_on_removed_layer(self, tmp_path):
+        master, revision = make_added_removed_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        doc = ezdxf.readfile(str(output))
+        msp = doc.modelspace()
+        removed_entities = [e for e in msp if e.dxf.layer == "AI_REMOVED"]
+        assert len(removed_entities) >= 1
+
+    def test_identical_files_no_overlay_entities(self, tmp_path):
+        master, revision = make_identical_pair(tmp_path)
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        doc = ezdxf.readfile(str(output))
+        msp = doc.modelspace()
+        overlay_layers = {name for name, _ in DiffOverlayLayers.ALL}
+        overlay_entities = [e for e in msp if e.dxf.layer in overlay_layers]
+        assert len(overlay_entities) == 0
+
+    def test_moved_entities_on_moved_layer(self, tmp_path):
+        master, revision = make_moved_entity_pair(tmp_path, dx=5.0, dy=5.0)
+        config = ComparisonConfig(tolerance=20.0, move_threshold=0.25)
+        result = _run_pipeline(master, revision, config)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        doc = ezdxf.readfile(str(output))
+        msp = doc.modelspace()
+        moved_entities = [e for e in msp if e.dxf.layer == "AI_MOVED"]
+        assert len(moved_entities) >= 1
+
+    def test_original_master_untouched(self, tmp_path):
+        """write_diff_overlay should not modify the master file."""
+        master, revision = make_added_removed_pair(tmp_path)
+        master_bytes_before = master.read_bytes()
+        result = _run_pipeline(master, revision)
+        output = tmp_path / "diff.dxf"
+        write_diff_overlay(master, result, output)
+        master_bytes_after = master.read_bytes()
+        assert master_bytes_before == master_bytes_after

--- a/tests/unit/test_comparison_schema.py
+++ b/tests/unit/test_comparison_schema.py
@@ -1,0 +1,276 @@
+"""Tests for comparison_schema.py — Pydantic models."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.models.cad_schema import EntityType, Point2D
+from cad_dxf_agent.models.comparison_schema import (
+    ChangeCategory,
+    ComparisonConfig,
+    ComparisonResult,
+    DiffOverlayLayers,
+    EntityChange,
+    GeometrySnapshot,
+    MatchResult,
+)
+
+
+class TestGeometrySnapshot:
+    def test_centroid_single_point(self):
+        snap = GeometrySnapshot(
+            handle="A1",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            points=[Point2D(x=10, y=20)],
+        )
+        assert snap.centroid.x == 10.0
+        assert snap.centroid.y == 20.0
+
+    def test_centroid_multiple_points(self):
+        snap = GeometrySnapshot(
+            handle="A2",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+        )
+        assert snap.centroid.x == 5.0
+        assert snap.centroid.y == 0.0
+
+    def test_centroid_empty_points(self):
+        snap = GeometrySnapshot(
+            handle="A3",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[],
+        )
+        assert snap.centroid.x == 0.0
+        assert snap.centroid.y == 0.0
+
+    def test_centroid_four_corners(self):
+        snap = GeometrySnapshot(
+            handle="A4",
+            entity_type=EntityType.LWPOLYLINE,
+            layer="STRUCTURAL",
+            points=[
+                Point2D(x=0, y=0),
+                Point2D(x=10, y=0),
+                Point2D(x=10, y=10),
+                Point2D(x=0, y=10),
+            ],
+        )
+        assert snap.centroid.x == 5.0
+        assert snap.centroid.y == 5.0
+
+    def test_optional_fields_default_none(self):
+        snap = GeometrySnapshot(
+            handle="B1",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=0, y=0)],
+        )
+        assert snap.text_content is None
+        assert snap.block_name is None
+        assert snap.attributes == {}
+
+    def test_text_content(self):
+        snap = GeometrySnapshot(
+            handle="B2",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            points=[Point2D(x=5, y=5)],
+            text_content="Hello",
+        )
+        assert snap.text_content == "Hello"
+
+    def test_block_name(self):
+        snap = GeometrySnapshot(
+            handle="B3",
+            entity_type=EntityType.INSERT,
+            layer="STRUCTURAL",
+            points=[Point2D(x=1, y=1)],
+            block_name="COLUMN_MARK",
+        )
+        assert snap.block_name == "COLUMN_MARK"
+
+    def test_attributes(self):
+        snap = GeometrySnapshot(
+            handle="B4",
+            entity_type=EntityType.CIRCLE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=50, y=50)],
+            attributes={"radius": 10.0},
+        )
+        assert snap.attributes["radius"] == 10.0
+
+    def test_serialization_round_trip(self):
+        snap = GeometrySnapshot(
+            handle="C1",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=0, y=0), Point2D(x=10, y=5)],
+            text_content=None,
+            block_name=None,
+            attributes={"custom": "value"},
+        )
+        data = snap.model_dump()
+        restored = GeometrySnapshot(**data)
+        assert restored.handle == "C1"
+        assert restored.centroid.x == 5.0
+        assert restored.centroid.y == 2.5
+
+
+class TestComparisonConfig:
+    def test_defaults(self):
+        config = ComparisonConfig()
+        assert config.tolerance == 0.25
+        assert config.move_threshold == 0.25
+        assert config.ignored_layers == []
+        assert config.focus_entity_types is None
+
+    def test_custom_values(self):
+        config = ComparisonConfig(
+            tolerance=0.5,
+            move_threshold=1.0,
+            ignored_layers=["TEMP"],
+            focus_entity_types=[EntityType.LINE, EntityType.TEXT],
+        )
+        assert config.tolerance == 0.5
+        assert config.focus_entity_types is not None
+        assert len(config.focus_entity_types) == 2
+
+
+class TestChangeCategory:
+    def test_values(self):
+        assert ChangeCategory.ADDED == "added"
+        assert ChangeCategory.REMOVED == "removed"
+        assert ChangeCategory.MODIFIED == "modified"
+        assert ChangeCategory.MOVED == "moved"
+        assert ChangeCategory.UNCHANGED == "unchanged"
+
+    def test_is_strenum(self):
+        assert isinstance(ChangeCategory.ADDED, str)
+
+
+class TestEntityChange:
+    def test_added(self):
+        snap = GeometrySnapshot(
+            handle="X1",
+            entity_type=EntityType.LINE,
+            layer="STRUCTURAL",
+            points=[Point2D(x=0, y=0)],
+        )
+        change = EntityChange(
+            category=ChangeCategory.ADDED,
+            revision_snapshot=snap,
+        )
+        assert change.category == ChangeCategory.ADDED
+        assert change.master_snapshot is None
+        assert change.revision_snapshot is not None
+
+    def test_removed(self):
+        snap = GeometrySnapshot(
+            handle="X2",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            points=[Point2D(x=5, y=5)],
+        )
+        change = EntityChange(
+            category=ChangeCategory.REMOVED,
+            master_snapshot=snap,
+        )
+        assert change.revision_snapshot is None
+
+    def test_moved_with_displacement(self):
+        change = EntityChange(
+            category=ChangeCategory.MOVED,
+            master_snapshot=GeometrySnapshot(
+                handle="M1",
+                entity_type=EntityType.LINE,
+                layer="S",
+                points=[Point2D(x=0, y=0)],
+            ),
+            revision_snapshot=GeometrySnapshot(
+                handle="R1",
+                entity_type=EntityType.LINE,
+                layer="S",
+                points=[Point2D(x=5, y=5)],
+            ),
+            displacement=Point2D(x=5, y=5),
+        )
+        assert change.displacement is not None
+        assert change.displacement.x == 5.0
+
+    def test_modified_with_modifications(self):
+        change = EntityChange(
+            category=ChangeCategory.MODIFIED,
+            master_snapshot=GeometrySnapshot(
+                handle="M2",
+                entity_type=EntityType.TEXT,
+                layer="N",
+                points=[Point2D(x=10, y=10)],
+                text_content="Old",
+            ),
+            revision_snapshot=GeometrySnapshot(
+                handle="R2",
+                entity_type=EntityType.TEXT,
+                layer="N",
+                points=[Point2D(x=10, y=10)],
+                text_content="New",
+            ),
+            modifications={"text_content": {"from": "Old", "to": "New"}},
+        )
+        assert change.modifications is not None
+        assert "text_content" in change.modifications
+
+
+class TestMatchResult:
+    def test_empty(self):
+        mr = MatchResult()
+        assert mr.pairs == []
+        assert mr.master_only == []
+        assert mr.revision_only == []
+
+    def test_with_pairs(self):
+        s1 = GeometrySnapshot(
+            handle="A",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0, y=0)],
+        )
+        s2 = GeometrySnapshot(
+            handle="B",
+            entity_type=EntityType.LINE,
+            layer="S",
+            points=[Point2D(x=0, y=0)],
+        )
+        mr = MatchResult(pairs=[(s1, s2)])
+        assert len(mr.pairs) == 1
+
+
+class TestComparisonResult:
+    def test_default_summary(self):
+        result = ComparisonResult()
+        assert result.summary["added"] == 0
+        assert result.total_changes == 0
+
+    def test_total_changes(self):
+        result = ComparisonResult(
+            summary={"added": 3, "removed": 1, "modified": 2, "moved": 1, "unchanged": 10}
+        )
+        assert result.total_changes == 7
+
+
+class TestDiffOverlayLayers:
+    def test_layer_names(self):
+        assert DiffOverlayLayers.ADDED[0] == "AI_ADDED"
+        assert DiffOverlayLayers.REMOVED[0] == "AI_REMOVED"
+        assert DiffOverlayLayers.MODIFIED[0] == "AI_MODIFIED"
+        assert DiffOverlayLayers.MOVED[0] == "AI_MOVED"
+
+    def test_color_codes(self):
+        assert DiffOverlayLayers.ADDED[1] == 3  # green
+        assert DiffOverlayLayers.REMOVED[1] == 1  # red
+        assert DiffOverlayLayers.MODIFIED[1] == 2  # yellow
+        assert DiffOverlayLayers.MOVED[1] == 4  # cyan
+
+    def test_all_list(self):
+        assert len(DiffOverlayLayers.ALL) == 4

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -5,7 +5,8 @@ Routes:
     POST /api/upload     — Upload DXF/PDF, get session + file info
     POST /api/plan       — Send prompt, get planned operations + preview
     POST /api/apply      — Apply selected operations
-    GET  /api/render     — Get PNG render (original/edited/diff)
+    POST /api/compare    — Upload revision DXF, compare against master
+    GET  /api/render     — Get PNG render (original/edited/diff/comparison)
     GET  /api/download   — Download edited DXF
 """
 
@@ -357,6 +358,78 @@ async def clear_history(body: ClearHistoryRequest, user: dict = Depends(get_user
     return {"message": "Conversation cleared."}
 
 
+@app.post("/api/compare")
+async def compare(
+    file: UploadFile = File(...),
+    session_id: str = Query(...),
+    user: dict = Depends(get_user),
+):
+    """Upload a revision DXF and compare against the session's master file."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    ext = Path(file.filename).suffix.lower()
+    if ext != ".dxf":
+        raise HTTPException(status_code=400, detail="Comparison requires a .dxf file")
+
+    try:
+        session = session_mgr.get(session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    if session.original_path is None or not session.original_path.exists():
+        raise HTTPException(status_code=400, detail="No master file loaded. Upload a file first.")
+
+    # Save revision file
+    session_dir = Path("/tmp/cad-sessions") / session.session_id
+    revision_path = session_dir / "revision.dxf"
+    content = await file.read()
+    revision_path.write_bytes(content)
+
+    try:
+        from cad_dxf_agent.core.comparison.engine import ComparisonEngine
+
+        engine = ComparisonEngine()
+        result = engine.compare(session.original_path, revision_path)
+
+        # Generate outputs
+        output_dir = session_dir / "comparison"
+        outputs = engine.generate_outputs(
+            session.original_path, revision_path, result, output_dir
+        )
+
+        # Store in session
+        session.comparison_result = result
+        session.comparison_changelog = outputs.changelog
+        session.diff_overlay_path = outputs.diff_overlay_path
+
+        # Render diff overlay preview
+        if outputs.diff_overlay_path and outputs.diff_overlay_path.exists():
+            try:
+                from cad_dxf_agent.core.renderer import render_dxf_to_png
+
+                render_result = render_dxf_to_png(
+                    outputs.diff_overlay_path, session_dir / "comparison.png"
+                )
+                if render_result.success:
+                    session.diff_overlay_render = render_result.output_path
+            except Exception as e:
+                logger.warning("Comparison render failed (non-fatal): %s", e)
+
+        return {
+            "summary": result.summary,
+            "total_changes": result.total_changes,
+            "changelog": outputs.changelog.to_json(),
+            "render_available": session.diff_overlay_render is not None,
+        }
+
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Comparison failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Comparison failed: {e}")
+
+
 @app.get("/api/render")
 async def render(
     session_id: str = Query(...),
@@ -377,6 +450,7 @@ async def render(
         "original": session.original_render,
         "edited": session.edited_render,
         "diff": session.diff_render,
+        "comparison": session.diff_overlay_render,
     }
     path = render_map.get(type)
 

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -33,6 +33,11 @@ class Session:
     context: object | None = None
     file_info: dict = field(default_factory=dict)
     conversation_history: list[dict] = field(default_factory=list)
+    # Comparison state
+    comparison_result: object | None = None
+    comparison_changelog: object | None = None
+    diff_overlay_path: Path | None = None
+    diff_overlay_render: Path | None = None
 
 
 class SessionManager:

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -1,19 +1,45 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const TABS = [
   { key: 'original', label: 'Original' },
   { key: 'edited', label: 'Edited' },
   { key: 'diff', label: 'Diff' },
+  { key: 'comparison', label: 'Compare' },
 ];
 
-export default function PreviewPanel({ previewUrls, operations, selectedOps, onToggleOp, onApply, onDownload, loading }) {
+export default function PreviewPanel({
+  previewUrls,
+  operations,
+  selectedOps,
+  onToggleOp,
+  onApply,
+  onDownload,
+  onCompare,
+  comparisonResult,
+  loading,
+}) {
   const [activeTab, setActiveTab] = useState('original');
   const hasEdited = !!previewUrls.edited;
   const hasOperations = operations.length > 0;
+  const hasComparison = !!previewUrls.comparison;
+  const revisionInputRef = useRef(null);
 
   useEffect(() => {
     if (previewUrls.edited) setActiveTab('edited');
   }, [previewUrls.edited]);
+
+  useEffect(() => {
+    if (previewUrls.comparison) setActiveTab('comparison');
+  }, [previewUrls.comparison]);
+
+  const handleRevisionUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (file && onCompare) {
+      onCompare(file);
+    }
+    // Reset input so re-uploading same file triggers change
+    if (revisionInputRef.current) revisionInputRef.current.value = '';
+  };
 
   return (
     <div className="preview">
@@ -42,10 +68,65 @@ export default function PreviewPanel({ previewUrls, operations, selectedOps, onT
           <div className="preview__placeholder">
             {activeTab === 'original'
               ? 'Upload a file to see the preview'
-              : 'Run an edit to see the result'}
+              : activeTab === 'comparison'
+                ? 'Upload a revision DXF to compare against the original'
+                : 'Run an edit to see the result'}
           </div>
         )}
       </div>
+
+      {/* Comparison summary */}
+      {activeTab === 'comparison' && comparisonResult && (
+        <div className="comparison-summary">
+          <h4 className="op-list__title">Comparison Results</h4>
+          <div className="comparison-summary__grid">
+            {comparisonResult.summary.added > 0 && (
+              <span className="comparison-badge comparison-badge--added">
+                +{comparisonResult.summary.added} added
+              </span>
+            )}
+            {comparisonResult.summary.removed > 0 && (
+              <span className="comparison-badge comparison-badge--removed">
+                -{comparisonResult.summary.removed} removed
+              </span>
+            )}
+            {comparisonResult.summary.modified > 0 && (
+              <span className="comparison-badge comparison-badge--modified">
+                ~{comparisonResult.summary.modified} modified
+              </span>
+            )}
+            {comparisonResult.summary.moved > 0 && (
+              <span className="comparison-badge comparison-badge--moved">
+                &rarr;{comparisonResult.summary.moved} moved
+              </span>
+            )}
+            {comparisonResult.total_changes === 0 && (
+              <span className="comparison-badge">No changes detected</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Upload revision button (always visible when file loaded) */}
+      {activeTab === 'comparison' && onCompare && (
+        <div style={{ marginTop: 'var(--space-2)' }}>
+          <input
+            ref={revisionInputRef}
+            type="file"
+            accept=".dxf"
+            onChange={handleRevisionUpload}
+            style={{ display: 'none' }}
+            id="revision-upload"
+          />
+          <button
+            className="btn btn--secondary btn--full"
+            onClick={() => revisionInputRef.current?.click()}
+            disabled={loading}
+          >
+            {loading ? <span className="spinner" aria-hidden="true" /> : 'Upload Revision DXF'}
+          </button>
+        </div>
+      )}
 
       {hasOperations && (
         <div className="op-list">

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -5,7 +5,7 @@ import PreviewPanel from './PreviewPanel';
 
 export default function Workspace({ user, onSignOut }) {
   const session = useSession();
-  const { fileInfo, sessionId, messages, operations, selectedOps, previewUrls, loading, error } = session;
+  const { fileInfo, sessionId, messages, operations, selectedOps, previewUrls, comparisonResult, loading, error } = session;
 
   return (
     <div className="page" style={{ height: '100vh', overflow: 'hidden' }}>
@@ -93,6 +93,8 @@ export default function Workspace({ user, onSignOut }) {
               onToggleOp={session.toggleOp}
               onApply={() => session.apply()}
               onDownload={session.download}
+              onCompare={session.compareRevision}
+              comparisonResult={comparisonResult}
               loading={loading}
             />
           </section>

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { uploadFile, planEdit, applyChanges, downloadFile, getRenderBlob, clearHistory } from '../lib/api';
+import { uploadFile, planEdit, applyChanges, downloadFile, getRenderBlob, clearHistory, compareFiles } from '../lib/api';
 
 const NO_CHANGES_MESSAGE = "I couldn't plan any changes. Try being more specific about which element to edit.";
 
@@ -11,6 +11,7 @@ export function useSession() {
   const [selectedOps, setSelectedOps] = useState([]);
   const [validation, setValidation] = useState(null);
   const [previewUrls, setPreviewUrls] = useState({ original: null, edited: null, diff: null });
+  const [comparisonResult, setComparisonResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -134,6 +135,35 @@ export function useSession() {
     setValidation(null);
   }, [sessionId]);
 
+  const compareRevision = useCallback(async (file) => {
+    if (!sessionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await compareFiles(sessionId, file);
+      setComparisonResult(data);
+      setMessages((prev) => [...prev, {
+        role: 'system',
+        text: `Comparison complete: ${data.total_changes} change(s) found — ${data.summary.added || 0} added, ${data.summary.removed || 0} removed, ${data.summary.modified || 0} modified, ${data.summary.moved || 0} moved.`,
+      }]);
+
+      // Fetch comparison render
+      if (data.render_available) {
+        try {
+          const blob = await getRenderBlob(sessionId, 'comparison');
+          const url = URL.createObjectURL(blob);
+          setPreviewUrls((prev) => ({ ...prev, comparison: url }));
+        } catch (renderErr) {
+          console.warn('[cad] Comparison render fetch failed:', renderErr.message);
+        }
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
   const reset = useCallback(() => {
     // Revoke blob URLs to free memory
     Object.values(previewUrls).forEach((url) => {
@@ -145,7 +175,8 @@ export function useSession() {
     setOperations([]);
     setSelectedOps([]);
     setValidation(null);
-    setPreviewUrls({ original: null, edited: null, diff: null });
+    setPreviewUrls({ original: null, edited: null, diff: null, comparison: null });
+    setComparisonResult(null);
     setError(null);
   }, [previewUrls]);
 
@@ -157,6 +188,7 @@ export function useSession() {
     selectedOps,
     validation,
     previewUrls,
+    comparisonResult,
     loading,
     error,
     clearError,
@@ -165,6 +197,7 @@ export function useSession() {
     toggleOp,
     apply,
     download,
+    compareRevision,
     clearConversation,
     reset,
   };

--- a/web/frontend/src/lib/api.js
+++ b/web/frontend/src/lib/api.js
@@ -80,6 +80,17 @@ export async function getRenderBlob(sessionId, type = 'original') {
   return res.blob();
 }
 
+export async function compareFiles(sessionId, revisionFile) {
+  const formData = new FormData();
+  formData.append('file', revisionFile);
+
+  const res = await request(`/api/compare?session_id=${sessionId}`, {
+    method: 'POST',
+    body: formData,
+  });
+  return res.json();
+}
+
 export async function downloadFile(sessionId) {
   const res = await request(`/api/download?session_id=${sessionId}`);
   const blob = await res.blob();

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -581,3 +581,49 @@
     transform: translateY(0);
   }
 }
+
+/* Comparison summary */
+.comparison-summary {
+  padding: var(--space-3);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+}
+
+.comparison-summary__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.comparison-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  border-radius: var(--radius-full);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.comparison-badge--added {
+  background: var(--accent-success-light);
+  color: var(--accent-success);
+}
+
+.comparison-badge--removed {
+  background: var(--accent-danger-light);
+  color: var(--accent-danger);
+}
+
+.comparison-badge--modified {
+  background: var(--accent-warning-light);
+  color: var(--accent-warning);
+}
+
+.comparison-badge--moved {
+  background: var(--accent-primary-light);
+  color: var(--accent-primary);
+}


### PR DESCRIPTION
## Summary

- Adds a **deterministic geometry comparison engine** that takes a master and revision DXF, identifies changes (added/removed/modified/moved), generates color-coded diff overlay layers, and produces structured change logs
- No LLM involved — purely geometric fingerprint hashing + greedy nearest-neighbor matching
- Web integration: `POST /api/compare` endpoint, "Compare" tab with revision upload and summary badges
- 86 new tests, all passing; existing 297+ tests unaffected

## New modules

| Module | Purpose |
|--------|---------|
| `comparison_schema.py` | Pydantic models: GeometrySnapshot, ComparisonConfig, EntityChange, ComparisonResult |
| `geometry.py` | Extract full point data from ezdxf entities |
| `matcher.py` | Fingerprint hash (exact) + greedy nearest-neighbor (fuzzy) matching |
| `classifier.py` | Classify pairs as unchanged/moved/modified + orphans as added/removed |
| `diff_overlay.py` | Write AI_ADDED (green), AI_REMOVED (red), AI_MODIFIED (yellow), AI_MOVED (cyan) layers |
| `changelog.py` | JSON + human-readable change log generation |
| `engine.py` | ComparisonEngine orchestrator |

## Test plan

- [x] `pytest tests/unit/test_comparison_*.py -v` — 86 tests pass
- [x] `ruff check` — clean
- [x] `mypy src/` — 0 errors
- [x] Full test suite — 670 passed (2 pre-existing live API flakes)
- [ ] Manual: upload master → upload revision → see diff overlay + change log
- [ ] CI: verify GH Actions passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full DXF comparison engine: extract, match, classify changes (added/removed/modified/moved) and produce structured results.
  * Changelog generation in JSON and human-readable text with categorized entries and summaries.
  * Color-coded diff overlay DXF export and optional preview render.
  * UI & API integration: upload revision files, run comparisons, see badges/counts, and view/download outputs.

* **Tests**
  * Comprehensive unit tests and helpers covering extraction, matching, classification, overlay, and end-to-end flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->