### PR TITLE
fix: PDF entity colors, classifier, render quality guard

### DIFF
--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -22,6 +22,10 @@ from ..settings import settings
 logger = logging.getLogger(__name__)
 tracer = get_tracer(__name__)
 
+# ACI white — ezdxf's matplotlib renderer uses blackWhiteInversion so
+# entities tagged "white" render as visible black on a white background.
+PDF_ENTITY_COLOR = 7
+
 
 @dataclass
 class ConversionResult:
@@ -33,6 +37,7 @@ class ConversionResult:
     success: bool
     warnings: list[str] = field(default_factory=list)
     error: str | None = None
+    classifications: list | None = None  # list[PageClassification] when available
 
 
 class ConversionError(Exception):
@@ -223,13 +228,30 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
     output_path = _get_output_path(source_path, output_dir)
     warnings: list[str] = [_PDF_WARNING]
 
+    # Run classifier if PyMuPDF is available
+    classifications = None
+    if has_fitz:
+        try:
+            from .pdf_classifier import classify_pdf_pages
+
+            classifications = classify_pdf_pages(source_path)
+            for c in classifications:
+                warnings.append(
+                    f"Page {c.page_num + 1}: {c.content_type.value} "
+                    f"(vectors={c.vector_count}, text={c.text_count})"
+                )
+        except Exception as e:
+            logger.warning("PDF classification failed (non-fatal): %s", e)
+
     try:
         doc = ezdxf.new(dxfversion=_version_to_acdb(settings.target_dxf_version))
+        # Ensure layer "0" has explicit color
+        doc.layers.get("0").color = PDF_ENTITY_COLOR
         msp = doc.modelspace()
         total_entities = 0
 
         if has_fitz:
-            total_entities = _extract_pdf_fitz(msp, source_path)
+            total_entities = _extract_pdf_fitz(msp, source_path, doc)
             if total_entities == 0:
                 warnings.append(
                     "No vector geometry found in PDF — may be a raster/scanned document"
@@ -249,6 +271,9 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
                     )
                 plumber_x_offset = 0.0
                 for page_num, page in enumerate(pdf.pages):
+                    layer = f"PDF_PAGE_{page_num + 1}" if page_num > 0 else "0"
+                    if page_num > 0 and layer not in doc.layers:
+                        doc.layers.add(layer, color=PDF_ENTITY_COLOR)
                     total_entities += _extract_pdf_page_plumber(
                         msp, page, page_num, x_offset=plumber_x_offset
                     )
@@ -270,6 +295,7 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
             output_path=output_path,
             success=True,
             warnings=warnings,
+            classifications=classifications,
         )
     except Exception as e:
         return ConversionResult(
@@ -281,18 +307,54 @@ def _convert_pdf(source_path: Path, output_dir: str | Path | None) -> Conversion
         )
 
 
+# ── Color helpers ─────────────────────────────────────────────────
+
+
+def _rgb_to_aci(rgb_tuple) -> int:
+    """Map PDF RGB stroke color to nearest DXF ACI color index.
+
+    ``rgb_tuple`` comes from PyMuPDF ``path_item["color"]`` — an (R, G, B)
+    tuple with values in [0, 1].  Returns the closest AutoCAD Color Index.
+    """
+    if rgb_tuple is None:
+        return PDF_ENTITY_COLOR
+    try:
+        r, g, b = [int(c * 255) for c in rgb_tuple[:3]]
+    except (TypeError, ValueError):
+        return PDF_ENTITY_COLOR
+    # Near-black → use white (viewer inverts to visible black)
+    if r < 30 and g < 30 and b < 30:
+        return 7
+    if r > 200 and g < 50 and b < 50:
+        return 1  # red
+    if r > 200 and g > 200 and b < 50:
+        return 2  # yellow
+    if g > 200 and r < 50 and b < 50:
+        return 3  # green
+    if g > 200 and b > 200 and r < 50:
+        return 4  # cyan
+    if b > 200 and r < 50 and g < 50:
+        return 5  # blue
+    if r > 200 and b > 200 and g < 50:
+        return 6  # magenta
+    return PDF_ENTITY_COLOR
+
+
 # ── PyMuPDF extraction (preferred) ──────────────────────────────
 
 
 PDF_PAGE_GAP = 50.0  # gap between pages in DXF units (~17.6mm)
 
 
-def _extract_pdf_fitz(msp, source_path: Path) -> int:
+def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
     """Extract vector geometry using PyMuPDF's page.get_drawings().
 
     PyMuPDF recovers Bezier curves, arcs, lines, and rects from PDF
     content streams — much better than pdfplumber for CAD PDFs.
     Multi-page PDFs are laid out side-by-side with PDF_PAGE_GAP spacing.
+
+    When ``doc`` is provided (ezdxf Document), per-page layers are created
+    with explicit colors so entities are visible in viewers.
     """
     import math
 
@@ -304,19 +366,24 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
 
     for page_num, page in enumerate(pdf_doc):
         layer = f"PDF_PAGE_{page_num + 1}" if page_num > 0 else "0"
+        # Create layer with explicit color so entities are visible
+        if doc is not None and page_num > 0 and layer not in doc.layers:
+            doc.layers.add(layer, color=PDF_ENTITY_COLOR)
         page_height = page.rect.height
         page_width = page.rect.width
         drawings = page.get_drawings()
 
         for path_item in drawings:
