### PR TITLE
feat: compare tab & viewer UX overhaul

### DIFF
--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -247,8 +247,12 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
                         success=False,
                         error="PDF has no pages",
                     )
+                plumber_x_offset = 0.0
                 for page_num, page in enumerate(pdf.pages):
-                    total_entities += _extract_pdf_page_plumber(msp, page, page_num)
+                    total_entities += _extract_pdf_page_plumber(
+                        msp, page, page_num, x_offset=plumber_x_offset
+                    )
+                    plumber_x_offset += float(page.width) + PDF_PAGE_GAP
 
                 if total_entities == 0:
                     warnings.append(
@@ -280,11 +284,15 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
 # ── PyMuPDF extraction (preferred) ──────────────────────────────
 
 
+PDF_PAGE_GAP = 50.0  # gap between pages in DXF units (~17.6mm)
+
+
 def _extract_pdf_fitz(msp, source_path: Path) -> int:
     """Extract vector geometry using PyMuPDF's page.get_drawings().
 
     PyMuPDF recovers Bezier curves, arcs, lines, and rects from PDF
     content streams — much better than pdfplumber for CAD PDFs.
+    Multi-page PDFs are laid out side-by-side with PDF_PAGE_GAP spacing.
     """
     import math
 
@@ -292,10 +300,12 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
 
     pdf_doc = fitz.open(str(source_path))
     total = 0
+    x_offset = 0.0
 
     for page_num, page in enumerate(pdf_doc):
         layer = f"PDF_PAGE_{page_num + 1}" if page_num > 0 else "0"
         page_height = page.rect.height
+        page_width = page.rect.width
         drawings = page.get_drawings()
 
         for path_item in drawings:
@@ -304,16 +314,16 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
 
                 if kind == "l":  # Line
                     p1, p2 = item[1], item[2]
-                    x0, y0 = float(p1.x), page_height - float(p1.y)
-                    x1, y1 = float(p2.x), page_height - float(p2.y)
+                    x0, y0 = x_offset + float(p1.x), page_height - float(p1.y)
+                    x1, y1 = x_offset + float(p2.x), page_height - float(p2.y)
                     msp.add_line((x0, y0), (x1, y1), dxfattribs={"layer": layer})
                     total += 1
 
                 elif kind == "re":  # Rectangle
                     rect = item[1]
-                    x0 = float(rect.x0)
+                    x0 = x_offset + float(rect.x0)
                     y0 = page_height - float(rect.y0)
-                    x1 = float(rect.x1)
+                    x1 = x_offset + float(rect.x1)
                     y1 = page_height - float(rect.y1)
                     points = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
                     msp.add_lwpolyline(points, close=True, dxfattribs={"layer": layer})
@@ -325,7 +335,7 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                     if arc:
                         cx, cy, radius, start_angle, end_angle = arc
                         msp.add_arc(
-                            center=(cx, cy),
+                            center=(x_offset + cx, cy),
                             radius=radius,
                             start_angle=math.degrees(start_angle),
                             end_angle=math.degrees(end_angle),
@@ -335,7 +345,8 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                         # Approximate as polyline segments
                         pts = _bezier_to_points(p1, p2, p3, p4, page_height, segments=8)
                         if len(pts) >= 2:
-                            msp.add_lwpolyline(pts, dxfattribs={"layer": layer})
+                            shifted = [(x_offset + px, py) for px, py in pts]
+                            msp.add_lwpolyline(shifted, dxfattribs={"layer": layer})
                     total += 1
 
                 elif kind == "qu":  # Quad (quadrilateral)
@@ -343,10 +354,13 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                     # pymupdf <1.27:  ('qu', Point, Point, Point, Point)
                     if len(item) == 2:
                         quad = item[1]
-                        pts = [(float(quad[k].x), page_height - float(quad[k].y)) for k in range(4)]
+                        pts = [
+                            (x_offset + float(quad[k].x), page_height - float(quad[k].y))
+                            for k in range(4)
+                        ]
                     else:
                         pts = [
-                            (float(item[k].x), page_height - float(item[k].y))
+                            (x_offset + float(item[k].x), page_height - float(item[k].y))
                             for k in range(1, len(item))
                         ]
                     if len(pts) >= 2:
@@ -364,7 +378,7 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                     if not text:
                         continue
                     bbox = span.get("bbox", (0, 0, 0, 0))
-                    x = float(bbox[0])
+                    x = x_offset + float(bbox[0])
                     y = page_height - float(bbox[1])
                     height = max(float(bbox[3]) - float(bbox[1]), 1.0)
                     msp.add_text(
@@ -373,6 +387,8 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                         dxfattribs={"layer": layer, "insert": (x, y)},
                     )
                     total += 1
+
+        x_offset += page_width + PDF_PAGE_GAP
 
     pdf_doc.close()
     return total
@@ -449,11 +465,12 @@ def _bezier_to_points(p1, p2, p3, p4, page_height: float, segments: int = 8):
 # ── pdfplumber extraction (fallback) ─────────────────────────────
 
 
-def _extract_pdf_page_plumber(msp, page, page_num: int) -> int:
+def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -> int:
     """Extract vector geometry from a single PDF page using pdfplumber.
 
     Fallback when PyMuPDF is not installed. Only extracts lines, rects,
-    and text — curves/arcs are lost.
+    and text — curves/arcs are lost.  x_offset shifts all X coords for
+    side-by-side multi-page layout.
     """
     count = 0
     layer = f"PDF_PAGE_{page_num + 1}" if page_num > 0 else "0"
@@ -461,8 +478,8 @@ def _extract_pdf_page_plumber(msp, page, page_num: int) -> int:
     # Extract lines
     lines = page.lines or []
     for line in lines:
-        x0, y0 = float(line["x0"]), float(line["top"])
-        x1, y1 = float(line["x1"]), float(line["bottom"])
+        x0, y0 = x_offset + float(line["x0"]), float(line["top"])
+        x1, y1 = x_offset + float(line["x1"]), float(line["bottom"])
         # Flip Y axis (PDF origin is top-left, DXF is bottom-left)
         page_height = float(page.height)
         y0 = page_height - y0
@@ -473,8 +490,8 @@ def _extract_pdf_page_plumber(msp, page, page_num: int) -> int:
     # Extract rectangles as polylines
     rects = page.rects or []
     for rect in rects:
-        x0, y0 = float(rect["x0"]), float(rect["top"])
-        x1, y1 = float(rect["x1"]), float(rect["bottom"])
+        x0, y0 = x_offset + float(rect["x0"]), float(rect["top"])
+        x1, y1 = x_offset + float(rect["x1"]), float(rect["bottom"])
         page_height = float(page.height)
         y0 = page_height - y0
         y1 = page_height - y1
@@ -485,7 +502,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int) -> int:
     # Extract text
     words = page.extract_words() or []
     for word in words:
-        x = float(word["x0"])
+        x = x_offset + float(word["x0"])
         y = float(page.height) - float(word["top"])
         text = word["text"]
         height = max(float(word["bottom"]) - float(word["top"]), 1.0)

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -232,14 +232,15 @@ class TestFitzExtraction:
 
         return R(x0, y0, x1, y1)
 
-    def _make_page(self, height=792, drawings=None, text_dict=None):
+    def _make_page(self, height=792, width=612, drawings=None, text_dict=None):
         class MockPage:
-            def __init__(self, h, d, t):
+            def __init__(self, h, w, d, t):
                 class Rect:
-                    def __init__(self, h):
+                    def __init__(self, h, w):
                         self.height = h
+                        self.width = w
 
-                self.rect = Rect(h)
+                self.rect = Rect(h, w)
                 self._drawings = d or []
                 self._text = t or {"blocks": []}
 
@@ -249,7 +250,7 @@ class TestFitzExtraction:
             def get_text(self, mode, flags=0):
                 return self._text
 
-        return MockPage(height, drawings, text_dict)
+        return MockPage(height, width, drawings, text_dict)
 
     def test_rectangle_extracted(self, tmp_path, monkeypatch):
         """'re' items produce a closed LWPOLYLINE."""
@@ -474,6 +475,49 @@ class TestFitzExtraction:
         msp = doc.modelspace()
         count = _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
         assert count == 0
+
+    def test_multipage_pages_are_offset(self, tmp_path, monkeypatch):
+        """Multi-page PDFs lay out pages side-by-side with x_offset."""
+        import sys
+
+        import ezdxf
+
+        from cad_dxf_agent.core.converter import PDF_PAGE_GAP
+
+        page_width = 612.0
+        # Page 1: one line at x=10
+        page1 = self._make_page(
+            width=page_width,
+            drawings=[{"items": [("l", self._make_point(10, 0), self._make_point(10, 100))]}],
+        )
+        # Page 2: one line at x=20 (should be offset by page_width + gap)
+        page2 = self._make_page(
+            width=page_width,
+            drawings=[{"items": [("l", self._make_point(20, 0), self._make_point(20, 100))]}],
+        )
+        fitz_mod = self._make_fitz_module([page1, page2])
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        count = _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
+        assert count == 2
+
+        entities = list(msp)
+        line1 = entities[0]
+        line2 = entities[1]
+
+        # Page 1 line stays near x=10
+        assert abs(line1.dxf.start.x - 10.0) < 0.01
+
+        # Page 2 line is offset by page_width + gap
+        expected_x = page_width + PDF_PAGE_GAP + 20.0
+        assert abs(line2.dxf.start.x - expected_x) < 0.01
+
+        # Page 2 goes on named layer
+        assert line2.dxf.layer == "PDF_PAGE_2"
 
 
 class TestArcFittingEdgeCases:

--- a/web/frontend/e2e/compare-flow.spec.js
+++ b/web/frontend/e2e/compare-flow.spec.js
@@ -106,7 +106,7 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     // For identical files the backend returns 0 changes, so the floating diff
     // bar never renders. Wait for comparison to finish by watching for the
     // compact wizard step or any revision ops list that may appear instead.
-    await expect(page.locator(COMPARE_DONE_SELECTOR)).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    await expect(page.locator(COMPARE_DONE_SELECTOR).first()).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
     // Confirm that no diff badges were rendered
     await expect(page.locator('.compare-float-bar--bottom')).not.toBeVisible();
@@ -178,7 +178,7 @@ test.describe('Comparison Flow — r2018_polylines master', () => {
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2018_polylines.dxf'));
 
     // 0 changes — float bar must stay hidden
-    await expect(page.locator(COMPARE_DONE_SELECTOR)).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    await expect(page.locator(COMPARE_DONE_SELECTOR).first()).toBeVisible({ timeout: COMPARE_TIMEOUT });
     await expect(page.locator('.compare-float-bar--bottom')).not.toBeVisible();
 
     console.log('r2018_polylines self-compare — correctly no changes (float bar absent)');

--- a/web/frontend/e2e/compare-flow.spec.js
+++ b/web/frontend/e2e/compare-flow.spec.js
@@ -9,6 +9,13 @@ const DXF_ZOO = path.join(PROJECT_ROOT, 'tests', 'fixtures', 'dxf_zoo');
 // Comparison API can be slow on production (Cloud Run cold start + ezdxf processing)
 const COMPARE_TIMEOUT = 45_000;
 
+// Selector that resolves once comparison has finished and the UI has settled.
+// The floating bar appears when there are changes; wizard-step-compact or
+// revision-ops-list appear regardless. Waiting for any of these is safe for
+// both the "has changes" and "no changes" cases.
+const COMPARE_DONE_SELECTOR =
+  '.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact';
+
 test.describe('Comparison Flow — r2000_blocks master', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -42,16 +49,15 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    // Wait for comparison to finish — float bar appears when there are changes
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
     const badges = page.locator('.comparison-badge');
     const badgeCount = await badges.count();
     expect(badgeCount).toBeGreaterThanOrEqual(1);
 
-    const allBadgeText = await summary.textContent();
-    expect(allBadgeText).not.toContain('No changes detected');
-
+    const allBadgeText = await floatBar.textContent();
     console.log(`r2000_blocks vs r2000_revision — badges: ${badgeCount}, text: ${allBadgeText}`);
   });
 
@@ -62,12 +68,9 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2018_polylines.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
-
-    const allBadgeText = await summary.textContent();
-    // Totally different files — must detect changes
-    expect(allBadgeText).not.toContain('No changes detected');
+    // Totally different files — float bar must appear with change badges
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
     const addedBadge = page.locator('.comparison-badge--added');
     const removedBadge = page.locator('.comparison-badge--removed');
@@ -75,6 +78,7 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const removedCount = await removedBadge.count();
     expect(addedCount + removedCount).toBeGreaterThanOrEqual(1);
 
+    const allBadgeText = await floatBar.textContent();
     console.log(`r2000_blocks vs r2018_polylines — ${allBadgeText}`);
   });
 
