### PR TITLE
feat: Manual control-point alignment for shifted drawings

### DIFF
--- a/src/cad_dxf_agent/cli/commands.py
+++ b/src/cad_dxf_agent/cli/commands.py
@@ -19,6 +19,23 @@ from ..models.comparison_schema import AlignmentConfig, ComparisonConfig
 from . import formatters
 
 
+def _parse_control_points(
+    raw: list[str] | None,
+) -> list[tuple[tuple[float, float], tuple[float, float]]] | None:
+    """Parse --control-points strings like '0,0:5,3' into typed tuples."""
+    if not raw:
+        return None
+    pairs: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    for token in raw:
+        master_str, _, rev_str = token.partition(":")
+        if not rev_str:
+            raise ValueError(f"Invalid control point format (expected mx,my:rx,ry): {token!r}")
+        mx, my = (float(v) for v in master_str.split(","))
+        rx, ry = (float(v) for v in rev_str.split(","))
+        pairs.append(((mx, my), (rx, ry)))
+    return pairs
+
+
 def _validate_inputs(master: str, revision: str) -> tuple[Path, Path]:
     """Validate that both input files exist, raising FileNotFoundError if not."""
     mp = Path(master)
@@ -37,7 +54,9 @@ def cmd_diff(args: Namespace) -> int:
     """
     master_path, revision_path = _validate_inputs(args.master, args.revision)
 
-    config = ComparisonConfig(tolerance=args.tolerance)
+    control_points = _parse_control_points(getattr(args, "control_points", None))
+    alignment = AlignmentConfig(enabled=bool(control_points), control_points=control_points)
+    config = ComparisonConfig(tolerance=args.tolerance, alignment=alignment)
     engine = ComparisonEngine()
     result = engine.compare(master_path, revision_path, config)
 
@@ -60,9 +79,12 @@ def cmd_align(args: Namespace) -> int:
     """
     master_path, revision_path = _validate_inputs(args.master, args.revision)
 
+    control_points = _parse_control_points(getattr(args, "control_points", None))
     config = AlignmentConfig(
+        enabled=True,
         confidence_threshold=args.confidence,
         max_residual=args.max_residual,
+        control_points=control_points,
     )
 
     master_snaps = extract_snapshots(master_path)

--- a/src/cad_dxf_agent/cli/main.py
+++ b/src/cad_dxf_agent/cli/main.py
@@ -28,6 +28,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_diff.add_argument(
         "--tolerance", type=float, default=1.0, help="Coordinate tolerance (default: 1.0)"
     )
+    _add_control_points_arg(p_diff)
 
     # hidden alias: compare
     p_compare = sub.add_parser("compare")
@@ -46,6 +47,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_align.add_argument(
         "--max-residual", type=float, default=5.0, help="Max RMS residual (default: 5.0)"
     )
+    _add_control_points_arg(p_align)
 
     # --- dry-run ---
     p_dryrun = sub.add_parser("dry-run", help="Show proposed ops without applying")
@@ -78,6 +80,16 @@ def _add_input_args(parser: argparse.ArgumentParser) -> None:
     """Add the shared master/revision positional arguments."""
     parser.add_argument("master", help="Path to master (original) DXF file")
     parser.add_argument("revision", help="Path to revision (modified) DXF file")