+            stroke_color = _rgb_to_aci(path_item.get("color"))
             for item in path_item.get("items", []):
                 kind = item[0]
+                attribs = {"layer": layer, "color": stroke_color}
 
                 if kind == "l":  # Line
                     p1, p2 = item[1], item[2]
                     x0, y0 = x_offset + float(p1.x), page_height - float(p1.y)
                     x1, y1 = x_offset + float(p2.x), page_height - float(p2.y)
-                    msp.add_line((x0, y0), (x1, y1), dxfattribs={"layer": layer})
+                    msp.add_line((x0, y0), (x1, y1), dxfattribs=attribs)
                     total += 1
 
                 elif kind == "re":  # Rectangle
@@ -326,7 +393,7 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                     x1 = x_offset + float(rect.x1)
                     y1 = page_height - float(rect.y1)
                     points = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
-                    msp.add_lwpolyline(points, close=True, dxfattribs={"layer": layer})
+                    msp.add_lwpolyline(points, close=True, dxfattribs=attribs)
                     total += 1
 
                 elif kind == "c":  # Cubic Bezier curve
@@ -339,14 +406,14 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                             radius=radius,
                             start_angle=math.degrees(start_angle),
                             end_angle=math.degrees(end_angle),
-                            dxfattribs={"layer": layer},
+                            dxfattribs=attribs,
                         )
                     else:
                         # Approximate as polyline segments
                         pts = _bezier_to_points(p1, p2, p3, p4, page_height, segments=8)
                         if len(pts) >= 2:
                             shifted = [(x_offset + px, py) for px, py in pts]
-                            msp.add_lwpolyline(shifted, dxfattribs={"layer": layer})
+                            msp.add_lwpolyline(shifted, dxfattribs=attribs)
                     total += 1
 
                 elif kind == "qu":  # Quad (quadrilateral)
@@ -364,7 +431,7 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                             for k in range(1, len(item))
                         ]
                     if len(pts) >= 2:
-                        msp.add_lwpolyline(pts, close=True, dxfattribs={"layer": layer})
+                        msp.add_lwpolyline(pts, close=True, dxfattribs=attribs)
                     total += 1
 
         # Extract text blocks from the page
@@ -384,7 +451,11 @@ def _extract_pdf_fitz(msp, source_path: Path) -> int:
                     msp.add_text(
                         text,
                         height=height * 0.7,
-                        dxfattribs={"layer": layer, "insert": (x, y)},
+                        dxfattribs={
+                            "layer": layer,
+                            "color": PDF_ENTITY_COLOR,
+                            "insert": (x, y),
+                        },
                     )
                     total += 1
 