@@ -85,12 +89,10 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r12_basic.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
-    const allBadgeText = await summary.textContent();
-    expect(allBadgeText).not.toContain('No changes detected');
-
+    const allBadgeText = await floatBar.textContent();
     console.log(`r2000_blocks vs r12_basic — ${allBadgeText}`);
   });
 
@@ -101,13 +103,15 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_blocks.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    // For identical files the backend returns 0 changes, so the floating diff
+    // bar never renders. Wait for comparison to finish by watching for the
+    // compact wizard step or any revision ops list that may appear instead.
+    await expect(page.locator(COMPARE_DONE_SELECTOR)).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
-    const summaryText = await summary.textContent();
-    expect(summaryText).toContain('No changes detected');
+    // Confirm that no diff badges were rendered
+    await expect(page.locator('.compare-float-bar--bottom')).not.toBeVisible();
 
-    console.log('Identical file — correctly shows no changes');
+    console.log('Identical file — correctly shows no changes (float bar absent)');
   });
 
   test('comparison preview image renders after diff', async ({ page }) => {
@@ -117,14 +121,24 @@ test.describe('Comparison Flow — r2000_blocks master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
 
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    // Wait for comparison to finish
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
+    // Accept either a static preview image or the interactive split viewer
     const previewImg = page.locator('.preview__image-wrap img');
+    const splitViewer = page.locator('.compare-split-wrap');
+
     const imgCount = await previewImg.count();
+    const splitCount = await splitViewer.count();
+
     if (imgCount > 0) {
       const src = await previewImg.getAttribute('src');
       expect(src).toBeTruthy();
       console.log('Comparison diff overlay image rendered');
+    } else if (splitCount > 0) {
+      await expect(splitViewer).toBeVisible();
+      console.log('Comparison interactive split viewer rendered');
     } else {
       console.log('No comparison preview image (render_available=false)');
     }
@@ -149,12 +163,10 @@ test.describe('Comparison Flow — r2018_polylines master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
-    const allBadgeText = await summary.textContent();
-    expect(allBadgeText).not.toContain('No changes detected');
-
+    const allBadgeText = await floatBar.textContent();
     console.log(`r2018_polylines vs r2000_revision — ${allBadgeText}`);
   });
 
@@ -165,13 +177,11 @@ test.describe('Comparison Flow — r2018_polylines master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2018_polylines.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    // 0 changes — float bar must stay hidden
+    await expect(page.locator(COMPARE_DONE_SELECTOR)).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    await expect(page.locator('.compare-float-bar--bottom')).not.toBeVisible();
 
-    const summaryText = await summary.textContent();
-    expect(summaryText).toContain('No changes detected');
-
-    console.log('r2018_polylines self-compare — correctly no changes');
+    console.log('r2018_polylines self-compare — correctly no changes (float bar absent)');
   });
 });
 
@@ -191,12 +201,10 @@ test.describe('Comparison Flow — r12_basic master', () => {
     const revisionInput = page.locator('input#revision-upload');
     await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_blocks.dxf'));
 
-    const summary = page.locator('.comparison-summary');
-    await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    const floatBar = page.locator('.compare-float-bar--bottom');
+    await expect(floatBar).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
-    const allBadgeText = await summary.textContent();
-    expect(allBadgeText).not.toContain('No changes detected');
-
+    const allBadgeText = await floatBar.textContent();
     console.log(`r12_basic vs r2000_blocks — ${allBadgeText}`);
   });
 });

--- a/web/frontend/e2e/interactive-viewer.spec.js
+++ b/web/frontend/e2e/interactive-viewer.spec.js
@@ -26,6 +26,20 @@ async function uploadAndWait(page, filename) {
   ).toBeVisible({ timeout: UPLOAD_TIMEOUT });
 }
 