+
+
+def _add_control_points_arg(parser: argparse.ArgumentParser) -> None:
+    """Add the --control-points flag for manual alignment."""
+    parser.add_argument(
+        "--control-points",
+        nargs="*",
+        metavar="MX,MY:RX,RY",
+        help='Manual alignment control point pairs, format: "mx,my:rx,ry"',
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/cad_dxf_agent/core/comparison/alignment.py
+++ b/src/cad_dxf_agent/core/comparison/alignment.py
@@ -538,6 +538,57 @@ def try_feature_alignment(
 
 
 # ---------------------------------------------------------------------------
+# Manual alignment from user-supplied control points
+# ---------------------------------------------------------------------------
+
+
+def try_manual_alignment(
+    master_snaps: list[GeometrySnapshot],
+    revision_snaps: list[GeometrySnapshot],
+    config: AlignmentConfig,
+) -> AlignmentResult:
+    """Compute alignment from user-supplied control point pairs.
+
+    Args:
+        master_snaps: Canonical snapshots from master DXF.
+        revision_snaps: Canonical snapshots from revision DXF.
+        config: Alignment configuration (must have control_points set).
+
+    Returns:
+        AlignmentResult with method=manual. Always returns a result
+        (user points are trusted); confidence reflects geometric quality.
+    """
+    assert config.control_points is not None
+    pairs = config.control_points
+
+    m_pts = np.array([mp for mp, _rp in pairs])
+    r_pts = np.array([rp for _mp, rp in pairs])
+
+    if len(pairs) == 1:
+        # Pure translation: t = master_pt - revision_pt, R = I
+        R = np.eye(2)
+        t = m_pts[0] - r_pts[0]
+    else:
+        # 2+ points: rigid transform via Kabsch
+        R, t = _kabsch(m_pts, r_pts)
+
+    rot_deg = _rotation_to_degrees(R)
+    rc = r_pts.mean(axis=0)
+
+    diag = score_alignment(m_pts, r_pts, R, t, master_snaps, revision_snaps, config.max_residual)
+    confidence = compute_confidence(diag, config.max_residual)
+
+    return AlignmentResult(
+        method=AlignmentMethod.manual,
+        confidence=confidence,
+        translation=(float(t[0]), float(t[1])),
+        rotation_deg=round(rot_deg, 6),
+        rotation_center=(float(rc[0]), float(rc[1])),
+        diagnostics=diag,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Ladder orchestrator
 # ---------------------------------------------------------------------------
 
@@ -576,6 +627,22 @@ def align_drawings(
     """
     with tracer.start_as_current_span("cad.compare.align_drawings") as span:
         attempts: list[AlignmentAttempt] = []
+
+        # Manual control points take priority over the automatic ladder
+        if config.control_points:
+            logger.info("Alignment: using %d manual control points", len(config.control_points))
+            manual_result = try_manual_alignment(master_snaps, revision_snaps, config)
+            attempts.append(
+                AlignmentAttempt(
+                    method="manual",
+                    success=True,
+                    confidence=manual_result.confidence,
+                )
+            )
+            manual_result.diagnostics.attempts = attempts
+            span.set_attribute("cad.align.method", "manual")
+            span.set_attribute("cad.align.confidence", manual_result.confidence)
+            return manual_result
 
         for method_name, method_fn in _LADDER_STEPS:
             logger.info("Alignment: trying %s", method_name)

--- a/src/cad_dxf_agent/models/comparison_schema.py
+++ b/src/cad_dxf_agent/models/comparison_schema.py
@@ -42,6 +42,14 @@ class AlignmentConfig(BaseModel):
         default_factory=lambda: ["GRID*", "COLUMN*", "AXIS*"],
         description="Layer name glob patterns to search for anchor blocks",
     )
+    control_points: list[tuple[tuple[float, float], tuple[float, float]]] | None = Field(
+        default=None,
+        description=(
+            "User-supplied control point pairs for manual alignment. "
+            "Each entry is (master_xy, revision_xy). "
+            "1 point = translation only, 2+ = rigid via Kabsch."
+        ),
+    )
 
 
 class AlignmentAttempt(BaseModel):

--- a/tests/unit/test_alignment.py
+++ b/tests/unit/test_alignment.py
@@ -26,6 +26,7 @@ from cad_dxf_agent.core.comparison.alignment import (
     score_alignment,
     try_anchor_alignment,
     try_feature_alignment,
+    try_manual_alignment,
 )
 from cad_dxf_agent.core.comparison.geometry import extract_snapshots
 from cad_dxf_agent.models.cad_schema import EntityType, Point2D
@@ -668,3 +669,95 @@ class TestApplyAlignment:
         assert result[0].text_content == "Hello"
         assert result[0].stable_id == "TEXT:NOTES:abc123"
         assert result[0].entity_type == EntityType.TEXT
+
+
+# ---------------------------------------------------------------------------
+# cad-31i.5: Manual control-point alignment
+# ---------------------------------------------------------------------------
+
+
+class TestManualAlignment:
+    """Manual control-point alignment tests (cad-31i.5)."""
+
+    def test_manual_pure_translation(self):
+        """Single control point → pure translation, no rotation."""
+        m = [_make_snap(0, 0), _make_snap(10, 10)]
+        r = [_make_snap(5, 3), _make_snap(15, 13)]
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=10.0,
+            control_points=[((0.0, 0.0), (5.0, 3.0))],
+        )
+        result = try_manual_alignment(m, r, cfg)
+        assert result.method == AlignmentMethod.manual
+        assert abs(result.translation[0] - (-5.0)) < 0.001
+        assert abs(result.translation[1] - (-3.0)) < 0.001
+        assert abs(result.rotation_deg) < 0.001
+
+    def test_manual_two_points(self):
+        """Two control points → rigid transform via Kabsch."""
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=10.0,
+            control_points=[
+                ((0.0, 0.0), (5.0, 3.0)),
+                ((100.0, 0.0), (105.0, 3.0)),
+            ],
+        )
+        m = [_make_snap(0, 0), _make_snap(100, 0)]
+        r = [_make_snap(5, 3), _make_snap(105, 3)]
+        result = try_manual_alignment(m, r, cfg)
+        assert result.method == AlignmentMethod.manual
+        assert abs(result.translation[0] - (-5.0)) < 0.1
+        assert abs(result.translation[1] - (-3.0)) < 0.1
+
+    def test_manual_with_offset_pair(self, tmp_path):
+        """Offset DXF pair + correct control points → high confidence."""
+        master_path, rev_path = make_offset_pair(tmp_path, dx=5.0, dy=3.0)
+        m_snaps = extract_snapshots(master_path)
+        r_snaps = extract_snapshots(rev_path)
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=20.0,
+            control_points=[
+                ((0.0, 0.0), (5.0, 3.0)),
+                ((100.0, 0.0), (105.0, 3.0)),
+            ],
+        )
+        result = try_manual_alignment(m_snaps, r_snaps, cfg)
+        assert result.method == AlignmentMethod.manual
+        assert result.confidence > 0.3
+
+    def test_manual_bypasses_ladder(self):
+        """Control points set → ladder skipped, manual method returned."""
+        m = [_make_snap(0, 0), _make_snap(10, 10)]
+        r = [_make_snap(0, 0), _make_snap(10, 10)]  # identical = identity would win
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=10.0,
+            control_points=[((0.0, 0.0), (1.0, 1.0))],  # bogus offset
+        )
+        result = align_drawings(m, r, cfg)
+        assert result.method == AlignmentMethod.manual
+        # Only one attempt recorded (manual), not identity/anchor/feature
+        assert len(result.diagnostics.attempts) == 1
+        assert result.diagnostics.attempts[0].method == "manual"
+
+    def test_manual_bad_points_still_returns(self):
+        """Wrong control points → result still returned, low confidence."""
+        m = [_make_snap(0, 0), _make_snap(10, 10)]
+        r = [_make_snap(500, 500), _make_snap(600, 600)]
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=1.0,
+            control_points=[((0.0, 0.0), (999.0, 999.0))],  # wrong
+        )
+        result = try_manual_alignment(m, r, cfg)
+        assert result.method == AlignmentMethod.manual
+        # Result is returned (not None) but overlap should be zero
+        assert result.diagnostics.overlap_ratio == 0.0

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -8,6 +8,7 @@ from argparse import Namespace
 import pytest
 
 from cad_dxf_agent.cli.commands import (
+    cmd_align,
     cmd_apply,
     cmd_bundle,
     cmd_diff,
@@ -17,6 +18,7 @@ from tests.helpers.comparison_factory import (
     make_complex_pair,
     make_identical_pair,
     make_moved_entity_pair,
+    make_offset_pair,
 )
 
 
@@ -107,6 +109,24 @@ class TestCmdDiff:
         )
         with pytest.raises(FileNotFoundError):
             cmd_diff(args)
+
+
+class TestCmdAlign:
+    def test_align_with_control_points(self, tmp_path, capsys):
+        master, revision = make_offset_pair(tmp_path, dx=5.0, dy=3.0)
+        args = Namespace(
+            master=str(master),
+            revision=str(revision),
+            confidence=0.3,
+            max_residual=20.0,
+            control_points=["0,0:5,3", "100,0:105,3"],
+            json=False,
+            verbose=False,
+        )
+        rc = cmd_align(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "manual" in out.lower()
 
 
 class TestCmdApply:

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -84,6 +84,20 @@ class TestAlignCommand:
         assert args.confidence == 0.8
         assert args.max_residual == 2.0
 
+    def test_align_control_points_flag(self, parser):
+        args = parser.parse_args(
+            ["align", "m.dxf", "r.dxf", "--control-points", "0,0:5,3", "100,0:105,3"]
+        )
+        assert args.control_points == ["0,0:5,3", "100,0:105,3"]
+
+    def test_align_control_points_none_by_default(self, parser):
+        args = parser.parse_args(["align", "m.dxf", "r.dxf"])
+        assert args.control_points is None
+
+    def test_diff_control_points_flag(self, parser):
+        args = parser.parse_args(["diff", "m.dxf", "r.dxf", "--control-points", "0,0:5,3"])
+        assert args.control_points == ["0,0:5,3"]
+
 
 class TestDryRunCommand:
     def test_basic_dry_run(self, parser):


### PR DESCRIPTION
## Summary

The automatic alignment ladder (identity → anchor → feature) works well for most drawings, but breaks down when there's a large coordinate offset, rotation, or no shared anchor blocks between master and revision files. The guidance text already told users to "supply 2-3 control point pairs" — this PR delivers the implementation behind that promise.

- Adds `control_points` field to `AlignmentConfig` for user-supplied `(master_xy, revision_xy)` pairs
- Implements `try_manual_alignment()` — one point gives pure translation, two or more feed the existing Kabsch SVD solver for full rigid transform
- Wires manual path into `align_drawings()` so control points take priority over the automatic ladder
- Adds `--control-points "mx,my:rx,ry"` flag to `align` and `diff` CLI subcommands
- 10 new tests across alignment logic, CLI parsing, and end-to-end command execution

## Usage

```bash
cad-revision align master.dxf revision.dxf \
  --control-points "0,0:5,3" "100,0:105,3"

cad-revision diff master.dxf revision.dxf \
  --control-points "0,0:5,3"
```

## Test plan

- [x] `mypy` clean on all modified files
- [x] `ruff check` + `ruff format --check` pass
- [x] 91 targeted tests pass (test_alignment, test_cli_parsing, test_cli_commands)
- [x] Full suite: 992 passed, 15 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual alignment for CAD drawings using control point pairs in align and diff operations. Single control points enable translation-only alignment; multiple points enable rigid geometric transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->