@@ -474,6 +545,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
     """
     count = 0
     layer = f"PDF_PAGE_{page_num + 1}" if page_num > 0 else "0"
+    attribs = {"layer": layer, "color": PDF_ENTITY_COLOR}
 
     # Extract lines
     lines = page.lines or []
@@ -484,7 +556,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         page_height = float(page.height)
         y0 = page_height - y0
         y1 = page_height - y1
-        msp.add_line((x0, y0), (x1, y1), dxfattribs={"layer": layer})
+        msp.add_line((x0, y0), (x1, y1), dxfattribs=attribs)
         count += 1
 
     # Extract rectangles as polylines
@@ -496,7 +568,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         y0 = page_height - y0
         y1 = page_height - y1
         points = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
-        msp.add_lwpolyline(points, close=True, dxfattribs={"layer": layer})
+        msp.add_lwpolyline(points, close=True, dxfattribs=attribs)
         count += 1
 
     # Extract text
@@ -509,7 +581,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         msp.add_text(
             text,
             height=height * 0.7,  # approximate PDF text height to DXF
-            dxfattribs={"layer": layer, "insert": (x, y)},
+            dxfattribs={"layer": layer, "color": PDF_ENTITY_COLOR, "insert": (x, y)},
         )
         count += 1
 

--- a/src/cad_dxf_agent/core/pdf_classifier.py
+++ b/src/cad_dxf_agent/core/pdf_classifier.py
@@ -1,0 +1,130 @@
+"""Per-page PDF content classifier.
+
+Classifies each page of a PDF by content type (vector layout, raster scan,
+mixed, or cover/text-heavy) using PyMuPDF metadata.  The converter uses
+these classifications to decide extraction strategy per page.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class PageContentType(StrEnum):
+    """Content type classification for a single PDF page."""
+
+    VECTOR_LAYOUT = "vector_layout"
+    RASTER_SCANNED = "raster_scanned"
+    MIXED = "mixed"
+    COVER_TEXT_HEAVY = "cover_text_heavy"
+
+
+@dataclass
+class PageClassification:
+    """Classification result for one PDF page."""
+
+    page_num: int
+    content_type: PageContentType
+    vector_count: int
+    image_count: int
+    image_area_ratio: float
+    text_count: int
+
+
+def classify_pdf_pages(source_path: Path) -> list[PageClassification]:
+    """Classify each page of a PDF by content type.
+
+    Uses PyMuPDF to count vector paths, embedded images, and text spans
+    per page, then applies heuristic rules.
+
+    Args:
+        source_path: Path to the PDF file.
+
+    Returns:
+        List of PageClassification, one per page.
+    """
+    import fitz
+
+    doc = fitz.open(str(source_path))
+    results: list[PageClassification] = []
+
+    for page_num, page in enumerate(doc):
+        drawings = page.get_drawings()
+        images = page.get_images()
+        text_dict = page.get_text("dict", flags=fitz.TEXT_PRESERVE_WHITESPACE)
+
+        vector_count = sum(len(pi.get("items", [])) for pi in drawings)
+        image_count = len(images)
+
+        text_count = sum(
+            1
+            for block in text_dict.get("blocks", [])
+            if block.get("type") == 0
+            for line in block.get("lines", [])
+            for span in line.get("spans", [])
+            if span.get("text", "").strip()
+        )
+
+        # Estimate image area ratio
+        page_area = page.rect.width * page.rect.height
+        image_area_ratio = 0.0
+        if page_area > 0 and image_count > 0:
+            total_img_area = 0.0
+            for img in images:
+                # img tuple: (xref, smask, width, height, bpc, ...)
+                if len(img) >= 4:
+                    total_img_area += img[2] * img[3]
+            image_area_ratio = min(total_img_area / page_area, 1.0)
+
+        content_type = _classify_page(vector_count, image_count, image_area_ratio, text_count)
+
+        results.append(
+            PageClassification(
+                page_num=page_num,
+                content_type=content_type,
+                vector_count=vector_count,
+                image_count=image_count,
+                image_area_ratio=image_area_ratio,
+                text_count=text_count,
+            )
+        )
+        logger.debug(
+            "Page %d: %s (vectors=%d, images=%d, img_ratio=%.2f, text=%d)",
+            page_num + 1,
+            content_type.value,
+            vector_count,
+            image_count,
+            image_area_ratio,
+            text_count,
+        )
+
+    doc.close()
+    return results
+
+
+def _classify_page(
+    vector_count: int,
+    image_count: int,
+    image_area_ratio: float,
+    text_count: int,
+) -> PageContentType:
+    """Apply heuristic rules to classify a page."""
+    has_vectors = vector_count > 50
+    has_large_images = image_area_ratio > 0.5
+    is_text_heavy = text_count > 20 and vector_count < 50
+
+    if is_text_heavy:
+        return PageContentType.COVER_TEXT_HEAVY
+    if has_vectors and has_large_images:
+        return PageContentType.MIXED
+    if has_vectors:
+        return PageContentType.VECTOR_LAYOUT
+    if image_count > 0 and (has_large_images or vector_count < 10):
+        return PageContentType.RASTER_SCANNED
+    # Fallback: few vectors, few images, little text
+    return PageContentType.COVER_TEXT_HEAVY

--- a/src/cad_dxf_agent/core/renderer.py
+++ b/src/cad_dxf_agent/core/renderer.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import ezdxf
@@ -32,6 +32,7 @@ class RenderResult:
     dpi: int
     success: bool
     error: str | None = None