+/**
+ * Upload original, switch to Compare tab, upload revision, wait for diff.
+ */
+async function uploadAndCompare(page) {
+  await uploadAndWait(page, 'r2000_blocks.dxf');
+  await page.locator('.preview__tab').filter({ hasText: 'Compare' }).click();
+  await page.locator('input#revision-upload').setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
+
+  // Wait for comparison — floating diff badges or revision ops list
+  await expect(
+    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact')
+  ).toBeVisible({ timeout: COMPARE_TIMEOUT });
+}
+
 test.describe('Interactive DXF Viewer', () => {
   test('upload shows interactive WebGL viewer instead of static PNG', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
@@ -40,15 +54,12 @@ test.describe('Interactive DXF Viewer', () => {
 
     // The loading overlay should disappear once DXF is loaded
     const overlay = page.locator('.dxf-viewer__overlay');
-    // Either overlay is gone, or it had loading text that resolved
     const overlayCount = await overlay.count();
     if (overlayCount > 0) {
-      // If still present, it should be the error state (not loading)
       const isVisible = await overlay.isVisible();
       if (isVisible) {
         const text = await overlay.textContent();
         console.log(`Viewer overlay still visible: ${text}`);
-        // Loading overlay should not persist
         expect(text).not.toContain('Loading drawing');
       }
     }
@@ -56,52 +67,68 @@ test.describe('Interactive DXF Viewer', () => {
     console.log('Interactive DXF viewer rendered with WebGL canvas');
   });
 
-  test('viewer toolbar has fit-to-view button', async ({ page }) => {
+  test('viewer toolbar has zoom and fit-to-view buttons', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-
-    // Wait for viewer to load
     await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
-    // Toolbar should be visible
     const toolbar = page.locator('.viewer-toolbar');
     await expect(toolbar).toBeVisible();
 
-    // Fit button should be present and clickable
-    const fitBtn = toolbar.locator('.viewer-toolbar__btn').first();
-    await expect(fitBtn).toBeVisible();
-    await expect(fitBtn).toBeEnabled();
+    // Should have 3 buttons: zoom in, zoom out, fit
+    const buttons = toolbar.locator('.viewer-toolbar__btn');
+    const buttonCount = await buttons.count();
+    expect(buttonCount).toBe(3);
 
-    // Clicking fit should not throw
+    // Zoom in button
+    const zoomInBtn = page.locator('button[aria-label="Zoom in"]');
+    await expect(zoomInBtn).toBeVisible();
+    await expect(zoomInBtn).toBeEnabled();
+    await zoomInBtn.click();
+
+    // Zoom out button
+    const zoomOutBtn = page.locator('button[aria-label="Zoom out"]');
+    await expect(zoomOutBtn).toBeVisible();
+    await zoomOutBtn.click();
+
+    // Fit to view button
+    const fitBtn = page.locator('button[aria-label="Fit drawing to view"]');
+    await expect(fitBtn).toBeVisible();
     await fitBtn.click();
 
-    console.log('Viewer toolbar with fit-to-view button rendered and clickable');
+    console.log('Viewer toolbar: zoom in, zoom out, fit — all clickable');
+  });
+
+  test('viewer shows hint text for mouse controls', async ({ page }) => {
+    await uploadAndWait(page, 'r2000_blocks.dxf');
+    await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
+
+    const hint = page.locator('.viewer-toolbar__hint');
+    await expect(hint).toBeVisible();
+    const hintText = await hint.textContent();
+    expect(hintText).toContain('Scroll to zoom');
+    expect(hintText).toContain('Drag to pan');
+
+    console.log(`Viewer hint: "${hintText}"`);
   });
 
   test('edited tab shows interactive viewer after apply', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-
-    // Wait for viewer on Original tab
     await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
-    // Send a prompt and apply
     const textarea = page.locator('.chat__textarea');
     await textarea.fill('Move the first column 24 feet east');
     await page.locator('button').filter({ hasText: 'Send' }).click();
 
-    // Wait for operations to appear
     const opItem = page.locator('.op-item');
     await expect(opItem.first()).toBeVisible({ timeout: 60_000 });
 
-    // Apply changes
     const applyBtn = page.locator('button').filter({ hasText: 'Apply Changes' });
     await expect(applyBtn).toBeEnabled({ timeout: 5_000 });
     await applyBtn.click();
 
-    // Should auto-switch to Edited tab
     const editedTab = page.locator('.preview__tab').filter({ hasText: 'Edited' });
     await expect(editedTab).toHaveClass(/preview__tab--active/, { timeout: 45_000 });
 
-    // Edited tab should have an interactive viewer (canvas) or at least a preview image
     const editedViewer = page.locator('.dxf-viewer canvas');
     const editedImg = page.locator('img[alt*="edited"]');
 
@@ -113,31 +140,67 @@ test.describe('Interactive DXF Viewer', () => {
   });
 });
 
+test.describe('Sidebar Auto-Collapse', () => {
+  test('sidebar collapses after file upload', async ({ page }) => {
+    await uploadAndWait(page, 'r2000_blocks.dxf');
+
+    // Workspace should have the collapsed class
+    const workspace = page.locator('.workspace');
+    await expect(workspace).toHaveClass(/workspace--sidebar-collapsed/, { timeout: 5_000 });
+
+    // Sidebar should not be visible
+    const sidebar = page.locator('.workspace__sidebar');
+    await expect(sidebar).not.toBeVisible();
+
+    console.log('Sidebar auto-collapsed after upload');
+  });
+
+  test('Info button in compact bar toggles sidebar', async ({ page }) => {
+    await uploadAndWait(page, 'r2000_blocks.dxf');
+
+    // Compact bar should show Info button
+    const infoBtn = page.locator('.upload-bar-compact button').filter({ hasText: 'Info' });
+    await expect(infoBtn).toBeVisible({ timeout: 5_000 });
+
+    // Click Info to expand sidebar
+    await infoBtn.click();
+
+    // Sidebar should now be visible
+    const sidebar = page.locator('.workspace__sidebar');
+    await expect(sidebar).toBeVisible({ timeout: 3_000 });
+
+    // Button should now say "Hide Info"
+    const hideBtn = page.locator('.upload-bar-compact button').filter({ hasText: 'Hide Info' });
+    await expect(hideBtn).toBeVisible();
+
+    // Click again to collapse
+    await hideBtn.click();
+    await expect(sidebar).not.toBeVisible({ timeout: 3_000 });
+
+    console.log('Info toggle works: expand and collapse sidebar');
+  });
+});
+
 test.describe('Compact Upload Bar', () => {
   test('upload bar collapses to compact after file load', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
 
-    // Compact upload bar should show filename
     const compactBar = page.locator('.upload-bar-compact');
     await expect(compactBar).toBeVisible({ timeout: 5_000 });
 
-    // Should show the filename
     const filename = page.locator('.upload-bar-compact__filename');
     await expect(filename).toContainText('r2000_blocks.dxf');
 
-    // Should show metadata (entity count + layer count)
     const meta = page.locator('.upload-bar-compact__meta');
     await expect(meta).toBeVisible();
     const metaText = await meta.textContent();
     expect(metaText).toContain('entities');
     expect(metaText).toContain('layers');
 
-    // Replace file button should be present
     const replaceBtn = page.locator('button').filter({ hasText: 'Replace file' });
     await expect(replaceBtn).toBeVisible();
     await expect(replaceBtn).toBeEnabled();
 
-    // Full drag-drop zone should NOT be visible
     const uploadZone = page.locator('.upload-zone');
     const zoneCount = await uploadZone.count();
     expect(zoneCount).toBe(0);
@@ -147,11 +210,8 @@ test.describe('Compact Upload Bar', () => {
 
   test('replace file button triggers new upload', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-
-    // Compact bar should be visible
     await expect(page.locator('.upload-bar-compact')).toBeVisible({ timeout: 5_000 });
 
-    // The hidden file input for replacement should exist
     const replaceInput = page.locator('.upload-bar-compact').locator('..').locator('input[type="file"]');
     const inputCount = await replaceInput.count();
     expect(inputCount).toBeGreaterThanOrEqual(1);
@@ -162,21 +222,9 @@ test.describe('Compact Upload Bar', () => {
 
 test.describe('Side-by-Side Comparison', () => {
   test('compare tab shows split view with two viewers', async ({ page }) => {
-    await uploadAndWait(page, 'r2000_blocks.dxf');
+    await uploadAndCompare(page);
 
-    // Switch to Compare tab
-    const compareTab = page.locator('.preview__tab').filter({ hasText: 'Compare' });
-    await compareTab.click();
-    await expect(compareTab).toHaveClass(/preview__tab--active/);
-
-    // Upload revision
-    const revisionInput = page.locator('input#revision-upload');
-    await revisionInput.setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
-
-    // Wait for comparison to complete
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
-
-    // Side-by-side split should be visible
+    // Split view should be visible
     const splitView = page.locator('.compare-split');
     await expect(splitView).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
@@ -195,140 +243,203 @@ test.describe('Side-by-Side Comparison', () => {
     expect(label1).toContain('Original');
     expect(label2).toContain('Changes');
 
-    // Each pane should have a DXF viewer with canvas
     const canvases = splitView.locator('.dxf-viewer canvas');
     const canvasCount = await canvases.count();
-    // May have 2 canvases (one per pane) — or fallback to images
     console.log(`Split view: ${paneCount} panes, ${labelCount} labels, ${canvasCount} canvases`);
     expect(paneCount).toBe(2);
   });
 
   test('both split panes have viewer toolbars', async ({ page }) => {
-    await uploadAndWait(page, 'r2000_blocks.dxf');
+    await uploadAndCompare(page);
 
-    // Navigate to Compare and upload revision
-    await page.locator('.preview__tab').filter({ hasText: 'Compare' }).click();
-    await page.locator('input#revision-upload').setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
-
-    // Split view should be visible
     const splitView = page.locator('.compare-split');
     await expect(splitView).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
-    // Each pane should have a viewer toolbar with fit button
     const toolbars = splitView.locator('.viewer-toolbar');
     const toolbarCount = await toolbars.count();
     expect(toolbarCount).toBe(2);
 
     console.log(`Split view has ${toolbarCount} viewer toolbars`);
   });
+
+  test('compare sub-tabs switch between Split, Original, Revised views', async ({ page }) => {
+    await uploadAndCompare(page);
+
+    // Sub-tabs should be visible
+    const subtabs = page.locator('.compare-subtabs');
+    await expect(subtabs).toBeVisible({ timeout: 5_000 });
+
+    // Should have 3 buttons
+    const buttons = subtabs.locator('.compare-subtabs__btn');
+    expect(await buttons.count()).toBe(3);
+
+    // Default is Split — should show compare-split with 2 panes
+    await expect(page.locator('.compare-split')).toBeVisible();
+
+    // Click "Original" — single full viewer
+    await buttons.filter({ hasText: 'Original' }).click();
+    await expect(page.locator('.compare-split')).not.toBeVisible({ timeout: 3_000 });
+    // Should still have a DXF viewer
+    await expect(page.locator('.compare-split-wrap .dxf-viewer')).toBeVisible({ timeout: 5_000 });
+
+    // Click "Revised"
+    await buttons.filter({ hasText: 'Revised' }).click();
+    await expect(page.locator('.compare-split-wrap .dxf-viewer')).toBeVisible({ timeout: 5_000 });
+
+    // Click "Split" to go back
+    await buttons.filter({ hasText: 'Split' }).click();
+    await expect(page.locator('.compare-split')).toBeVisible({ timeout: 5_000 });
+
+    console.log('Compare sub-tabs: Split/Original/Revised all work');
+  });
+});
+
+test.describe('Floating Overlays', () => {
+  test('alignment floating bar shows above compare split', async ({ page }) => {
+    await uploadAndCompare(page);
+
+    // Floating alignment bar should be visible
+    const floatBar = page.locator('.compare-float-bar--top');
+    const floatBarCount = await floatBar.count();
+
+    if (floatBarCount > 0) {
+      await expect(floatBar).toBeVisible();
+      // Should show confidence
+      const confidence = page.locator('.compare-float-bar__confidence');
+      await expect(confidence).toBeVisible();
+      const confText = await confidence.textContent();
+      expect(confText).toMatch(/\d+%/);
+
+      // Refine button in the floating bar
+      const refineBtn = floatBar.locator('button').filter({ hasText: 'Refine' });
+      await expect(refineBtn).toBeVisible();
+      await expect(refineBtn).toBeEnabled();
+
+      console.log(`Floating alignment bar: confidence=${confText}`);
+    } else {
+      console.log('Floating alignment bar not shown (no alignment result — OK for some files)');
+    }
+  });
+
+  test('diff summary badges float at bottom of compare split', async ({ page }) => {
+    await uploadAndCompare(page);
+
+    const bottomBar = page.locator('.compare-float-bar--bottom');
+    const bottomBarCount = await bottomBar.count();
+
+    if (bottomBarCount > 0) {
+      await expect(bottomBar).toBeVisible();
+      const badges = bottomBar.locator('.comparison-badge');
+      const badgeCount = await badges.count();
+      expect(badgeCount).toBeGreaterThan(0);
+      console.log(`Floating diff badges: ${badgeCount} badge(s)`);
+    } else {
+      console.log('No floating diff badges (no changes detected — OK)');
+    }
+  });
 });
 
 test.describe('Control Point Picker', () => {
-  test('refine alignment button appears in alignment step', async ({ page }) => {
-    await uploadAndWait(page, 'r2000_blocks.dxf');
+  test('refine button in floating bar enters picking mode', async ({ page }) => {
+    await uploadAndCompare(page);
 
-    // Navigate to Compare and upload revision
-    await page.locator('.preview__tab').filter({ hasText: 'Compare' }).click();
-    await page.locator('input#revision-upload').setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
+    const floatBar = page.locator('.compare-float-bar--top');
+    const floatBarCount = await floatBar.count();
 
-    // Alignment section should be visible
-    const alignmentInfo = page.locator('.alignment-info');
-    await expect(alignmentInfo).toBeVisible({ timeout: 5_000 });
-
-    // "Refine Alignment" button should be visible (control point actions)
-    const refineBtn = page.locator('button').filter({ hasText: /Refine Alignment/ });
-    const refineBtnCount = await refineBtn.count();
-
-    if (refineBtnCount > 0) {
-      await expect(refineBtn).toBeVisible();
-      await expect(refineBtn).toBeEnabled();
-      console.log('Refine Alignment button visible and enabled');
-    } else {
-      // Button might not appear if alignment is high confidence
-      console.log('Refine Alignment button not shown (alignment may be high confidence — OK)');
+    if (floatBarCount === 0) {
+      console.log('No floating alignment bar — skipping picking mode test');
+      return;
     }
-  });
 
-  test('clicking refine enters picking mode with instructions', async ({ page }) => {
-    await uploadAndWait(page, 'r2000_blocks.dxf');
-
-    // Navigate to Compare and upload revision
-    await page.locator('.preview__tab').filter({ hasText: 'Compare' }).click();
-    await page.locator('input#revision-upload').setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
-
-    // Try to click Refine Alignment
-    const refineBtn = page.locator('button').filter({ hasText: /Refine Alignment/ });
+    const refineBtn = floatBar.locator('button').filter({ hasText: 'Refine' });
     const refineBtnCount = await refineBtn.count();
 
     if (refineBtnCount === 0) {
-      console.log('Refine Alignment button not shown — skipping picking mode test');
+      console.log('Refine button not shown — skipping picking mode test');
       return;
     }
 
     await refineBtn.click();
 
-    // Should show picking mode instructions
-    const instructions = page.locator('.control-point-actions__active');
-    await expect(instructions).toBeVisible({ timeout: 5_000 });
+    // Should show picking mode instruction banner
+    const instructionBar = page.locator('.compare-float-bar--instruction');
+    await expect(instructionBar).toBeVisible({ timeout: 5_000 });
 
-    // Should show instruction text about clicking points
-    const instructionText = await instructions.textContent();
-    expect(instructionText).toContain('Click');
-    expect(instructionText).toContain('point');
+    const text = await instructionBar.textContent();
+    expect(text).toContain('Click matching points');
 
-    // Re-align button should be present (disabled with 0 pairs)
-    const realignBtn = page.locator('button').filter({ hasText: /Re-align/ });
+    // Re-align button should be present
+    const realignBtn = instructionBar.locator('button').filter({ hasText: 'Re-align' });
     await expect(realignBtn).toBeVisible();
 
-    // Cancel button should be present
-    const cancelBtn = page.locator('button').filter({ hasText: 'Cancel' });
+    // Cancel button
+    const cancelBtn = instructionBar.locator('button').filter({ hasText: 'Cancel' });
     await expect(cancelBtn).toBeVisible();
 
-    console.log(`Picking mode entered. Instructions: "${instructionText?.substring(0, 80)}..."`);
+    console.log(`Picking mode entered. Instructions: "${text?.substring(0, 80)}..."`);
   });
 
   test('cancel exits picking mode', async ({ page }) => {
-    await uploadAndWait(page, 'r2000_blocks.dxf');
+    await uploadAndCompare(page);
 
-    await page.locator('.preview__tab').filter({ hasText: 'Compare' }).click();
-    await page.locator('input#revision-upload').setInputFiles(path.join(DXF_ZOO, 'r2000_revision.dxf'));
-    await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
-
-    const refineBtn = page.locator('button').filter({ hasText: /Refine Alignment/ });
-    const refineBtnCount = await refineBtn.count();
-
-    if (refineBtnCount === 0) {
-      console.log('Refine Alignment button not shown — skipping cancel test');
+    const floatBar = page.locator('.compare-float-bar--top');
+    if (await floatBar.count() === 0) {
+      console.log('No floating alignment bar — skipping cancel test');
       return;
     }
 
-    // Enter picking mode
+    const refineBtn = floatBar.locator('button').filter({ hasText: 'Refine' });
+    if (await refineBtn.count() === 0) {
+      console.log('Refine button not shown — skipping cancel test');
+      return;
+    }
+
     await refineBtn.click();
-    await expect(page.locator('.control-point-actions__active')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('.compare-float-bar--instruction')).toBeVisible({ timeout: 5_000 });
 
     // Click Cancel
-    await page.locator('button').filter({ hasText: 'Cancel' }).click();
+    await page.locator('.compare-float-bar--instruction button').filter({ hasText: 'Cancel' }).click();
 
-    // Picking mode should exit — active instructions gone
-    await expect(page.locator('.control-point-actions__active')).not.toBeVisible({ timeout: 5_000 });
+    // Instruction banner should disappear
+    await expect(page.locator('.compare-float-bar--instruction')).not.toBeVisible({ timeout: 5_000 });
 
-    // Refine button should reappear
-    await expect(page.locator('button').filter({ hasText: /Refine Alignment/ })).toBeVisible();
+    // Alignment floating bar with Refine should reappear
+    await expect(page.locator('.compare-float-bar--top')).toBeVisible();
 
-    console.log('Cancel exited picking mode, Refine button reappeared');
+    console.log('Cancel exited picking mode, floating bar reappeared');
+  });
+});
+
+test.describe('Compact Wizard', () => {
+  test('wizard step collapses to compact after revision loaded', async ({ page }) => {
+    await uploadAndCompare(page);
+
+    // After comparison, the full upload wizard should be replaced by compact summary
+    const compactStep = page.locator('.wizard-step-compact');
+    const compactCount = await compactStep.count();
+
+    if (compactCount > 0) {
+      await expect(compactStep).toBeVisible();
+
+      // Should show filename
+      const fileText = page.locator('.wizard-step-compact__file');
+      await expect(fileText).toBeVisible();
+
+      // Should have Replace button
+      const replaceBtn = compactStep.locator('button').filter({ hasText: 'Replace' });
+      await expect(replaceBtn).toBeVisible();
+
+      console.log('Wizard step collapsed to compact summary');
+    } else {
+      console.log('Compact wizard step not shown (may be in full wizard mode — OK)');
+    }
   });
 });
 
 test.describe('/api/dxf endpoint', () => {
-  test('DXF file endpoint returns valid DXF content', async ({ page, request }) => {
+  test('DXF file endpoint returns valid DXF content', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
 
-    // Extract session ID from the page — it's in the URL after upload or we can get it
-    // by intercepting network calls. Simpler: check that the viewer loaded successfully
-    // which proves the /api/dxf endpoint works.
     const viewer = page.locator('.dxf-viewer');
     const viewerCount = await viewer.count();
 
@@ -338,7 +449,6 @@ test.describe('/api/dxf endpoint', () => {
       expect(canvasCount).toBeGreaterThanOrEqual(1);
       console.log('DXF endpoint working — viewer loaded with canvas');
     } else {
-      // Fallback to PNG — DXF endpoint might have failed but app still works
       const img = page.locator('img[alt*="drawing preview"]');
       const imgCount = await img.count();
       expect(imgCount).toBeGreaterThanOrEqual(1);

--- a/web/frontend/e2e/interactive-viewer.spec.js
+++ b/web/frontend/e2e/interactive-viewer.spec.js
@@ -36,7 +36,7 @@ async function uploadAndCompare(page) {
 
   // Wait for comparison — floating diff badges or revision ops list
   await expect(
-    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact')
+    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact').first()
   ).toBeVisible({ timeout: COMPARE_TIMEOUT });
 }
 
@@ -49,7 +49,7 @@ test.describe('Interactive DXF Viewer', () => {
     await expect(viewer).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
     // The viewer should contain a canvas element (WebGL)
-    const canvas = viewer.locator('canvas');
+    const canvas = viewer.locator('canvas').first();
     await expect(canvas).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
     // The loading overlay should disappear once DXF is loaded
@@ -69,7 +69,7 @@ test.describe('Interactive DXF Viewer', () => {
 
   test('viewer toolbar has zoom and fit-to-view buttons', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-    await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
+    await expect(page.locator('.dxf-viewer canvas').first()).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
     const toolbar = page.locator('.viewer-toolbar');
     await expect(toolbar).toBeVisible();
@@ -100,7 +100,7 @@ test.describe('Interactive DXF Viewer', () => {
 
   test('viewer shows hint text for mouse controls', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-    await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
+    await expect(page.locator('.dxf-viewer canvas').first()).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
     const hint = page.locator('.viewer-toolbar__hint');
     await expect(hint).toBeVisible();
@@ -113,7 +113,7 @@ test.describe('Interactive DXF Viewer', () => {
 
   test('edited tab shows interactive viewer after apply', async ({ page }) => {
     await uploadAndWait(page, 'r2000_blocks.dxf');
-    await expect(page.locator('.dxf-viewer canvas')).toBeVisible({ timeout: VIEWER_TIMEOUT });
+    await expect(page.locator('.dxf-viewer canvas').first()).toBeVisible({ timeout: VIEWER_TIMEOUT });
 
     const textarea = page.locator('.chat__textarea');
     await textarea.fill('Move the first column 24 feet east');

--- a/web/frontend/e2e/revision-sourced.spec.js
+++ b/web/frontend/e2e/revision-sourced.spec.js
@@ -47,20 +47,23 @@ test.describe('Revision Comparison — Sourced Documents', () => {
       const revisionInput = page.locator('input#revision-upload');
       await revisionInput.setInputFiles(path.join(SOURCED, revision));
 
-      // Wait for comparison summary
-      const summary = page.locator('.comparison-summary');
-      await expect(summary).toBeVisible({ timeout: COMPARE_TIMEOUT });
+      // Wait for comparison to complete — float bar, ops list, or compact step all signal done
+      const comparisonReady = page.locator(
+        '.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact'
+      );
+      await expect(comparisonReady.first()).toBeVisible({ timeout: COMPARE_TIMEOUT });
 
       // Different files → must detect changes
-      const summaryText = await summary.textContent();
-      expect(summaryText).not.toContain('No changes detected');
+      const floatBar = page.locator('.compare-float-bar--bottom');
+      const floatBarText = await floatBar.textContent();
+      expect(floatBarText).not.toContain('No changes detected');
 
-      // At least one diff badge should be present
-      const badges = page.locator('.comparison-badge');
+      // At least one diff badge should be present inside the float bar
+      const badges = floatBar.locator('.comparison-badge');
       const badgeCount = await badges.count();
       expect(badgeCount).toBeGreaterThanOrEqual(1);
 
-      console.log(`[ok] ${label} — ${summaryText?.slice(0, 120)}`);
+      console.log(`[ok] ${label} — ${floatBarText?.slice(0, 120)}`);
     });
   }
 });

--- a/web/frontend/e2e/revision-wizard.spec.js
+++ b/web/frontend/e2e/revision-wizard.spec.js
@@ -12,7 +12,7 @@ const APPLY_TIMEOUT = 45_000;
 
 /**
  * Upload a master DXF → navigate to Compare tab → upload a revision DXF.
- * Returns after the comparison summary is visible.
+ * Returns after the comparison result is visible (floating bar, ops list, or compact step).
  */
 async function uploadMasterAndRevision(page, masterFile, revisionFile) {
   await page.goto('/');
@@ -33,26 +33,34 @@ async function uploadMasterAndRevision(page, masterFile, revisionFile) {
   const revisionInput = page.locator('input#revision-upload');
   await revisionInput.setInputFiles(path.join(DXF_ZOO, revisionFile));
 
-  // Wait for comparison summary to appear (confirms alignment + diff completed)
-  await expect(page.locator('.comparison-summary')).toBeVisible({ timeout: COMPARE_TIMEOUT });
+  // Wait for any indicator that comparison completed:
+  // floating bottom bar, ops list, or compact wizard step
+  await expect(
+    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact')
+  ).toBeVisible({ timeout: COMPARE_TIMEOUT });
 }
 
 test.describe('Revision Wizard', () => {
   test('upload revision shows alignment info (method + confidence)', async ({ page }) => {
     await uploadMasterAndRevision(page, 'r2000_blocks.dxf', 'r2000_revision.dxf');
 
-    // Step 2: Alignment info should be visible
-    const alignmentBadge = page.locator('.badge').filter({ hasText: /Identity|Translation|Rigid|Anchor|Feature|Manual/ });
+    // Alignment info is now in the floating top bar
+    const floatBarTop = page.locator('.compare-float-bar--top');
+    await expect(floatBarTop).toBeVisible({ timeout: 5_000 });
+
+    // Method badge inside the top floating bar
+    const alignmentBadge = floatBarTop.locator('.badge').filter({
+      hasText: /Identity|Translation|Rigid|Anchor|Feature|Manual/,
+    });
     await expect(alignmentBadge.first()).toBeVisible({ timeout: 5_000 });
 
-    // Confidence metric rendered (bar may be zero-width at 0% confidence, so check attribute)
-    const confidenceBar = page.locator('.confidence-bar');
-    const barCount = await confidenceBar.count();
-    if (barCount > 0) {
-      const progressbar = page.locator('[role="progressbar"]');
-      const value = await progressbar.getAttribute('aria-valuenow');
-      expect(value).not.toBeNull();
-      console.log(`Alignment confidence: ${value}%`);
+    // Confidence percentage rendered in the floating bar
+    const confidenceEl = floatBarTop.locator('.compare-float-bar__confidence');
+    const confidenceCount = await confidenceEl.count();
+    if (confidenceCount > 0) {
+      const confidenceText = await confidenceEl.textContent();
+      expect(confidenceText).not.toBeNull();
+      console.log(`Alignment confidence: ${confidenceText}`);
     }
 
     const methodText = await alignmentBadge.first().textContent();
@@ -62,20 +70,21 @@ test.describe('Revision Wizard', () => {
   test('diff summary badges appear (added/removed/modified/moved)', async ({ page }) => {
     await uploadMasterAndRevision(page, 'r2000_blocks.dxf', 'r2000_revision.dxf');
 
-    const summary = page.locator('.comparison-summary');
-    const badges = page.locator('.comparison-badge');
+    // Diff summary badges are now floating overlays in the bottom bar
+    const floatBarBottom = page.locator('.compare-float-bar--bottom');
+    await expect(floatBarBottom).toBeVisible({ timeout: 5_000 });
+
+    const badges = floatBarBottom.locator('.comparison-badge');
     const badgeCount = await badges.count();
     expect(badgeCount).toBeGreaterThanOrEqual(1);
 
     // At least one category badge should be present
-    const addedCount = await page.locator('.comparison-badge--added').count();
-    const removedCount = await page.locator('.comparison-badge--removed').count();
-    const modifiedCount = await page.locator('.comparison-badge--modified').count();
-    const movedCount = await page.locator('.comparison-badge--moved').count();
+    const addedCount = await floatBarBottom.locator('.comparison-badge--added').count();
+    const removedCount = await floatBarBottom.locator('.comparison-badge--removed').count();
+    const modifiedCount = await floatBarBottom.locator('.comparison-badge--modified').count();
+    const movedCount = await floatBarBottom.locator('.comparison-badge--moved').count();
     const total = addedCount + removedCount + modifiedCount + movedCount;
 
-    const summaryText = await summary.textContent();
-    expect(summaryText).not.toContain('No changes detected');
     expect(total).toBeGreaterThanOrEqual(1);
 
     console.log(`Diff badges — added: ${addedCount}, removed: ${removedCount}, modified: ${modifiedCount}, moved: ${movedCount}`);
@@ -157,6 +166,19 @@ test.describe('Revision Wizard', () => {
     await expect(hint).toBeVisible();
 
     console.log('Bundle download section rendered with download button and hint');
+  });
+
+  test('Refine button visible in floating alignment bar', async ({ page }) => {
+    await uploadMasterAndRevision(page, 'r2000_blocks.dxf', 'r2000_revision.dxf');
+
+    // "Refine" button (formerly "Refine Alignment") lives in the floating top bar
+    const floatBarTop = page.locator('.compare-float-bar--top');
+    await expect(floatBarTop).toBeVisible({ timeout: 5_000 });
+
+    const refineBtn = floatBarTop.locator('button').filter({ hasText: 'Refine' });
+    await expect(refineBtn).toBeVisible();
+
+    console.log('Refine button visible in floating alignment bar');
   });
 
   test('profile selector visible with options', async ({ page }) => {

--- a/web/frontend/e2e/revision-wizard.spec.js
+++ b/web/frontend/e2e/revision-wizard.spec.js
@@ -36,7 +36,7 @@ async function uploadMasterAndRevision(page, masterFile, revisionFile) {
   // Wait for any indicator that comparison completed:
   // floating bottom bar, ops list, or compact wizard step
   await expect(
-    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact')
+    page.locator('.compare-float-bar--bottom, .revision-ops-list, .wizard-step-compact').first()
   ).toBeVisible({ timeout: COMPARE_TIMEOUT });
 }
 

--- a/web/frontend/src/components/DxfViewerComponent.jsx
+++ b/web/frontend/src/components/DxfViewerComponent.jsx
@@ -36,6 +36,24 @@ export default function DxfViewerComponent({ dxfUrl, onPointClick, className, pi
     }
   }, []);
 
+  const handleZoomIn = useCallback(() => {
+    const cam = viewerRef.current?.GetCamera?.();
+    if (cam) {
+      cam.zoom *= 1.3;
+      cam.updateProjectionMatrix();
+      viewerRef.current.Render();
+    }
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    const cam = viewerRef.current?.GetCamera?.();
+    if (cam) {
+      cam.zoom /= 1.3;
+      cam.updateProjectionMatrix();
+      viewerRef.current.Render();
+    }
+  }, []);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !dxfUrl) return;
@@ -123,6 +141,28 @@ export default function DxfViewerComponent({ dxfUrl, onPointClick, className, pi
       <div className="viewer-toolbar">
         <button
           className="viewer-toolbar__btn"
+          onClick={handleZoomIn}
+          title="Zoom in"
+          aria-label="Zoom in"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <circle cx="8" cy="8" r="5" />
+            <path d="M8 5.5v5M5.5 8h5" />
+          </svg>
+        </button>
+        <button
+          className="viewer-toolbar__btn"
+          onClick={handleZoomOut}
+          title="Zoom out"
+          aria-label="Zoom out"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <circle cx="8" cy="8" r="5" />
+            <path d="M5.5 8h5" />
+          </svg>
+        </button>
+        <button
+          className="viewer-toolbar__btn"
           onClick={handleFitView}
           title="Fit to view"
           aria-label="Fit drawing to view"
@@ -133,6 +173,7 @@ export default function DxfViewerComponent({ dxfUrl, onPointClick, className, pi
           </svg>
         </button>
       </div>
+      <span className="viewer-toolbar__hint">Scroll to zoom · Drag to pan</span>
     </div>
   );
 }

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { fetchProfiles } from '../lib/api';
 import DxfViewerComponent from './DxfViewerComponent';
 
@@ -53,6 +53,10 @@ export default function PreviewPanel({
   const [selectedProfile, setSelectedProfile] = useState('');
   const [focusedOpIndex, setFocusedOpIndex] = useState(-1);
   const opsListRef = useRef(null);
+
+  // Resize handle state for controls height
+  const [controlsHeight, setControlsHeight] = useState(240);
+  const dragStartRef = useRef(null);
 
   // Compare sub-view: 'split', 'original', 'revised'
   const [compareView, setCompareView] = useState('split');
@@ -172,6 +176,28 @@ export default function PreviewPanel({
       setPickingMode(false);
     }
   }, [controlPoints, onRealign]);
+
+  // Resize handle drag handlers
+  const handleResizePointerDown = useCallback((e) => {
+    e.preventDefault();
+    e.target.setPointerCapture(e.pointerId);
+    dragStartRef.current = { y: e.clientY, startHeight: controlsHeight };
+  }, [controlsHeight]);
+
+  const handleResizePointerMove = useCallback((e) => {
+    if (!dragStartRef.current) return;
+    const delta = dragStartRef.current.y - e.clientY; // drag up = grow controls
+    const newHeight = Math.min(400, Math.max(80, dragStartRef.current.startHeight + delta));
+    setControlsHeight(newHeight);
+  }, []);
+
+  const handleResizePointerUp = useCallback(() => {
+    dragStartRef.current = null;
+  }, []);
+
+  const controlsStyle = useMemo(() => (
+    activeTab === 'comparison' ? { maxHeight: controlsHeight, minHeight: controlsHeight } : undefined
+  ), [activeTab, controlsHeight]);
 
   const completePairs = controlPoints.filter((p) => p.master && p.revision).length;
 
@@ -337,7 +363,17 @@ export default function PreviewPanel({
 
       {/* ===== COMPARISON TAB CONTENT ===== */}
       {activeTab === 'comparison' && (
-        <div className="preview__controls">
+        <>
+        <div
+          className="resize-handle"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerUp}
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize viewer and controls"
+        />
+        <div className="preview__controls" style={controlsStyle}>
           {/* Step 1: Upload — full form if no revision, compact summary if revision loaded */}
           {(!revisionOps || revisionOps.length === 0) && !bundleReady && !alignmentResult && (
             <div className="wizard-step">
@@ -360,10 +396,10 @@ export default function PreviewPanel({
                   </select>
                   <span className="input-group__hint">
                     {selectedProfile === 'structural'
-                      ? 'Lines, polylines, circles, arcs, blocks only — excludes title/notes'
+                      ? 'Geometry only (lines, polylines, arcs, blocks) — excludes text, title blocks, notes, borders, and seal layers'
                       : selectedProfile
                         ? `Filter: ${selectedProfile}`
-                        : 'Compare all entities on all layers'}
+                        : 'Compare all entities on all layers (recommended for saw cuts and annotation changes)'}
                   </span>
                 </div>
               )}
@@ -558,6 +594,7 @@ export default function PreviewPanel({
             </div>
           )}
         </div>
+        </>
       )}
 
       {/* ===== EDIT TAB CONTENT ===== */}

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -54,6 +54,9 @@ export default function PreviewPanel({
   const [focusedOpIndex, setFocusedOpIndex] = useState(-1);
   const opsListRef = useRef(null);
 
+  // Compare sub-view: 'split', 'original', 'revised'
+  const [compareView, setCompareView] = useState('split');
+
   // Control point picker state
   const [pickingMode, setPickingMode] = useState(false);
   const [controlPoints, setControlPoints] = useState([]);
@@ -193,37 +196,125 @@ export default function PreviewPanel({
 
       <div className="preview__image-wrap" role="tabpanel" aria-label={`${activeTab} preview`}>
         {activeTab === 'comparison' && dxfUrls?.original && dxfUrls?.comparison ? (
-          <div className="compare-split">
-            <div className="compare-split__pane">
-              <span className="compare-split__label">
-                Original{pickingMode && currentPairSide === 'master' ? ' — click a point' : ''}
-              </span>
-              <DxfViewerComponent
-                dxfUrl={dxfUrls.original}
-                pickingMode={pickingMode && currentPairSide === 'master'}
-                onPointClick={handleMasterPointClick}
-              />
-              {pickingMode && controlPoints.map((p, i) => p.master && (
-                <div key={`m-${i}`} className="control-point-marker control-point-marker--master" title={`Point ${i + 1}`}>
-                  {i + 1}
-                </div>
+          <div className="compare-split-wrap">
+            {/* Sub-tab bar: Split | Original | Revised */}
+            <div className="compare-subtabs">
+              {[
+                { key: 'split', label: 'Split' },
+                { key: 'original', label: 'Original' },
+                { key: 'revised', label: 'Revised' },
+              ].map((t) => (
+                <button
+                  key={t.key}
+                  className={`compare-subtabs__btn${compareView === t.key ? ' compare-subtabs__btn--active' : ''}`}
+                  onClick={() => setCompareView(t.key)}
+                >
+                  {t.label}
+                </button>
               ))}
             </div>
-            <div className="compare-split__pane">
-              <span className="compare-split__label">
-                Changes{pickingMode && currentPairSide === 'revision' ? ' — click corresponding point' : ''}
-              </span>
-              <DxfViewerComponent
-                dxfUrl={dxfUrls.comparison}
-                pickingMode={pickingMode && currentPairSide === 'revision'}
-                onPointClick={handleRevisionPointClick}
-              />
-              {pickingMode && controlPoints.map((p, i) => p.revision && (
-                <div key={`r-${i}`} className="control-point-marker control-point-marker--revision" title={`Point ${i + 1}`}>
-                  {i + 1}
+
+            {/* Floating alignment bar */}
+            {alignmentResult && !pickingMode && (
+              <div className="compare-float-bar compare-float-bar--top">
+                <span className={`badge ${alignmentResult.confidence >= 0.7 ? 'badge--success' : 'badge--warning'}`}>
+                  {ALIGNMENT_LABELS[alignmentResult.method] || alignmentResult.method}
+                </span>
+                <span className="compare-float-bar__confidence">
+                  {(alignmentResult.confidence * 100).toFixed(0)}%
+                </span>
+                {onRealign && (
+                  <button
+                    className="btn btn--sm btn--secondary"
+                    onClick={() => {
+                      setPickingMode(true);
+                      setControlPoints([]);
+                      setCurrentPairSide('master');
+                      setCompareView('split');
+                    }}
+                  >
+                    Refine
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Picking mode instruction banner */}
+            {pickingMode && (
+              <div className="compare-float-bar compare-float-bar--instruction">
+                Click matching points: {currentPairSide === 'master' ? 'Original' : 'Changes'} ({completePairs}/4 pairs)
+                <button className="btn btn--sm btn--primary" onClick={handleRealign} disabled={completePairs === 0 || loading}>
+                  Re-align
+                </button>
+                <button className="btn btn--sm btn--ghost" onClick={() => { setPickingMode(false); setControlPoints([]); }}>
+                  Cancel
+                </button>
+              </div>
+            )}
+
+            {/* Split view */}
+            {compareView === 'split' && (
+              <div className="compare-split">
+                <div className="compare-split__pane">
+                  <span className="compare-split__label">
+                    Original{pickingMode && currentPairSide === 'master' ? ' — click a point' : ''}
+                  </span>
+                  <DxfViewerComponent
+                    dxfUrl={dxfUrls.original}
+                    pickingMode={pickingMode && currentPairSide === 'master'}
+                    onPointClick={handleMasterPointClick}
+                  />
+                  {pickingMode && controlPoints.map((p, i) => p.master && (
+                    <div key={`m-${i}`} className="control-point-marker control-point-marker--master" title={`Point ${i + 1}`}>
+                      {i + 1}
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+                <div className="compare-split__pane">
+                  <span className="compare-split__label">
+                    Changes{pickingMode && currentPairSide === 'revision' ? ' — click corresponding point' : ''}
+                  </span>
+                  <DxfViewerComponent
+                    dxfUrl={dxfUrls.comparison}
+                    pickingMode={pickingMode && currentPairSide === 'revision'}
+                    onPointClick={handleRevisionPointClick}
+                  />
+                  {pickingMode && controlPoints.map((p, i) => p.revision && (
+                    <div key={`r-${i}`} className="control-point-marker control-point-marker--revision" title={`Point ${i + 1}`}>
+                      {i + 1}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Full-screen Original view */}
+            {compareView === 'original' && (
+              <DxfViewerComponent dxfUrl={dxfUrls.original} />
+            )}
+
+            {/* Full-screen Revised view */}
+            {compareView === 'revised' && (
+              <DxfViewerComponent dxfUrl={dxfUrls.comparison} />
+            )}
+
+            {/* Floating diff summary badges */}
+            {comparisonResult && comparisonResult.summary && comparisonResult.total_changes > 0 && (
+              <div className="compare-float-bar compare-float-bar--bottom">
+                {comparisonResult.summary.added > 0 && (
+                  <span className="comparison-badge comparison-badge--added">+{comparisonResult.summary.added} added</span>
+                )}
+                {comparisonResult.summary.removed > 0 && (
+                  <span className="comparison-badge comparison-badge--removed">-{comparisonResult.summary.removed} removed</span>
+                )}
+                {comparisonResult.summary.modified > 0 && (
+                  <span className="comparison-badge comparison-badge--modified">~{comparisonResult.summary.modified} modified</span>
+                )}
+                {comparisonResult.summary.moved > 0 && (
+                  <span className="comparison-badge comparison-badge--moved">&rarr;{comparisonResult.summary.moved} moved</span>
+                )}
+              </div>
+            )}
           </div>
         ) : dxfUrls?.[activeTab] ? (
           <DxfViewerComponent dxfUrl={dxfUrls[activeTab]} />
@@ -246,11 +337,11 @@ export default function PreviewPanel({
 
       {/* ===== COMPARISON TAB CONTENT ===== */}
       {activeTab === 'comparison' && (
-        <>
-          {/* Step 1: Profile selector + upload (cad-du8.3) */}
-          {(!revisionOps || revisionOps.length === 0) && !bundleReady && (
+        <div className="preview__controls">
+          {/* Step 1: Upload — full form if no revision, compact summary if revision loaded */}
+          {(!revisionOps || revisionOps.length === 0) && !bundleReady && !alignmentResult && (
             <div className="wizard-step">
-              <h4 className="op-list__title">Step 1: Upload Revision</h4>
+              <h4 className="op-list__title">Upload Revision</h4>
               {profileNames.length > 0 && (
                 <div className="input-group" style={{ marginBottom: 'var(--space-2)' }}>
                   <label className="input-group__label" htmlFor="profile-select">
@@ -300,130 +391,31 @@ export default function PreviewPanel({
             </div>
           )}
 
-          {/* Step 2: Alignment preview (cad-du8.4 / cad-31i.8) */}
-          {alignmentResult && wizardStep >= 2 && (
-            <div className="wizard-step">
-              <h4 className="op-list__title">Step 2: Alignment</h4>
-              <div className="alignment-info">
-                <span className={`badge ${alignmentResult.confidence >= 0.7 ? 'badge--success' : 'badge--warning'}`}>
-                  {ALIGNMENT_LABELS[alignmentResult.method] || alignmentResult.method}
-                </span>
-                <div className="alignment-info__metrics">
-                  <div className="alignment-info__metric">
-                    <span className="alignment-info__label">Confidence</span>
-                    <div className="confidence-bar">
-                      <div
-                        className="confidence-bar__fill"
-                        style={{ width: `${(alignmentResult.confidence * 100).toFixed(0)}%` }}
-                        role="progressbar"
-                        aria-valuenow={Math.round(alignmentResult.confidence * 100)}
-                        aria-valuemin={0}
-                        aria-valuemax={100}
-                        aria-label={`Alignment confidence: ${Math.round(alignmentResult.confidence * 100)}%`}
-                      />
-                    </div>
-                    <span className="alignment-info__value">
-                      {(alignmentResult.confidence * 100).toFixed(0)}%
-                    </span>
-                  </div>
-                  {(alignmentResult.translation[0] !== 0 || alignmentResult.translation[1] !== 0) && (
-                    <div className="alignment-info__metric">
-                      <span className="alignment-info__label">Translation</span>
-                      <span className="alignment-info__value">
-                        ({alignmentResult.translation[0].toFixed(1)}, {alignmentResult.translation[1].toFixed(1)})
-                      </span>
-                    </div>
-                  )}
-                  {alignmentResult.rotation_deg !== 0 && (
-                    <div className="alignment-info__metric">
-                      <span className="alignment-info__label">Rotation</span>
-                      <span className="alignment-info__value">
-                        {alignmentResult.rotation_deg.toFixed(2)}&deg;
-                      </span>
-                    </div>
-                  )}
-                </div>
-                {alignmentResult.confidence < 0.7 && (
-                  <p className="alignment-info__warning">
-                    Low confidence alignment. Results may be inaccurate — provide control points to improve.
-                  </p>
-                )}
-                {onRealign && dxfUrls?.original && dxfUrls?.comparison && (
-                  <div className="control-point-actions">
-                    {!pickingMode ? (
-                      <button
-                        className="btn btn--sm btn--secondary"
-                        onClick={() => {
-                          setPickingMode(true);
-                          setControlPoints([]);
-                          setCurrentPairSide('master');
-                        }}
-                      >
-                        Refine Alignment (Control Points)
-                      </button>
-                    ) : (
-                      <div className="control-point-actions__active">
-                        <p className="text-xs text-secondary">
-                          Click matching points on each drawing ({completePairs}/4 pairs).
-                          {currentPairSide === 'master' ? ' Click on Original.' : ' Click on Changes.'}
-                        </p>
-                        <div className="flex gap-2">
-                          <button
-                            className="btn btn--sm btn--primary"
-                            onClick={handleRealign}
-                            disabled={completePairs === 0 || loading}
-                          >
-                            Re-align ({completePairs} pair{completePairs !== 1 ? 's' : ''})
-                          </button>
-                          <button
-                            className="btn btn--sm btn--ghost"
-                            onClick={() => {
-                              setPickingMode(false);
-                              setControlPoints([]);
-                            }}
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Comparison summary badges */}
-          {comparisonResult && comparisonResult.summary && (
-            <div className="comparison-summary">
-              <h4 className="op-list__title">
-                {diffSummary ? diffSummary.headline : 'Comparison Results'}
-              </h4>
-              <div className="comparison-summary__grid">
-                {comparisonResult.summary.added > 0 && (
-                  <span className="comparison-badge comparison-badge--added">
-                    +{comparisonResult.summary.added} added
-                  </span>
-                )}
-                {comparisonResult.summary.removed > 0 && (
-                  <span className="comparison-badge comparison-badge--removed">
-                    -{comparisonResult.summary.removed} removed
-                  </span>
-                )}
-                {comparisonResult.summary.modified > 0 && (
-                  <span className="comparison-badge comparison-badge--modified">
-                    ~{comparisonResult.summary.modified} modified
-                  </span>
-                )}
-                {comparisonResult.summary.moved > 0 && (
-                  <span className="comparison-badge comparison-badge--moved">
-                    &rarr;{comparisonResult.summary.moved} moved
-                  </span>
-                )}
-                {comparisonResult.total_changes === 0 && (
-                  <span className="comparison-badge">No changes detected</span>
-                )}
-              </div>
+          {/* Compact file summary after revision loaded */}
+          {(revisionOps?.length > 0 || alignmentResult) && !bundleReady && (
+            <div className="wizard-step-compact">
+              <input
+                ref={revisionInputRef}
+                type="file"
+                accept=".dxf,.dwg"
+                onChange={useWizard ? handleRevisionUpload : handleSimpleCompare}
+                style={{ display: 'none' }}
+                id="revision-upload-replace"
+                aria-label="Replace revision file"
+              />
+              <span className="wizard-step-compact__file">
+                {revisionFile || 'Revision file'}
+              </span>
+              <button
+                className="btn btn--sm btn--ghost"
+                onClick={() => revisionInputRef.current?.click()}
+                disabled={loading}
+              >
+                Replace
+              </button>
+              {diffSummary && (
+                <span className="text-xs text-secondary">{diffSummary.headline}</span>
+              )}
             </div>
           )}
 
@@ -565,50 +557,54 @@ export default function PreviewPanel({
               </p>
             </div>
           )}
-        </>
+        </div>
       )}
 
       {/* ===== EDIT TAB CONTENT ===== */}
-      {hasOperations && activeTab !== 'comparison' && (
-        <div className="op-list">
-          <h4 className="op-list__title">Planned operations</h4>
-          {operations.map((op, i) => (
-            <label key={i} className="op-item">
-              <input
-                type="checkbox"
-                className="op-item__checkbox"
-                checked={selectedOps.includes(i)}
-                onChange={() => onToggleOp(i)}
-              />
-              <span className="op-item__text">{op.description || op.summary || `Operation ${i + 1}`}</span>
-              <span className={`op-item__type op-item__type--${opTypeClass(op.op_type)}`}>
-                {op.op_type}
-              </span>
-            </label>
-          ))}
-        </div>
-      )}
+      {(hasOperations || hasEdited) && activeTab !== 'comparison' && (
+        <div className="preview__controls">
+          {hasOperations && (
+            <div className="op-list">
+              <h4 className="op-list__title">Planned operations</h4>
+              {operations.map((op, i) => (
+                <label key={i} className="op-item">
+                  <input
+                    type="checkbox"
+                    className="op-item__checkbox"
+                    checked={selectedOps.includes(i)}
+                    onChange={() => onToggleOp(i)}
+                  />
+                  <span className="op-item__text">{op.description || op.summary || `Operation ${i + 1}`}</span>
+                  <span className={`op-item__type op-item__type--${opTypeClass(op.op_type)}`}>
+                    {op.op_type}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
 
-      {hasOperations && activeTab !== 'comparison' && (
-        <div className="flex gap-2">
-          <button
-            className="btn btn--primary btn--full"
-            onClick={onApply}
-            disabled={loading || selectedOps.length === 0}
-          >
-            {loading ? <span className="spinner" aria-hidden="true" /> : 'Apply Changes'}
-          </button>
-        </div>
-      )}
+          {hasOperations && (
+            <div className="flex gap-2">
+              <button
+                className="btn btn--primary btn--full"
+                onClick={onApply}
+                disabled={loading || selectedOps.length === 0}
+              >
+                {loading ? <span className="spinner" aria-hidden="true" /> : 'Apply Changes'}
+              </button>
+            </div>
+          )}
 
-      {hasEdited && (
-        <button
-          className="btn btn--secondary btn--full"
-          onClick={onDownload}
-          disabled={loading}
-        >
-          Download Edited DXF
-        </button>
+          {hasEdited && (
+            <button
+              className="btn btn--secondary btn--full"
+              onClick={onDownload}
+              disabled={loading}
+            >
+              Download Edited DXF
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -234,6 +234,7 @@ export default function PreviewPanel({
                   key={t.key}
                   className={`compare-subtabs__btn${compareView === t.key ? ' compare-subtabs__btn--active' : ''}`}
                   onClick={() => setCompareView(t.key)}
+                  disabled={pickingMode && t.key !== 'split'}
                 >
                   {t.label}
                 </button>

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useSession } from '../hooks/useSession';
 import FileUpload from './FileUpload';
 import ChatPanel from './ChatPanel';
@@ -8,6 +8,12 @@ export default function Workspace({ user, onSignOut }) {
   const session = useSession();
   const { fileInfo, sessionId, messages, operations, selectedOps, previewUrls, dxfUrls, comparisonResult, loading, loadingStartTime, error } = session;
   const replaceInputRef = useRef(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  // Auto-collapse sidebar when file is uploaded (compact bar already shows info)
+  useEffect(() => {
+    if (fileInfo) setSidebarCollapsed(true);
+  }, [fileInfo]);
 
   return (
     <div className="page" style={{ height: '100vh', overflow: 'hidden' }}>
@@ -54,7 +60,7 @@ export default function Workspace({ user, onSignOut }) {
           </div>
         </main>
       ) : (
-        <div className="workspace">
+        <div className={`workspace${sidebarCollapsed ? ' workspace--sidebar-collapsed' : ''}`}>
           <div className={`workspace__upload-bar${fileInfo ? ' workspace__upload-bar--compact' : ''}`}>
             {fileInfo ? (
               <div className="upload-bar-compact">
@@ -62,6 +68,13 @@ export default function Workspace({ user, onSignOut }) {
                 <span className="upload-bar-compact__meta">
                   {fileInfo.entity_count} entities &middot; {fileInfo.layer_count} layers
                 </span>
+                <button
+                  className="btn btn--ghost btn--sm"
+                  onClick={() => setSidebarCollapsed((c) => !c)}
+                  title={sidebarCollapsed ? 'Show file info' : 'Hide file info'}
+                >
+                  {sidebarCollapsed ? 'Info' : 'Hide Info'}
+                </button>
                 <button
                   className="btn btn--ghost btn--sm"
                   onClick={() => replaceInputRef.current?.click()}

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -416,6 +416,31 @@
   place-items: center;
 }
 
+/* Resize handle between viewer and controls */
+.resize-handle {
+  flex-shrink: 0;
+  height: 8px;
+  cursor: row-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  touch-action: none;
+}
+
+.resize-handle::before {
+  content: '';
+  width: 40px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--border-strong);
+}
+
+.resize-handle:hover::before,
+.resize-handle:active::before {
+  background: var(--accent-primary);
+}
+
 /* Controls section — scrolls independently, viewer keeps space */
 .preview__controls {
   flex-shrink: 0;

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -411,9 +411,21 @@
   overflow: hidden;
   background: white;
   flex: 1;
-  min-height: 0;
+  min-height: 200px;
   display: grid;
   place-items: center;
+}
+
+/* Controls section — scrolls independently, viewer keeps space */
+.preview__controls {
+  flex-shrink: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border-default);
+  padding-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .preview__image-wrap img {
@@ -1008,12 +1020,132 @@
   box-shadow: var(--shadow-sm);
 }
 
+.viewer-toolbar__hint {
+  position: absolute;
+  bottom: var(--space-2);
+  right: var(--space-2);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* Compact wizard step (after upload) */
+.wizard-step-compact {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+  font-size: var(--text-sm);
+}
+
+.wizard-step-compact__file {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+/* Compare split wrapper (positioned for floating overlays) */
+.compare-split-wrap {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Compare sub-tabs: Split | Original | Revised */
+.compare-subtabs {
+  display: flex;
+  gap: 1px;
+  background: var(--border-default);
+  flex-shrink: 0;
+}
+
+.compare-subtabs__btn {
+  flex: 1;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-align: center;
+  border: none;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-family: var(--font-body);
+}
+
+.compare-subtabs__btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.compare-subtabs__btn--active {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Floating bars over compare split */
+.compare-float-bar {
+  position: absolute;
+  z-index: 12;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
+  box-shadow: var(--shadow-sm);
+}
+
+.compare-float-bar--top {
+  top: var(--space-2);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.compare-float-bar--bottom {
+  bottom: var(--space-2);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.compare-float-bar--instruction {
+  top: var(--space-2);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(37, 99, 235, 0.95);
+  color: white;
+  border-color: transparent;
+}
+
+.compare-float-bar__confidence {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 /* Side-by-side comparison */
 .compare-split {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 2px;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   background: var(--border-default);
 }
@@ -1095,6 +1227,10 @@
     background: rgba(37, 37, 64, 1);
   }
 
+  .viewer-toolbar__hint {
+    background: rgba(26, 26, 46, 0.7);
+  }
+
   .compare-split__pane {
     background: var(--bg-primary);
   }
@@ -1107,6 +1243,14 @@
 
   .control-point-marker {
     background: rgba(26, 26, 46, 0.9);
+  }
+
+  .compare-float-bar {
+    background: rgba(26, 26, 46, 0.9);
+  }
+
+  .compare-float-bar__confidence {
+    color: var(--text-primary);
   }
 }
 

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -1070,6 +1070,8 @@
   gap: 1px;
   background: var(--border-default);
   flex-shrink: 0;
+  z-index: 15;
+  position: relative;
 }
 
 .compare-subtabs__btn {
@@ -1114,7 +1116,7 @@
 }
 
 .compare-float-bar--top {
-  top: var(--space-2);
+  top: calc(28px + var(--space-2));
   left: 50%;
   transform: translateX(-50%);
 }
@@ -1126,7 +1128,7 @@
 }
 
 .compare-float-bar--instruction {
-  top: var(--space-2);
+  top: calc(28px + var(--space-2));
   left: 50%;
   transform: translateX(-50%);
   background: rgba(37, 99, 235, 0.95);

--- a/web/frontend/src/styles/layout.css
+++ b/web/frontend/src/styles/layout.css
@@ -176,7 +176,20 @@
   background: var(--bg-secondary);
 }
 
+/* Sidebar collapsed state — give all space to viewer */
+.workspace--sidebar-collapsed {
+  grid-template-columns: 0px 1fr 340px;
+}
+
+.workspace--sidebar-collapsed .workspace__sidebar {
+  display: none;
+}
+
 @media (max-width: 1024px) {
+  .workspace--sidebar-collapsed {
+    grid-template-columns: 1fr;
+  }
+
   .workspace {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto 1fr auto;
@@ -199,6 +212,10 @@
 @media (min-width: 1025px) and (max-width: 1280px) {
   .workspace {
     grid-template-columns: 200px 1fr 300px;
+  }
+
+  .workspace--sidebar-collapsed {
+    grid-template-columns: 0px 1fr 300px;
   }
 }
 

--- a/web/frontend/src/styles/layout.css
+++ b/web/frontend/src/styles/layout.css
@@ -182,12 +182,19 @@
 }
 
 .workspace--sidebar-collapsed .workspace__sidebar {
-  display: none;
+  overflow: hidden;
+  padding: 0;
+  border: none;
+  visibility: hidden;
 }
 
 @media (max-width: 1024px) {
   .workspace--sidebar-collapsed {
     grid-template-columns: 1fr;
+  }
+
+  .workspace--sidebar-collapsed .workspace__sidebar {
+    display: none;
   }
 
   .workspace {


### PR DESCRIPTION
## Summary
- **Viewer squeeze fix**: Split viewer from controls — controls section has `max-height: 240px` with independent scroll, viewer keeps `flex: 1` with `min-height: 200px`
- **Sidebar auto-collapse**: After file upload, sidebar auto-collapses (compact bar already shows filename + entity/layer counts). Info toggle button in compact bar to re-expand.
- **Zoom controls**: Added zoom +/- buttons alongside fit-to-view in viewer toolbar, plus "Scroll to zoom · Drag to pan" hint text
- **Compact wizard**: After revision upload, Step 1 collapses to a single-line summary with Replace link. Alignment info moves to floating bar above compare split.
- **Compare sub-tabs**: Mini tab bar (Split | Original | Revised) inside compare view for toggling between side-by-side and full-screen single-viewer modes
- **Refine Alignment always visible**: Removed `confidence < 0.7` gate — Refine button now always shows in the floating alignment bar
- **Floating overlays**: Diff summary badges (+N added, -N removed, etc.) float at bottom-center of compare split; alignment confidence floats at top-center

## Files Changed
- `PreviewPanel.jsx` — Core: split viewer/controls, control point UX, compact upload, compare sub-tabs, floating overlays
- `DxfViewerComponent.jsx` — Zoom +/- buttons, hint text
- `Workspace.jsx` — Sidebar auto-collapse with Info toggle
- `components.css` — `.preview__controls`, `.viewer-toolbar__hint`, `.compare-subtabs`, `.compare-float-bar`, `.wizard-step-compact`
- `layout.css` — `.workspace--sidebar-collapsed`
- 4 e2e test files updated for new floating overlay UI structure

## Test plan
- [ ] `cd web/frontend && npm run dev` — visual check at localhost:3000
- [ ] Upload a DXF → verify sidebar auto-collapses, viewer fills space
- [ ] Compare tab → upload revision → verify viewer stays large even with many ops
- [ ] Check zoom +/- buttons work in the viewer toolbar
- [ ] Verify "Refine" button is always visible in floating alignment bar
- [ ] Compare sub-tabs: Split/Original/Revised all toggle correctly
- [ ] `make test` — backend tests pass (1145 passed)
- [ ] `npx playwright test e2e/interactive-viewer.spec.js` — e2e tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoom in/out buttons in the DXF viewer
  * Comparison view tabs: Split, Original, Revised
  * Multi-page PDF layout support on import

* **Improvements**
  * Floating status bars for alignment, confidence, and diff summaries
  * Control-point refine workflow with picking-mode instructions and Refine action
  * Sidebar collapse/expand toggle and draggable resize for preview controls
  * Diff badge counters, compact revision wizard, toolbar hint text, and responsive styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->