### PR TITLE
feat: save/load/list ComparisonProfile with builtin presets (cad-v4f.4)

### DIFF
--- a/src/cad_dxf_agent/core/profiles.py
+++ b/src/cad_dxf_agent/core/profiles.py
@@ -1,0 +1,70 @@
+"""Save, load, and list ComparisonProfile presets and user profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cad_dxf_agent.models.comparison_schema import ComparisonProfile
+from cad_dxf_agent.settings import settings
+
+BUILTIN_PROFILES: dict[str, ComparisonProfile] = {
+    "structural": ComparisonProfile.structural(),
+    "all": ComparisonProfile.all_entities(),
+}
+
+_BUILTIN_NAMES = frozenset(BUILTIN_PROFILES)
+
+
+def _default_user_dir() -> Path:
+    return settings.data_dir / "profiles"
+
+
+def list_profiles(user_dir: Path | None = None) -> dict[str, ComparisonProfile]:
+    """Return builtin profiles merged with any user-saved JSON profiles.
+
+    User profiles with the same name as a builtin are ignored (builtins win).
+    """
+    result = dict(BUILTIN_PROFILES)
+    directory = user_dir if user_dir is not None else _default_user_dir()
+    if directory.is_dir():
+        for path in sorted(directory.glob("*.json")):
+            name = path.stem
+            if name not in _BUILTIN_NAMES:
+                result[name] = ComparisonProfile.model_validate_json(path.read_text())
+    return result
+
+
+def load_profile(name: str, user_dir: Path | None = None) -> ComparisonProfile:
+    """Load a profile by name — builtins first, then user directory.
+
+    Raises:
+        KeyError: If no profile with that name exists.
+    """
+    if name in BUILTIN_PROFILES:
+        return BUILTIN_PROFILES[name]
+
+    directory = user_dir if user_dir is not None else _default_user_dir()
+    path = directory / f"{name}.json"
+    if path.is_file():
+        return ComparisonProfile.model_validate_json(path.read_text())
+
+    raise KeyError(f"Profile not found: {name!r}")
+
+
+def save_profile(profile: ComparisonProfile, user_dir: Path | None = None) -> Path:
+    """Save a profile to the user directory as JSON.
+
+    Raises:
+        ValueError: If the profile name collides with a builtin.
+    """
+    if profile.name in _BUILTIN_NAMES:
+        raise ValueError(
+            f"Cannot overwrite builtin profile {profile.name!r}. "
+            f"Choose a different name."
+        )
+
+    directory = user_dir if user_dir is not None else _default_user_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{profile.name}.json"
+    path.write_text(profile.model_dump_json(indent=2))
+    return path

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -1,0 +1,82 @@
+"""Tests for profile persistence (save/load/list)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cad_dxf_agent.core.profiles import (
+    BUILTIN_PROFILES,
+    list_profiles,
+    load_profile,
+    save_profile,
+)
+from cad_dxf_agent.models.comparison_schema import ComparisonProfile
+
+
+class TestBuiltinProfiles:
+    def test_builtin_profiles_available(self) -> None:
+        assert "structural" in BUILTIN_PROFILES
+        assert "all" in BUILTIN_PROFILES
+
+    def test_load_builtin(self) -> None:
+        profile = load_profile("structural")
+        assert profile.name == "structural"
+        assert len(profile.exclude_layers) > 0
+
+    def test_load_unknown_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(KeyError, match="no-such-profile"):
+            load_profile("no-such-profile", user_dir=tmp_path)
+
+
+class TestSaveLoad:
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        custom = ComparisonProfile(
+            name="my-custom",
+            description="Custom test profile",
+            exclude_layers=[r"(?i)^junk"],
+            tolerance=0.5,
+        )
+        path = save_profile(custom, user_dir=tmp_path)
+        assert path.exists()
+        assert path.name == "my-custom.json"
+
+        loaded = load_profile("my-custom", user_dir=tmp_path)
+        assert loaded.name == custom.name
+        assert loaded.description == custom.description
+        assert loaded.exclude_layers == custom.exclude_layers
+        assert loaded.tolerance == custom.tolerance
+
+    def test_save_builtin_name_rejected(self, tmp_path: Path) -> None:
+        for name in ("structural", "all"):
+            profile = ComparisonProfile(name=name)
+            with pytest.raises(ValueError, match="builtin"):
+                save_profile(profile, user_dir=tmp_path)
+
+    def test_save_overwrites_existing(self, tmp_path: Path) -> None:
+        v1 = ComparisonProfile(name="evolving", description="version 1")
+        save_profile(v1, user_dir=tmp_path)
+
+        v2 = ComparisonProfile(name="evolving", description="version 2")
+        save_profile(v2, user_dir=tmp_path)
+
+        loaded = load_profile("evolving", user_dir=tmp_path)
+        assert loaded.description == "version 2"
+
+
+class TestListProfiles:
+    def test_list_includes_builtins(self, tmp_path: Path) -> None:
+        profiles = list_profiles(user_dir=tmp_path)
+        assert "structural" in profiles
+        assert "all" in profiles
+
+    def test_list_includes_user_profiles(self, tmp_path: Path) -> None:
+        custom = ComparisonProfile(name="user-one", description="User profile")
+        save_profile(custom, user_dir=tmp_path)
+
+        profiles = list_profiles(user_dir=tmp_path)
+        assert "user-one" in profiles
+        assert profiles["user-one"].description == "User profile"
+        # Builtins still present
+        assert "structural" in profiles


### PR DESCRIPTION
## Summary
- Add `core/profiles.py` module with `save_profile`, `load_profile`, `list_profiles` functions and `BUILTIN_PROFILES` dict
- Builtin presets ("structural", "all") always available; user profiles persist as JSON to `~/.cad-dxf-agent/profiles/`
- Builtin names are reserved — `save_profile` rejects collisions with ValueError

## Test plan
- [x] 8 unit tests in `tests/unit/test_profiles.py` (all use `tmp_path`, no filesystem side effects)
- [x] Full test suite passes (1087 passed)
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now save and load custom comparison profiles; built-in profiles (structural and all_entities) are available by default.

* **Tests**
  * Added comprehensive unit tests for profile persistence, loading, saving, and listing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->