+    quality_warnings: list[str] = field(default_factory=list)
 
 
 def render_dxf_to_png(
@@ -154,11 +155,16 @@ def _render(
             span.set_attribute("cad.render.output_basename", output_path.name)
             logger.info("Rendered %s → %s (%d dpi)", dxf_path.name, output_path, dpi)
 
+            quality_warnings = _check_render_quality(output_path)
+            for w in quality_warnings:
+                logger.warning("Render quality: %s", w)
+
             return RenderResult(
                 output_path=output_path,
                 format=fmt,
                 dpi=dpi,
                 success=True,
+                quality_warnings=quality_warnings,
             )
 
         except Exception as e:
@@ -170,6 +176,33 @@ def _render(
                 success=False,
                 error=f"Render failed: {e}",
             )
+
+
+def _check_render_quality(output_path: Path) -> list[str]:
+    """Detect mostly-black or mostly-white renders that indicate a rendering bug.
+
+    Only runs on PNG images (PIL can't open PDF renders).
+    """
+    if output_path.suffix.lower() != ".png":
+        return []
+    warnings: list[str] = []
+    try:
+        import numpy as np
+        from PIL import Image
+
+        img = np.array(Image.open(str(output_path)).convert("L"))
+        mean_lum = float(img.mean())
+        if mean_lum < 20:
+            warnings.append(
+                f"Render appears mostly black (mean luminance {mean_lum:.0f}/255)"
+            )
+        elif mean_lum > 250:
+            warnings.append(
+                f"Render appears blank (mean luminance {mean_lum:.0f}/255)"
+            )
+    except ImportError:
+        pass  # PIL/numpy not available, skip check
+    return warnings
 
 
 def _bg_hex(color_name: str) -> str:

--- a/tests/fixtures/test_pdfs/sawcuts_baseline.json
+++ b/tests/fixtures/test_pdfs/sawcuts_baseline.json
@@ -1,0 +1,55 @@
+{
+  "description": "Baseline metrics from S202-S203_SAWCUTS_APP (1).pdf before color/classifier fixes",
+  "date": "2026-03-05",
+  "pages": [
+    {
+      "page": 1,
+      "width": 612.0,
+      "height": 792.0,
+      "drawing_count": 12,
+      "path_item_count": 12,
+      "image_count": 1,
+      "text_span_count": 32,
+      "expected_classification": "cover_text_heavy"
+    },
+    {
+      "page": 2,
+      "width": 3024.0,
+      "height": 2160.0,
+      "drawing_count": 17741,
+      "path_item_count": 18175,
+      "image_count": 1,
+      "text_span_count": 351,
+      "expected_classification": "vector_layout"
+    },
+    {
+      "page": 3,
+      "width": 3024.0,
+      "height": 2160.0,
+      "drawing_count": 14294,
+      "path_item_count": 14672,
+      "image_count": 1,
+      "text_span_count": 316,
+      "expected_classification": "vector_layout"
+    }
+  ],
+  "before": {
+    "total_entities_extracted": 33555,
+    "render_mean_luminance": 254.8,
+    "entity_colors": "all 256 (BYLAYER, no explicit color)",
+    "layers": {
+      "0": {"entity_count": 44, "color": 7},
+      "PDF_PAGE_2": {"entity_count": 18524, "color": "auto-created, no explicit"},
+      "PDF_PAGE_3": {"entity_count": 14987, "color": "auto-created, no explicit"}
+    },
+    "bug": "entities invisible — BYLAYER color on auto-created layers without color metadata renders as white-on-white"
+  },
+  "acceptance_criteria": {
+    "all_entities_have_explicit_color": true,
+    "layers_have_explicit_colors": true,
+    "render_mean_luminance_below": 250,
+    "render_mean_luminance_above": 20,
+    "pages_2_3_classified_as": "vector_layout",
+    "entity_count_threshold": 30000
+  }
+}

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import ezdxf
 import pytest
 
-from cad_dxf_agent.core.converter import _PDF_WARNING, ConversionResult, convert_to_dxf
+from cad_dxf_agent.core.converter import (
+    _PDF_WARNING,
+    PDF_ENTITY_COLOR,
+    ConversionResult,
+    _rgb_to_aci,
+    convert_to_dxf,
+)
 
 
 class TestDxfPassthrough:
@@ -767,6 +773,177 @@ class TestPdfConversionException:
         result = _convert_pdf(pdf_path, tmp_path)
         assert result.success is False
         assert "PDF conversion failed" in (result.error or "")
+
+
+class TestPdfEntityColors:
+    """Entities from PDF extraction must have explicit ACI colors."""
+
+    def test_fitz_entities_have_explicit_color(self, tmp_path, monkeypatch):
+        """Every entity from _extract_pdf_fitz has an explicit color (not BYLAYER/256)."""
+        import sys
+        import types
+
+        import ezdxf
+
+        fitz_mod = types.ModuleType("fitz")
+        fitz_mod.TEXT_PRESERVE_WHITESPACE = 1
+
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        class MockPage:
+            class Rect:
+                height = 792.0
+                width = 612.0
+
+            rect = Rect()
+
+            def get_drawings(self):
+                return [{"items": [("l", Pt(0, 0), Pt(10, 10))], "color": None}]
+
+            def get_text(self, mode, flags=0):
+                return {"blocks": []}
+
+        class MockDoc:
+            def __iter__(self):
+                return iter([MockPage()])
+
+            def close(self):
+                pass
+
+        fitz_mod.open = lambda path: MockDoc()
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        doc.layers.get("0").color = PDF_ENTITY_COLOR
+        msp = doc.modelspace()
+        count = _extract_pdf_fitz(msp, tmp_path / "dummy.pdf", doc)
+        assert count == 1
+
+        for entity in msp:
+            assert entity.dxf.color != 256, f"{entity.dxftype()} has BYLAYER color"
+            assert entity.dxf.color == PDF_ENTITY_COLOR
+
+    def test_fitz_layers_created_with_color(self, tmp_path, monkeypatch):
+        """Per-page layers (PDF_PAGE_2, etc.) are created with explicit colors."""
+        import sys
+        import types
+
+        import ezdxf
+
+        fitz_mod = types.ModuleType("fitz")
+        fitz_mod.TEXT_PRESERVE_WHITESPACE = 1
+
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        class MockPage:
+            def __init__(self, w=612, h=792):
+                class R:
+                    height = h
+                    width = w
+
+                self.rect = R()
+
+            def get_drawings(self):
+                return [{"items": [("l", Pt(0, 0), Pt(10, 10))]}]
+
+            def get_text(self, mode, flags=0):
+                return {"blocks": []}
+
+        class MockDoc:
+            def __iter__(self):
+                return iter([MockPage(), MockPage()])
+
+            def close(self):
+                pass
+
+        fitz_mod.open = lambda path: MockDoc()
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        doc.layers.get("0").color = PDF_ENTITY_COLOR
+        msp = doc.modelspace()
+        _extract_pdf_fitz(msp, tmp_path / "dummy.pdf", doc)
+
+        layer2 = doc.layers.get("PDF_PAGE_2")
+        assert layer2.color == PDF_ENTITY_COLOR
+
+    def test_pdfplumber_entities_have_explicit_color(self, tmp_path):
+        """pdfplumber fallback entities have explicit color."""
+        import ezdxf
+
+        from cad_dxf_agent.core.converter import _extract_pdf_page_plumber
+
+        class SingleLinePage:
+            height = 792.0
+            lines = [{"x0": 0.0, "top": 0.0, "x1": 50.0, "bottom": 0.0}]
+            rects = []
+
+            def extract_words(self):
+                return []
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        _extract_pdf_page_plumber(msp, SingleLinePage(), 0)
+
+        for entity in msp:
+            assert entity.dxf.color == PDF_ENTITY_COLOR
+
+
+class TestRgbToAci:
+    """Tests for _rgb_to_aci color mapping."""
+
+    def test_none_returns_default(self):
+        assert _rgb_to_aci(None) == PDF_ENTITY_COLOR
+
+    def test_black_returns_white(self):
+        assert _rgb_to_aci((0, 0, 0)) == 7
+
+    def test_red(self):
+        assert _rgb_to_aci((1.0, 0, 0)) == 1
+
+    def test_green(self):
+        assert _rgb_to_aci((0, 1.0, 0)) == 3
+
+    def test_blue(self):
+        assert _rgb_to_aci((0, 0, 1.0)) == 5
+
+    def test_yellow(self):
+        assert _rgb_to_aci((1.0, 1.0, 0)) == 2
+
+    def test_cyan(self):
+        assert _rgb_to_aci((0, 1.0, 1.0)) == 4
+
+    def test_magenta(self):
+        assert _rgb_to_aci((1.0, 0, 1.0)) == 6
+
+    def test_invalid_type_returns_default(self):
+        assert _rgb_to_aci("not a tuple") == PDF_ENTITY_COLOR
+
+    def test_near_black_returns_white(self):
+        assert _rgb_to_aci((0.05, 0.05, 0.05)) == 7
+
+
+class TestConversionResultClassifications:
+    """ConversionResult includes classifications field."""
+
+    def test_classifications_default_none(self, tmp_path):
+        result = ConversionResult(
+            source_path=tmp_path / "test.dxf",
+            source_format="pdf",
+            output_path=tmp_path / "out.dxf",
+            success=True,
+        )
+        assert result.classifications is None
 
 
 def _create_minimal_pdf(path: Path, *, empty: bool = False) -> None:

--- a/tests/unit/test_pdf_classifier.py
+++ b/tests/unit/test_pdf_classifier.py
@@ -1,0 +1,112 @@
+"""Tests for the PDF per-page content classifier."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.pdf_classifier import (
+    PageContentType,
+    _classify_page,
+)
+
+
+class TestClassifyPageRules:
+    """Test the heuristic classification rules."""
+
+    def test_vector_layout(self):
+        result = _classify_page(
+            vector_count=500, image_count=0, image_area_ratio=0.0, text_count=10,
+        )
+        assert result == PageContentType.VECTOR_LAYOUT
+
+    def test_raster_scanned(self):
+        result = _classify_page(vector_count=5, image_count=1, image_area_ratio=0.8, text_count=0)
+        assert result == PageContentType.RASTER_SCANNED
+
+    def test_mixed(self):
+        result = _classify_page(vector_count=200, image_count=2, image_area_ratio=0.6, text_count=5)
+        assert result == PageContentType.MIXED
+
+    def test_cover_text_heavy(self):
+        result = _classify_page(vector_count=10, image_count=0, image_area_ratio=0.0, text_count=30)
+        assert result == PageContentType.COVER_TEXT_HEAVY
+
+    def test_few_vectors_few_images_falls_to_cover(self):
+        result = _classify_page(vector_count=5, image_count=0, image_area_ratio=0.0, text_count=2)
+        assert result == PageContentType.COVER_TEXT_HEAVY
+
+    def test_raster_with_low_area_but_no_vectors(self):
+        result = _classify_page(vector_count=3, image_count=1, image_area_ratio=0.3, text_count=0)
+        assert result == PageContentType.RASTER_SCANNED
+
+    def test_many_vectors_with_small_image(self):
+        """Vectors dominate despite small embedded image."""
+        result = _classify_page(
+            vector_count=1000, image_count=1, image_area_ratio=0.1, text_count=50,
+        )
+        assert result == PageContentType.VECTOR_LAYOUT
+
+
+class TestClassifyPdfPages:
+    """Integration test for classify_pdf_pages using mocked fitz."""
+
+    def test_classify_with_mocked_fitz(self, tmp_path, monkeypatch):
+        """Mocked multi-page PDF returns correct classifications."""
+        import sys
+        import types
+
+        fitz_mod = types.ModuleType("fitz")
+        fitz_mod.TEXT_PRESERVE_WHITESPACE = 1
+
+        class MockPage:
+            def __init__(self, w, h, drawings, images, text_dict):
+                class Rect:
+                    def __init__(self, w, h):
+                        self.width = w
+                        self.height = h
+                self.rect = Rect(w, h)
+                self._drawings = drawings
+                self._images = images
+                self._text = text_dict
+
+            def get_drawings(self):
+                return self._drawings
+
+            def get_images(self):
+                return self._images
+
+            def get_text(self, mode, flags=0):
+                return self._text
+
+        # Page 1: cover (few vectors, lots of text)
+        page1 = MockPage(612, 792,
+            drawings=[{"items": [("l",)]}],  # 1 item
+            images=[],
+            text_dict={
+                "blocks": [{"type": 0, "lines": [
+                    {"spans": [{"text": f"word{i}"} for i in range(25)]}
+                ]}],
+            },
+        )
+        # Page 2: vector layout (many vectors, no images)
+        page2 = MockPage(3024, 2160,
+            drawings=[{"items": [("l",)] * 200}],
+            images=[],
+            text_dict={"blocks": []},
+        )
+
+        class MockDoc:
+            def __init__(self):
+                self._pages = [page1, page2]
+            def __iter__(self):
+                return iter(self._pages)
+            def close(self):
+                pass
+
+        fitz_mod.open = lambda path: MockDoc()
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.pdf_classifier import classify_pdf_pages
+
+        results = classify_pdf_pages(tmp_path / "dummy.pdf")
+        assert len(results) == 2
+        assert results[0].content_type == PageContentType.COVER_TEXT_HEAVY
+        assert results[1].content_type == PageContentType.VECTOR_LAYOUT

--- a/tests/unit/test_renderer.py
+++ b/tests/unit/test_renderer.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from cad_dxf_agent.core.renderer import RenderResult, render_dxf_to_pdf, render_dxf_to_png
+from cad_dxf_agent.core.renderer import (
+    RenderResult,
+    _check_render_quality,
+    render_dxf_to_pdf,
+    render_dxf_to_png,
+)
 
 
 class TestPngRendering:
@@ -167,3 +172,57 @@ class TestRenderExceptionPath:
         assert result.success is False
         assert result.error is not None
         assert "Render failed" in result.error
+
+
+class TestRenderQualityGuard:
+    """Tests for _check_render_quality black/blank detection."""
+
+    def test_detects_mostly_black(self, tmp_path: Path):
+        """A nearly-black image triggers a warning."""
+        from PIL import Image
+
+        img = Image.new("L", (100, 100), color=5)
+        output = tmp_path / "black.png"
+        img.save(str(output))
+
+        warnings = _check_render_quality(output)
+        assert len(warnings) == 1
+        assert "mostly black" in warnings[0]
+
+    def test_detects_blank_white(self, tmp_path: Path):
+        """A nearly-white image triggers a warning."""
+        from PIL import Image
+
+        img = Image.new("L", (100, 100), color=252)
+        output = tmp_path / "white.png"
+        img.save(str(output))
+
+        warnings = _check_render_quality(output)
+        assert len(warnings) == 1
+        assert "blank" in warnings[0]
+
+    def test_normal_render_no_warnings(self, tmp_path: Path):
+        """A normal-luminance image produces no warnings."""
+        from PIL import Image
+
+        img = Image.new("L", (100, 100), color=128)
+        output = tmp_path / "normal.png"
+        img.save(str(output))
+
+        warnings = _check_render_quality(output)
+        assert len(warnings) == 0
+
+    def test_skips_non_png(self, tmp_path: Path):
+        """Non-PNG files are skipped (PDF renders can't be opened by PIL)."""
+        output = tmp_path / "render.pdf"
+        output.write_bytes(b"%PDF-fake")
+
+        warnings = _check_render_quality(output)
+        assert len(warnings) == 0
+
+    def test_render_result_includes_quality_warnings(self, sample_dxf: Path, tmp_path: Path):
+        """Successful PNG render includes quality_warnings field."""
+        output = tmp_path / "preview.png"
+        result = render_dxf_to_png(sample_dxf, output_path=output)
+        assert result.success is True
+        assert isinstance(result.quality_warnings, list)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -207,6 +207,7 @@ async def upload(
 
     # Convert if needed
     dxf_path = session.original_path
+    pdf_classifications = None
     if ext == ".pdf":
         try:
             from cad_dxf_agent.core.converter import convert_to_dxf
@@ -216,6 +217,8 @@ async def upload(
                 detail = _user_friendly_conversion_error(result.error, ext)
                 raise HTTPException(status_code=422, detail=detail)
             shutil.copy2(str(result.output_path), str(dxf_path))
+            # Store page classifications for response
+            pdf_classifications = result.classifications
         except ImportError:
             raise HTTPException(
                 status_code=500,
@@ -260,10 +263,21 @@ async def upload(
     except Exception as e:
         logger.warning("Original render failed (non-fatal): %s", e, exc_info=True)
 
-    return {
+    response: dict = {
         "session_id": session.session_id,
         "file_info": session.file_info,
     }
+    if pdf_classifications:
+        response["page_classifications"] = [
+            {
+                "page": c.page_num + 1,
+                "type": c.content_type.value,
+                "vectors": c.vector_count,
+                "text": c.text_count,
+            }
+            for c in pdf_classifications
+        ]
+    return response
 
 
 @app.post("/api/plan")

--- a/web/frontend/e2e/global-setup.js
+++ b/web/frontend/e2e/global-setup.js
@@ -1,0 +1,28 @@
+// @ts-check
+/**
+ * Global setup: sign in anonymously once and save the auth state.
+ * All tests reuse this storage state, avoiding repeated signInAnonymously
+ * calls that trigger Firebase rate limiting.
+ */
+import { chromium } from '@playwright/test';
+import path from 'path';
+
+const STORAGE_STATE_PATH = path.join(import.meta.dirname, '..', 'test-results', '.auth-state.json');
+
+export default async function globalSetup(config) {
+  const baseURL = config.projects[0].use.baseURL || 'http://localhost:3000';
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  await page.goto(baseURL);
+  // Wait for Firebase anonymous auth to complete — h2 appears when auth is done
+  await page.locator('h2').waitFor({ state: 'visible', timeout: 30_000 });
+
+  // Save auth state (includes Firebase IndexedDB tokens)
+  await page.context().storageState({ path: STORAGE_STATE_PATH });
+
+  await browser.close();
+}
+
+export { STORAGE_STATE_PATH };

--- a/web/frontend/e2e/upload-dxf.spec.js
+++ b/web/frontend/e2e/upload-dxf.spec.js
@@ -18,16 +18,13 @@ test.describe('DXF Upload', () => {
     const systemMsg = page.locator('.message--system');
     await expect(systemMsg).toContainText('Loaded r2000_blocks.dxf', { timeout: 20_000 });
 
-    // File info sidebar
-    await expect(page.locator('.file-info__name')).toContainText('r2000_blocks.dxf');
+    // Compact bar shows filename (sidebar auto-collapses after upload)
+    await expect(page.locator('.upload-bar-compact__filename')).toContainText('r2000_blocks.dxf');
 
-    // Entity count > 0
-    const entityStat = page.locator('.file-info__stat-value').first();
-    const entityText = await entityStat.textContent();
-    expect(Number(entityText)).toBeGreaterThan(0);
-
-    // Layer badges visible
-    await expect(page.locator('.badge').first()).toBeVisible();
+    // Entity/layer count visible in compact bar meta
+    const compactMeta = page.locator('.upload-bar-compact__meta');
+    const metaText = await compactMeta.textContent();
+    expect(metaText).toMatch(/\d+\s+entities/);
 
     // Preview image rendered
     const previewImg = page.locator('img[alt*="drawing preview"]');
@@ -45,7 +42,7 @@ test.describe('DXF Upload', () => {
     await page.locator('input[type="file"]').setInputFiles(path.join(DXF_ZOO, 'r12_basic.dxf'));
 
     await expect(page.locator('.message--system')).toContainText('Loaded r12_basic.dxf', { timeout: 20_000 });
-    await expect(page.locator('.file-info__name')).toContainText('r12_basic.dxf');
+    await expect(page.locator('.upload-bar-compact__filename')).toContainText('r12_basic.dxf');
   });
 
   test('uploads r2018_polylines.dxf — modern format loads OK', async ({ page }) => {
@@ -55,6 +52,6 @@ test.describe('DXF Upload', () => {
     await page.locator('input[type="file"]').setInputFiles(path.join(DXF_ZOO, 'r2018_polylines.dxf'));
 
     await expect(page.locator('.message--system')).toContainText('Loaded r2018_polylines.dxf', { timeout: 20_000 });
-    await expect(page.locator('.file-info__name')).toContainText('r2018_polylines.dxf');
+    await expect(page.locator('.upload-bar-compact__filename')).toContainText('r2018_polylines.dxf');
   });
 });

--- a/web/frontend/e2e/upload-pdf.spec.js
+++ b/web/frontend/e2e/upload-pdf.spec.js
@@ -20,7 +20,7 @@ test.describe('PDF Upload', () => {
     ]);
 
     if (result === 'success') {
-      await expect(page.locator('.file-info__name')).toBeVisible();
+      await expect(page.locator('.upload-bar-compact__filename')).toBeVisible();
     } else {
       const errorText = await page.locator('[role="alert"]').textContent();
       // Must be user-friendly — no internal tracebacks
@@ -42,10 +42,9 @@ test.describe('PDF Upload', () => {
     ]);
 
     if (result === 'success') {
-      await expect(page.locator('.file-info__name')).toBeVisible();
-      const entityStat = page.locator('.file-info__stat-value').first();
-      const entityText = await entityStat.textContent();
-      expect(Number(entityText)).toBeGreaterThan(0);
+      await expect(page.locator('.upload-bar-compact__filename')).toBeVisible();
+      const metaText = await page.locator('.upload-bar-compact__meta').textContent();
+      expect(metaText).toMatch(/\d+\s+entities/);
     } else {
       const errorText = await page.locator('[role="alert"]').textContent();
       expect(errorText).not.toContain('Traceback');

--- a/web/frontend/e2e/upload-sourced.spec.js
+++ b/web/frontend/e2e/upload-sourced.spec.js
@@ -49,11 +49,10 @@ test.describe('Upload Sourced DXF Files', () => {
           ]);
 
           if (outcome === 'loaded') {
-            await expect(page.locator('.file-info__name')).toContainText(file);
-            const entityStat = page.locator('.file-info__stat-value').first();
-            const entityText = await entityStat.textContent();
-            expect(Number(entityText)).toBeGreaterThanOrEqual(0);
-            console.log(`  [ok] ${file} — loaded, ${entityText} entities`);
+            await expect(page.locator('.upload-bar-compact__filename')).toContainText(file);
+            const metaText = await page.locator('.upload-bar-compact__meta').textContent();
+            expect(metaText).toMatch(/\d+\s+entities/);
+            console.log(`  [ok] ${file} — loaded, ${metaText}`);
           } else {
             const alertText = await page.locator('[role="alert"]').textContent();
             expect(alertText).not.toMatch(/Traceback|Internal Server Error|500/);

--- a/web/frontend/playwright.config.js
+++ b/web/frontend/playwright.config.js
@@ -12,6 +12,8 @@ const isProduction = TARGET === 'production';
 const PROD_URL = 'https://cad-dxf-agent.web.app';
 const LOCAL_URL = 'http://localhost:3000';
 
+const AUTH_STATE_PATH = path.join(import.meta.dirname, 'test-results', '.auth-state.json');
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -20,6 +22,8 @@ export default defineConfig({
   workers: 1,
   timeout: 90_000, // production can be slower (Cloud Run cold start)
 
+  globalSetup: './e2e/global-setup.js',
+
   reporter: [
     ['list'],
     ['html', { open: 'never' }],
@@ -27,6 +31,7 @@ export default defineConfig({
 
   use: {
     baseURL: isProduction ? PROD_URL : LOCAL_URL,
+    storageState: AUTH_STATE_PATH,
     trace: 'on',
     screenshot: 'on',
     video: 'retain-on-failure',

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -113,6 +113,22 @@ export default function Workspace({ user, onSignOut }) {
                   <span>Layers</span>
                   <span className="file-info__stat-value">{fileInfo.layer_count}</span>
                 </div>
+                {fileInfo.page_classifications && (
+                  <div style={{ marginTop: 'var(--space-3)' }}>
+                    <p className="text-xs text-tertiary" style={{ marginBottom: 'var(--space-1)' }}>Pages</p>
+                    <div className="flex gap-1" style={{ flexWrap: 'wrap' }}>
+                      {fileInfo.page_classifications.map((c) => (
+                        <span
+                          key={c.page}
+                          className={`badge ${c.type === 'vector_layout' ? 'badge--success' : c.type === 'raster_scanned' ? 'badge--warning' : ''}`}
+                          title={`${c.vectors} vectors, ${c.text} text`}
+                        >
+                          P{c.page}: {c.type.replace('_', ' ')}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 {fileInfo.layers && (
                   <div style={{ marginTop: 'var(--space-3)' }}>
                     <p className="text-xs text-tertiary" style={{ marginBottom: 'var(--space-1)' }}>Layers</p>

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -47,7 +47,7 @@ export function useSession() {
     try {
       const data = await uploadFile(file);
       setSessionId(data.session_id);
-      setFileInfo(data.file_info);
+      setFileInfo({ ...data.file_info, page_classifications: data.page_classifications || null });
       // Fetch PNG render and DXF blob in parallel
       const [renderResult, dxfResult] = await Promise.allSettled([
         getRenderBlob(data.session_id, 'original'),


### PR DESCRIPTION
## Summary

Fixes the "black blob" / invisible PDF rendering bug. When Tony uploaded his 3-page structural PDF (S202-S203), pages 2/3 had 33k+ entities that were completely invisible.

### Root Cause
The PDF-to-DXF converter never set explicit colors on extracted entities. All entities had `color=256` (BYLAYER), and auto-created layers (`PDF_PAGE_2`, `PDF_PAGE_3`) had no color metadata. Result: white-on-white rendering → invisible geometry.

### What Changed

**Entity Colors** (`converter.py`):
- Added `PDF_ENTITY_COLOR = 7` (ACI white → black via renderer inversion)
- Added `_rgb_to_aci()` to map PDF RGB stroke colors to nearest DXF ACI
- Every entity in both fitz and pdfplumber paths now gets explicit color
- Per-page layers created with explicit `color=7`

**PDF Classifier** (`pdf_classifier.py` — new):
- Per-page content classification: `vector_layout`, `raster_scanned`, `mixed`, `cover_text_heavy`
- Uses PyMuPDF to count paths, images, and text per page
- Wired into converter + upload API response

**Render Quality Guard** (`renderer.py`):
- `_check_render_quality()` detects mostly-black (lum < 20) or blank (lum > 250) renders
- Added `quality_warnings` field to `RenderResult`
- Only runs on PNG (skips PDF renders)

**Frontend**:
- Page classification badges in sidebar (e.g., "P1: cover text heavy", "P2: vector layout")

### Before/After Metrics (Tony's PDF)
| Metric | Before | After |
|--------|--------|-------|
| Entity colors | All 256 (BYLAYER) | 7 (white) + 5 (blue) |
| Layer colors | Auto-created, no explicit | All have `color=7` |
| Render mean luminance | 254.8/255 (invisible) | 225.4/255 (visible) |
| Page 1 classification | — | cover_text_heavy |
| Pages 2/3 classification | — | vector_layout |
| Entity count | 33,555 | 33,555 (unchanged) |

### Tests
- 27 new tests: entity colors, layer creation, `_rgb_to_aci`, classifier rules, render quality guard
- All 1354 unit/integration tests pass (3 live API failures are pre-existing)
- Baseline metrics committed to `tests/fixtures/test_pdfs/sawcuts_baseline.json`

## Test plan
- [x] `make test` — all backend tests pass (1354 passed)
- [x] Real PDF: entities have explicit colors, layers have colors
- [x] Real PDF: PNG render has reasonable luminance (225.4, not all-white)
- [x] Classifier correctly identifies cover vs vector layout pages
- [ ] After deploy: upload Tony's PDF → visible geometry, not invisible/black
- [ ] After deploy: comparison detects sawcut linework

🤖 Generated with [Claude Code](https://claude.com/claude-code)