### PR TITLE
feat: license gate + DWG support via server-side ODA

### DIFF
--- a/web/backend/Dockerfile
+++ b/web/backend/Dockerfile
@@ -12,6 +12,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libfontconfig1 \
     && rm -rf /var/lib/apt/lists/*
 
+# Install ODA File Converter for DWG support
+RUN apt-get update && apt-get install -y --no-install-recommends wget \
+    && wget -q "https://download.opendesign.com/guestfiles/ODAFileConverter/ODAFileConverter_QT6_lnxX64_8.3dll_25.12.deb" \
+       -O /tmp/oda.deb \
+    && dpkg -i /tmp/oda.deb || apt-get install -f -y \
+    && rm /tmp/oda.deb \
+    && apt-get purge -y wget \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Python deps (everything in one layer)
 COPY web/backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/web/backend/Dockerfile
+++ b/web/backend/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
     && wget -q "https://download.opendesign.com/guestfiles/ODAFileConverter/ODAFileConverter_QT6_lnxX64_8.3dll_25.12.deb" \
        -O /tmp/oda.deb \
-    && dpkg -i /tmp/oda.deb || apt-get install -f -y \
+    && echo "15facc7301b905a1b1aa742f7eeb936f96a1ad3f1828e8db7a444f4b572c7395  /tmp/oda.deb" | sha256sum -c - \
+    && (dpkg -i /tmp/oda.deb || apt-get install -f -y) \
     && rm /tmp/oda.deb \
     && apt-get purge -y wget \
     && rm -rf /var/lib/apt/lists/*

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -77,7 +77,11 @@ async def check_license(user: dict) -> None:
     if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
         return
 
-    uid = user.get("uid", "")
+    uid = user.get("uid")
+    if not uid:
+        logger.warning("License check called for user with no UID")
+        raise HTTPException(status_code=403, detail="License check unavailable")
+
     now = time.monotonic()
 
     # Check cache
@@ -89,18 +93,11 @@ async def check_license(user: dict) -> None:
                 raise HTTPException(status_code=403, detail="License inactive")
             return
 
-    # Query Firestore
+    # Query Firestore (sync client wrapped for async safety)
     try:
-        from google.cloud import firestore
+        from starlette.concurrency import run_in_threadpool
 
-        db = firestore.Client()
-        doc = db.collection("licenses").document(uid).get()
-
-        if not doc.exists:
-            _license_cache[uid] = (False, now)
-            raise HTTPException(status_code=403, detail="License inactive")
-
-        active = doc.to_dict().get("active", False)
+        active = await run_in_threadpool(_fetch_license, uid)
         _license_cache[uid] = (active, now)
 
         if not active:
@@ -112,6 +109,17 @@ async def check_license(user: dict) -> None:
         logger.error("License check failed: %s", e)
         # Fail open would be risky — fail closed instead
         raise HTTPException(status_code=403, detail="License check unavailable") from e
+
+
+def _fetch_license(uid: str) -> bool:
+    """Synchronous Firestore lookup — called via run_in_threadpool."""
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    doc = db.collection("licenses").document(uid).get()
+    if not doc.exists:
+        return False
+    return doc.to_dict().get("active", False)
 
 
 async def get_licensed_user(request: Request) -> dict:

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -1,13 +1,18 @@
-"""Firebase Auth token validation for the web backend."""
+"""Firebase Auth token validation and license gating for the web backend."""
 
 from __future__ import annotations
 
 import logging
 import os
+import time
 
 from fastapi import HTTPException, Request
 
 logger = logging.getLogger(__name__)
+
+# License cache: {uid: (active: bool, timestamp: float)}
+_license_cache: dict[str, tuple[bool, float]] = {}
+_LICENSE_CACHE_TTL = 300  # 5 minutes
 
 # Lazy-init firebase admin
 _firebase_app = None
@@ -57,3 +62,60 @@ async def verify_token(request: Request) -> dict:
     except Exception as e:
         logger.warning("Token verification failed: %s", e)
         raise HTTPException(status_code=401, detail="Invalid or expired token") from e
+
+
+async def check_license(user: dict) -> None:
+    """Verify the user holds an active license in Firestore.
+
+    Checks the ``licenses`` collection for a document whose ID matches the
+    user's Firebase UID.  The document must exist and have ``active: true``.
+    Results are cached for 5 minutes to avoid hitting Firestore on every request.
+
+    Raises HTTPException 403 if the license is missing or inactive.
+    """
+    # Skip in dev mode (same as auth skip)
+    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        return
+
+    uid = user.get("uid", "")
+    now = time.monotonic()
+
+    # Check cache
+    cached = _license_cache.get(uid)
+    if cached is not None:
+        active, ts = cached
+        if now - ts < _LICENSE_CACHE_TTL:
+            if not active:
+                raise HTTPException(status_code=403, detail="License inactive")
+            return
+
+    # Query Firestore
+    try:
+        from google.cloud import firestore
+
+        db = firestore.Client()
+        doc = db.collection("licenses").document(uid).get()
+
+        if not doc.exists:
+            _license_cache[uid] = (False, now)
+            raise HTTPException(status_code=403, detail="License inactive")
+
+        active = doc.to_dict().get("active", False)
+        _license_cache[uid] = (active, now)
+
+        if not active:
+            raise HTTPException(status_code=403, detail="License inactive")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("License check failed: %s", e)
+        # Fail open would be risky — fail closed instead
+        raise HTTPException(status_code=403, detail="License check unavailable") from e
+
+
+async def get_licensed_user(request: Request) -> dict:
+    """Combined dependency: authenticate then check license."""
+    user = await verify_token(request)
+    await check_license(user)
+    return user

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -37,7 +37,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 
-from .auth import verify_token
+from .auth import get_licensed_user
 from .session import SessionManager
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ class RevisionApplyRequest(BaseModel):
 
 
 async def get_user(request: Request) -> dict:
-    return await verify_token(request)
+    return await get_licensed_user(request)
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +171,7 @@ async def upload(
         raise HTTPException(status_code=400, detail="No file provided")
 
     ext = Path(file.filename).suffix.lower()
-    if ext not in (".dxf", ".pdf"):
+    if ext not in (".dxf", ".pdf", ".dwg"):
         raise HTTPException(status_code=400, detail=f"Unsupported file type: {ext}")
 
     session = session_mgr.create(user_id=user["uid"])
@@ -198,6 +198,14 @@ async def upload(
                 status_code=500,
                 detail="PDF conversion is temporarily unavailable. Please try a .dxf file.",
             ) from None
+    elif ext == ".dwg":
+        from cad_dxf_agent.core.converter import convert_to_dxf
+
+        result = convert_to_dxf(upload_path, output_dir=session_dir)
+        if not result.success:
+            detail = _user_friendly_conversion_error(result.error, ext)
+            raise HTTPException(status_code=422, detail=detail)
+        shutil.copy2(str(result.output_path), str(dxf_path))
     else:
         shutil.copy2(str(upload_path), str(dxf_path))
 
@@ -414,8 +422,8 @@ async def compare(
             raise HTTPException(status_code=400, detail="No file provided")
 
         ext = Path(file.filename).suffix.lower()
-        if ext != ".dxf":
-            raise HTTPException(status_code=400, detail="Comparison requires a .dxf file")
+        if ext not in (".dxf", ".dwg"):
+            raise HTTPException(status_code=400, detail="Comparison requires a .dxf or .dwg file")
 
         try:
             session = session_mgr.get(session_id, user["uid"])
@@ -427,11 +435,26 @@ async def compare(
                 status_code=400, detail="No master file loaded. Upload a file first."
             )
 
-        # Save revision file
+        # Save uploaded file
         session_dir = Path("/tmp/cad-sessions") / session.session_id
         revision_path = session_dir / "revision.dxf"
-        content = await file.read()
-        revision_path.write_bytes(content)
+
+        if ext == ".dwg":
+            # Save DWG then convert
+            dwg_path = session_dir / "revision_upload.dwg"
+            content = await file.read()
+            dwg_path.write_bytes(content)
+
+            from cad_dxf_agent.core.converter import convert_to_dxf
+
+            result = convert_to_dxf(dwg_path, output_dir=session_dir)
+            if not result.success:
+                detail = _user_friendly_conversion_error(result.error, ext)
+                raise HTTPException(status_code=422, detail=detail)
+            shutil.copy2(str(result.output_path), str(revision_path))
+        else:
+            content = await file.read()
+            revision_path.write_bytes(content)
 
         try:
             from cad_dxf_agent.core.comparison.engine import ComparisonEngine
@@ -526,11 +549,15 @@ async def render(
 @app.get("/api/download")
 async def download(
     session_id: str = Query(...),
+    output_format: str = Query("dxf", alias="format"),
 ):
-    """Download the edited DXF file.
+    """Download the edited file as DXF or DWG.
 
     No auth required — same rationale as /api/render (Firebase rewrites
     strip Authorization headers on proxied GET requests).
+
+    Query params:
+        format: "dxf" (default) or "dwg" (converts via ODA before download).
     """
     try:
         session = session_mgr.get_by_id(session_id)
@@ -542,11 +569,34 @@ async def download(
             status_code=404, detail="No edited file available. Run /api/apply first."
         )
 
-    # Build download filename from original
     original_name = session.file_info.get("filename", "drawing.dxf")
     stem = Path(original_name).stem
-    download_name = f"{stem}_edited.dxf"
 
+    if output_format == "dwg":
+        # ODA converts both ways — ezdxf odafc.export_dwg writes DWG from DXF
+        try:
+            from ezdxf.addons import odafc
+
+            session_dir = Path("/tmp/cad-sessions") / session.session_id
+            dwg_path = session_dir / f"{stem}_edited.dwg"
+            doc = __import__("ezdxf").readfile(str(session.edited_path))
+            odafc.export_dwg(doc, str(dwg_path))  # type: ignore[attr-defined]
+
+            download_name = f"{stem}_edited.dwg"
+            return FileResponse(
+                path=str(dwg_path),
+                media_type="application/octet-stream",
+                filename=download_name,
+                headers={"Content-Disposition": f'attachment; filename="{download_name}"'},
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"DWG export failed: {e}. Try downloading as DXF instead.",
+            ) from None
+
+    # Default: DXF download
+    download_name = f"{stem}_edited.dxf"
     return FileResponse(
         path=str(session.edited_path),
         media_type="application/dxf",
@@ -589,8 +639,10 @@ async def revision_upload(
             raise HTTPException(status_code=400, detail="No file provided")
 
         ext = Path(file.filename).suffix.lower()
-        if ext != ".dxf":
-            raise HTTPException(status_code=400, detail="Revision upload requires a .dxf file")
+        if ext not in (".dxf", ".dwg"):
+            raise HTTPException(
+                status_code=400, detail="Revision upload requires a .dxf or .dwg file"
+            )
 
         try:
             session = session_mgr.get(session_id, user["uid"])
@@ -599,8 +651,22 @@ async def revision_upload(
 
         session_dir = Path("/tmp/cad-sessions") / session.session_id
         revision_path = session_dir / "revision.dxf"
-        content = await file.read()
-        revision_path.write_bytes(content)
+
+        if ext == ".dwg":
+            dwg_path = session_dir / "revision_upload.dwg"
+            content = await file.read()
+            dwg_path.write_bytes(content)
+
+            from cad_dxf_agent.core.converter import convert_to_dxf
+
+            result = convert_to_dxf(dwg_path, output_dir=session_dir)
+            if not result.success:
+                detail = _user_friendly_conversion_error(result.error, ext)
+                raise HTTPException(status_code=422, detail=detail)
+            shutil.copy2(str(result.output_path), str(revision_path))
+        else:
+            content = await file.read()
+            revision_path.write_bytes(content)
         session.revision_path = revision_path
 
         return {"session_id": session.session_id, "filename": file.filename}

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -199,13 +199,7 @@ async def upload(
                 detail="PDF conversion is temporarily unavailable. Please try a .dxf file.",
             ) from None
     elif ext == ".dwg":
-        from cad_dxf_agent.core.converter import convert_to_dxf
-
-        result = convert_to_dxf(upload_path, output_dir=session_dir)
-        if not result.success:
-            detail = _user_friendly_conversion_error(result.error, ext)
-            raise HTTPException(status_code=422, detail=detail)
-        shutil.copy2(str(result.output_path), str(dxf_path))
+        _convert_dwg_to_dxf(upload_path, output_dir=session_dir, dest_path=dxf_path)
     else:
         shutil.copy2(str(upload_path), str(dxf_path))
 
@@ -440,18 +434,10 @@ async def compare(
         revision_path = session_dir / "revision.dxf"
 
         if ext == ".dwg":
-            # Save DWG then convert
             dwg_path = session_dir / "revision_upload.dwg"
             content = await file.read()
             dwg_path.write_bytes(content)
-
-            from cad_dxf_agent.core.converter import convert_to_dxf
-
-            result = convert_to_dxf(dwg_path, output_dir=session_dir)
-            if not result.success:
-                detail = _user_friendly_conversion_error(result.error, ext)
-                raise HTTPException(status_code=422, detail=detail)
-            shutil.copy2(str(result.output_path), str(revision_path))
+            _convert_dwg_to_dxf(dwg_path, output_dir=session_dir, dest_path=revision_path)
         else:
             content = await file.read()
             revision_path.write_bytes(content)
@@ -575,11 +561,12 @@ async def download(
     if output_format == "dwg":
         # ODA converts both ways — ezdxf odafc.export_dwg writes DWG from DXF
         try:
+            import ezdxf
             from ezdxf.addons import odafc
 
             session_dir = Path("/tmp/cad-sessions") / session.session_id
             dwg_path = session_dir / f"{stem}_edited.dwg"
-            doc = __import__("ezdxf").readfile(str(session.edited_path))
+            doc = ezdxf.readfile(str(session.edited_path))
             odafc.export_dwg(doc, str(dwg_path))  # type: ignore[attr-defined]
 
             download_name = f"{stem}_edited.dwg"
@@ -656,14 +643,7 @@ async def revision_upload(
             dwg_path = session_dir / "revision_upload.dwg"
             content = await file.read()
             dwg_path.write_bytes(content)
-
-            from cad_dxf_agent.core.converter import convert_to_dxf
-
-            result = convert_to_dxf(dwg_path, output_dir=session_dir)
-            if not result.success:
-                detail = _user_friendly_conversion_error(result.error, ext)
-                raise HTTPException(status_code=422, detail=detail)
-            shutil.copy2(str(result.output_path), str(revision_path))
+            _convert_dwg_to_dxf(dwg_path, output_dir=session_dir, dest_path=revision_path)
         else:
             content = await file.read()
             revision_path.write_bytes(content)
@@ -949,6 +929,22 @@ async def revision_download(session_id: str = Query(...)):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _convert_dwg_to_dxf(dwg_path: Path, output_dir: Path, dest_path: Path) -> list[str]:
+    """Convert a DWG file to DXF via ODA, copy to dest_path.
+
+    Returns any conversion warnings.
+    Raises HTTPException on failure.
+    """
+    from cad_dxf_agent.core.converter import convert_to_dxf
+
+    result = convert_to_dxf(dwg_path, output_dir=output_dir)
+    if not result.success:
+        detail = _user_friendly_conversion_error(result.error, ".dwg")
+        raise HTTPException(status_code=422, detail=detail)
+    shutil.copy2(str(result.output_path), str(dest_path))
+    return result.warnings
 
 
 def _user_friendly_conversion_error(raw_error: str | None, ext: str) -> str:

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -13,3 +13,4 @@ matplotlib>=3.8
 opentelemetry-api>=1.21
 opentelemetry-sdk>=1.21
 opentelemetry-exporter-gcp-trace>=1.6
+google-cloud-firestore>=2.16

--- a/web/frontend/src/components/FileUpload.jsx
+++ b/web/frontend/src/components/FileUpload.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 
-const ACCEPTED_TYPES = ['.dxf', '.pdf'];
+const ACCEPTED_TYPES = ['.dxf', '.pdf', '.dwg'];
 const MAX_SIZE_MB = 50;
 
 export default function FileUpload({ onUpload, loading }) {
@@ -11,7 +11,7 @@ export default function FileUpload({ onUpload, loading }) {
   const validate = useCallback((file) => {
     const ext = '.' + file.name.split('.').pop().toLowerCase();
     if (!ACCEPTED_TYPES.includes(ext)) {
-      return `Unsupported file type: ${ext}. Use .dxf or .pdf`;
+      return `Unsupported file type: ${ext}. Use .dxf, .dwg, or .pdf`;
     }
     if (file.size > MAX_SIZE_MB * 1024 * 1024) {
       return `File too large (max ${MAX_SIZE_MB}MB)`;
@@ -74,20 +74,20 @@ export default function FileUpload({ onUpload, loading }) {
             <p className="upload-zone__text">
               Drag and drop your file here, or click to browse
             </p>
-            <p className="upload-zone__formats">.dxf, .pdf &mdash; up to {MAX_SIZE_MB}MB</p>
+            <p className="upload-zone__formats">.dxf, .dwg, .pdf &mdash; up to {MAX_SIZE_MB}MB</p>
           </>
         )}
         <input
           ref={inputRef}
           type="file"
-          accept=".dxf,.pdf"
+          accept=".dxf,.dwg,.pdf"
           onChange={handleInputChange}
           style={{ display: 'none' }}
           aria-hidden="true"
         />
       </div>
       <p className="upload-zone__hint">
-        Accepts .dxf and .pdf files. For .dwg files, export as DXF from your CAD software.
+        Accepts .dxf, .dwg, and .pdf files.
       </p>
       {error && <p className="input-group__error mt-2" role="alert">{error}</p>}
     </div>


### PR DESCRIPTION
## Summary
- **License gate**: Firestore-based `check_license()` in `auth.py` — reads `licenses` collection by Firebase UID, caches 5 min, fail-closed. All authed endpoints gated via `get_licensed_user()`. Skipped in dev mode. Jeremy manages licenses directly in Firebase Console.
- **DWG upload support**: `.dwg` accepted on `/api/upload`, `/api/compare`, and `/api/revision/upload` — auto-converts to DXF server-side via ODA File Converter (already in `converter.py`).
- **DWG download**: `GET /api/download?format=dwg` converts edited DXF back to DWG via `odafc.export_dwg`.
- **Docker**: ODA File Converter `.deb` installed in Cloud Run image.
- **Frontend**: FileUpload component accepts `.dwg` files.

## Files changed
| File | Change |
|------|--------|
| `web/backend/auth.py` | `check_license()` + `get_licensed_user()` |
| `web/backend/main.py` | Wire license dep, accept .dwg in 3 endpoints, DWG download |
| `web/backend/Dockerfile` | Install ODA File Converter |
| `web/backend/requirements.txt` | Add `google-cloud-firestore` |
| `web/frontend/src/components/FileUpload.jsx` | Accept .dwg files |

## Firestore setup (manual)
After merge, create in Firebase Console:
- Collection: `licenses`
- Doc ID: `{firebase_uid}`, fields: `{ active: true, email: "...", created: timestamp }`
- To revoke: set `active: false` or delete doc. Takes effect within 5 min (cache TTL).

## Test plan
- [x] Lint, format, typecheck pass
- [x] 919 unit + integration tests pass (0 failures)
- [ ] Deploy to Cloud Run → verify license gate blocks unlicensed users (403)
- [ ] Upload `.dwg` via web UI → verify conversion + load
- [ ] Download with `?format=dwg` → verify DWG output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DWG support across uploads, comparisons, rendering, and downloads; users can upload .dwg, compare revisions, and export edited files as DWG via a new format option.
* **License Management**
  * Enforced active license checks for access; users must have a valid license to use the platform (short cache applied to reduce repeated checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->