### PR TITLE
docs: harden EPIC-CAD-01 foundation docs against original spec

### DIFF
--- a/000-docs/034-AT-AUDT-capability-audit.md
+++ b/000-docs/034-AT-AUDT-capability-audit.md
@@ -188,21 +188,56 @@ Ranked by impact on Design Operations and Construction Drawing workflows.
 ## 5. User Workflow Capability Matrix
 
 Capability score per user workflow class. Each task family scored for how well
-the current system serves that specific user type.
+the current system serves that specific user type. Target state defines "done"
+for each capability per user type.
 
-| # | Task Family | Design Ops User | Construction Drawing User | General Review User |
-|---|------------|-----------------|--------------------------|---------------------|
-| 1 | Edit (move/delete/text/block) | 75% — Gemini multi-turn works, protected layers enforced | 70% — same tools but redline markup input missing | 65% — query tools usable but edit risky without domain training |
-| 2 | Q&A | 15% — no intent router, edit ops returned for questions | 10% — same gap, construction specs unclear | 40% — DrawingContext serializable but no answer-only path |
-| 3 | Compare | 80% — full revision pipeline (upload/align/approve/apply/bundle) | 85% — revision workflow matches construction redline process well | 70% — diff available but approval workflow may confuse casual users |
-| 4 | Markup Interpretation | 5% — no redline/cloud input | 0% — critical gap for construction redlines | 5% — no markup detection |
-| 5 | Repeated Condition Search | 10% — text search token-only, no pattern matching | 15% — no multi-layer spatial search | 20% — can list entities by layer via query tools |
-| 6 | Summary | 25% — file_info on upload, no formatted summary | 20% — same | 50% — layers/counts shown in UI |
-| 7 | Takeoff/Estimate | 0% — missing | 5% — entity count available but no quantity logic | 0% — missing |
-| 8 | Design Assist | 5% — missing | 0% — missing | 0% — missing |
-| 9 | Apply Edit | 85% — apply endpoint, validation, rendering, download | 75% — same but no approval workflow for edits (only revisions) | 70% — requires understanding of operations |
+**Categorical labels:** 0–20% = unsupported, 21–50% = risky/unclear,
+51–75% = partially supported, 76–100% = supported.
 
-**Overall scores:** Design Ops 33%, Construction Drawing 31%, General Review 36%.
+### Design Ops User
+
+| # | Task Family | Current | Label | Target | Target Label |
+|---|------------|---------|-------|--------|--------------|
+| 1 | Edit (move/delete/text/block) | 75% | partially supported | 95% | supported — full multi-turn edit with undo, bulk ops, and V2 entity types |
+| 2 | Q&A | 15% | unsupported | 85% | supported — intent-routed Q&A with evidence citations from entities |
+| 3 | Compare | 80% | supported | 95% | supported — cross-operation conflict checks, visual diff preview |
+| 4 | Markup Interpretation | 5% | unsupported | 80% | supported — redline/cloud detection from uploaded markup images |
+| 5 | Repeated Condition Search | 10% | unsupported | 80% | supported — regex + spatial pattern search across layers |
+| 6 | Summary | 25% | risky/unclear | 85% | supported — formatted statistics with layer/type breakdowns |
+| 7 | Takeoff/Estimate | 0% | unsupported | 70% | partially supported — quantity extraction for common element types |
+| 8 | Design Assist | 5% | unsupported | 60% | partially supported — code-compliance suggestions for known domains |
+| 9 | Apply Edit | 85% | supported | 95% | supported — streaming apply with rollback on failure |
+
+### Construction Drawing User
+
+| # | Task Family | Current | Label | Target | Target Label |
+|---|------------|---------|-------|--------|--------------|
+| 1 | Edit (move/delete/text/block) | 70% | partially supported | 90% | supported — redline markup as edit input, approval workflow for edits |
+| 2 | Q&A | 10% | unsupported | 85% | supported — construction-spec-aware answers with reference citations |
+| 3 | Compare | 85% | supported | 95% | supported — automated revision numbering, transmittal-ready bundles |
+| 4 | Markup Interpretation | 0% | unsupported | 90% | supported — primary workflow; cloud/delta/revision triangle detection |
+| 5 | Repeated Condition Search | 15% | unsupported | 85% | supported — find all instances of detail/condition across sheets |
+| 6 | Summary | 20% | unsupported | 85% | supported — drawing register integration, scope-of-work summaries |
+| 7 | Takeoff/Estimate | 5% | unsupported | 75% | partially supported — BOQ extraction for structural/architectural elements |
+| 8 | Design Assist | 0% | unsupported | 50% | risky/unclear — code-check suggestions (limited domain coverage) |
+| 9 | Apply Edit | 75% | partially supported | 90% | supported — approval workflow for edits matching revision process |
+
+### General Review User
+
+| # | Task Family | Current | Label | Target | Target Label |
+|---|------------|---------|-------|--------|--------------|
+| 1 | Edit (move/delete/text/block) | 65% | partially supported | 85% | supported — guided edit wizard, confirmation prompts for destructive ops |
+| 2 | Q&A | 40% | risky/unclear | 90% | supported — natural language answers without needing CAD expertise |
+| 3 | Compare | 70% | partially supported | 90% | supported — simplified diff view with plain-language change summary |
+| 4 | Markup Interpretation | 5% | unsupported | 60% | partially supported — basic redline detection for review comments |
+| 5 | Repeated Condition Search | 20% | unsupported | 70% | partially supported — text search with fuzzy matching |
+| 6 | Summary | 50% | risky/unclear | 90% | supported — dashboard-style overview accessible to non-engineers |
+| 7 | Takeoff/Estimate | 0% | unsupported | 40% | risky/unclear — high-level counts only, no domain-specific quantities |
+| 8 | Design Assist | 0% | unsupported | 30% | risky/unclear — generic suggestions, limited without domain expertise |
+| 9 | Apply Edit | 70% | partially supported | 85% | supported — simplified apply with clear rollback option |
+
+**Overall current scores:** Design Ops 33%, Construction Drawing 31%, General Review 36%.
+**Overall target scores:** Design Ops 83%, Construction Drawing 83%, General Review 71%.
 
 ---
 
@@ -291,3 +326,169 @@ All API calls via `fetch()` in `web/frontend/src/lib/api.js`.
 | Tests | ~1351 | Unit ~1069, integration ~78, web ~123, benchmark ~15, GUI ~10, property ~7, smoke ~7, live varies |
 | Settings | 31 | Environment variables (all CAD_* prefixed) |
 | Coverage | 65% | Threshold in pyproject.toml |
+
+---
+
+## 10. Scale Risks
+
+Production deployment risks that emerge under load or multi-instance scenarios.
+
+| # | Risk | Impact | Detail |
+|---|------|--------|--------|
+| 1 | **In-memory session store** | No horizontal scaling | `SessionManager` is a process-local dict. A second Cloud Run instance sees no sessions from the first. Sticky sessions or external state store required for >1 instance. |
+| 2 | **Ephemeral `/tmp` on Cloud Run** | Data loss on restart | All DXF files, renders, and bundles live under `/tmp/cad-sessions/`. Cloud Run instances can be evicted at any time; ~2 GB tmpfs limit means large files or many concurrent sessions can exhaust storage. |
+| 3 | **Synchronous matplotlib rendering** | Event loop blocking | `renderer.py` calls matplotlib synchronously. On the async FastAPI backend this blocks the event loop for the duration of the render (seconds for complex drawings), starving other requests. |
+| 4 | **No rate limiting or request queuing** | Resource exhaustion | Any authenticated user can fire unlimited `/api/plan` or `/api/compare` requests. No middleware throttle, no per-user queue, no backpressure signal. |
+| 5 | **Gemini API rate limits not handled** | Silent failures under load | Vertex AI enforces per-project QPM/TPM quotas. The planner retry loop catches generic exceptions but does not detect or back off from 429 rate-limit responses specifically. |
+| 6 | **No background session cleanup daemon** | Disk leak | Session TTL (2 h) is enforced lazily on `.get()` only. If no one fetches an expired session, its `/tmp` directory remains until the container is evicted. No background sweep. |
+| 7 | **All state lost on container restart** | Workflow interruption | In-memory sessions, DrawingContexts, conversation histories, and pending ChangeSets vanish when the container is replaced. Users lose work with no warning or recovery path. |
+| 8 | **Cloud Run default concurrency (80) with CPU-bound sync ops** | Throughput collapse | Planner calls and matplotlib renders are CPU-bound and synchronous. At concurrency 80, a few long-running plans can saturate the single vCPU, causing timeouts for queued requests. |
+| 9 | **No streaming for long-running LLM operations** | Poor perceived latency | `/api/plan` blocks until the full ChangeSet is returned (up to `planner_timeout` seconds). No SSE/WebSocket streaming means the frontend shows a spinner with no progress indication. |
+
+---
+
+## 11. LLM Touchpoint Catalog
+
+All LLM and pseudo-LLM components that participate in the prompt-to-changeset flow.
+
+| Component | Module | API | Auth Model | When Used | Known Failure Modes |
+|-----------|--------|-----|-----------|-----------|---------------------|
+| **deterministic_planner** | `llm/deterministic_planner.py` | None (regex) | N/A | Always — first-try bypass before any LLM call | Returns `None` for prompts that don't match rigid patterns; false positives on ambiguous phrasing |
+| **MockProvider** | `llm/mock_provider.py` | None (keyword match) | N/A | CI tests, smoke tests, fallback when SDK missing | Returns empty ChangeSet for unrecognized keywords; no multi-turn support |
+| **GeminiProvider** | `llm/gemini_provider.py` | Vertex AI `GenerativeModel` | ADC (Application Default Credentials) | Dev, prod (one-shot mode) | Safety filter blocks (`ValueError`), empty response, JSON parse failure, Vertex import missing |
+| **AgentProvider** | `llm/agent_provider.py` | Vertex AI function calling | ADC | Prod (tool-use loop, up to 10 turns) | Infinite loop (capped at `MAX_AGENT_TURNS=10`), per-turn timeout, tool dispatch errors, vision describer failure |
+| **MockAgentProvider** | `llm/agent_provider.py` | None (scripted tool calls) | N/A | CI tests for tool-use flow | Only handles simple move/delete/text; context reconstruction may fail on missing fields |
+| **GeminiKeyProvider** | `llm/gemini_key_provider.py` | Public Gemini API (`google-generativeai` SDK) | API key (`CAD_GEMINI_API_KEY`) | Desktop users without GCP credentials | API key leak risk, no Vertex-specific features (grounding, tuning), rate limits differ from Vertex |
+| **ProxyAgentProvider** | `llm/proxy_client.py` | Cloud Run proxy (HTTP) | License key header | Desktop app via proxy | Proxy downtime, license validation failure, network latency added, double-hop timeout risk |
+
+**Orchestration:** `planner.py:run_planner()` drives the flow: deterministic check → provider
+selection via `get_provider()` → `_call_with_timeout()` with `ThreadPoolExecutor` → optional
+validation feedback loop (re-call LLM with blockers) → retry with exponential backoff on failure.
+Raises `PlannerTimeoutError` on wall-clock timeout, `PlannerRetryExhaustedError` when all
+retry attempts fail.
+
+---
+
+## 12. Backend Architecture
+
+### FastAPI App Structure
+
+The web backend (`web/backend/main.py`) is a single FastAPI application deployed as one
+Cloud Run container. Key structural elements:
+
+- **Lifespan handler** — initializes logging and OpenTelemetry on startup
+- **CORS middleware** — allows Firebase Hosting origins (`cad-dxf-agent.web.app`,
+  `cad-dxf-agent.firebaseapp.com`) plus `localhost:3000`/`localhost:5173` for dev;
+  custom origin via `CAD_WEB_CORS_ORIGIN` env var
+- **Request logging middleware** — logs method, path, status code, and duration for
+  every request; warnings for 4xx/5xx
+- **19 endpoints** — grouped by workflow: upload, plan, apply, compare, revision
+  (upload/align/diff/approve/apply/download), render, download, health
+
+### Auth Dependency Chain
+
+All protected endpoints use FastAPI's `Depends(get_user)` which resolves to
+`get_licensed_user()` in `web/backend/auth.py`:
+
+1. **`verify_token(request)`** — extracts `Authorization: Bearer <token>`, calls
+   `firebase_admin.auth.verify_id_token()`. Returns decoded token dict (`uid`, `email`).
+   Bypassed when `CAD_WEB_DEV_MODE=1`.
+2. **`check_license(user)`** — queries Firestore `licenses/{uid}` for `active: true`.
+   Results cached 5 min (`_license_cache` dict). Anonymous users bypass license check.
+   **Fails closed** — Firestore errors return 403, not 200.
+3. **`get_licensed_user(request)`** — composes `verify_token` then `check_license`.
+
+### Cloud Run Deployment Model
+
+- **Single container** — one Docker image, no sidecar
+- **Ephemeral filesystem** — `/tmp` is tmpfs (~2 GB), lost on instance replacement
+- **Concurrency** — default 80 concurrent requests per instance
+- **CPU** — 1 vCPU, 1 GiB memory (set in deploy command)
+- **Timeout** — 300 s per request
+- **Auto-scaling** — 0 to N instances (scale to zero enabled)
+- **Service account** — `cad-dxf-web-run@cad-dxf-agent.iam.gserviceaccount.com`
+
+### SessionManager Singleton
+
+`session_mgr = SessionManager()` is instantiated at module level in `main.py`. It is a
+plain Python object with no persistence backend:
+
+- `create(user_id)` — generates 16-char UUID, creates `/tmp/cad-sessions/{id}/` directory
+- `get(session_id)` — returns `Session` dataclass or `None` (lazy TTL expiration on access)
+- All session state (DrawingContext, ChangeSet, conversation history, comparison result,
+  approval set) lives in the `Session` dataclass's fields — all in-memory
+
+---
+
+## 13. Pipeline Step-by-Step Flows
+
+### Edit Pipeline
+
+```
+1. Upload         POST /api/upload → save to /tmp/cad-sessions/{id}/original.dxf
+                  (PDF/DWG auto-converted via converter.py)
+2. Load           ezdxf.readfile() → DXF document object
+3. Context build  dxf_reader.load_dxf() → DrawingContext (entities, layers, blocks)
+                  semantic_model.build_planner_context() → JSON dict (capped at 500 entities)
+4. Deterministic  deterministic_planner.deterministic_plan() — regex match for trivial ops
+   check          Returns ChangeSet directly if matched, skipping LLM entirely
+5. LLM plan       provider.plan(prompt, context_dict) → ChangeSet
+                  AgentProvider: multi-turn tool-use loop (query → edit → query → ...)
+                  GeminiProvider: one-shot JSON generation with optional PNG
+6. Validate       validators.validate_changeset(changeset, context, rule_config)
+                  Checks: entity existence, protected layers, numeric validity, move distance
+7. Retry loop     If blockers found: format errors → re-call LLM with corrective prompt
+                  Up to planner_max_validation_retries attempts
+8. Preview        preview_model.generate_preview() → human-readable operation descriptions
+                  Sent to frontend for user review before apply
+9. Apply          edit_engine.apply_changeset() → modified DXF document
+                  Each EditOperation applied to working copy via ezdxf
+10. Revision      revision_notes.insert_notes() → AI_REV_NOTES layer entries
+    notes         Deterministic text from operation metadata (never LLM-generated)
+11. Save          dxf_writer.save_dxf() → /tmp/cad-sessions/{id}/edited.dxf
+                  Original file untouched (save-as workflow)
+```
+
+### Compare Pipeline
+
+```
+1. Extract        geometry.extract_snapshots(master) → list[GeometrySnapshot]
+   snapshots      geometry.extract_snapshots(revision) → list[GeometrySnapshot]
+                  Each snapshot: entity type, vertices/points, layer, text, attributes
+2. Titleblock     geometry.detect_titleblock_region(master_snaps) → BBox | None
+   detect         Auto-excludes titleblock area from comparison to reduce noise
+3. Canonical IDs  canonical.assign_stable_ids(snaps) → snaps with content-hash IDs
+                  canonical.sort_snapshots(snaps) → deterministic ordering
+                  Ensures comparison results are reproducible across runs
+4. Align          alignment.align_drawings(master, revision, config) → AlignmentResult
+                  Alignment ladder: identity → centroid → ICP → manual control points
+                  alignment.apply_alignment(revision, result) → transformed snapshots
+5. Match          matcher.match_entities(master, revision, config) → MatchResult
+                  Pairs master↔revision entities by type + proximity + similarity
+                  Produces: matched pairs, master-only (deleted), revision-only (added)
+6. Classify       classifier.classify_changes(match_result, config) → ClassifiedResult
+                  Each pair → change type: MOVE, MODIFY_GEOMETRY, MODIFY_TEXT,
+                  MODIFY_ATTRIBUTES, or UNCHANGED
+                  Unmatched master → DELETE, unmatched revision → ADD
+7. Changelog      changelog.generate_changelog(result) → ChangeLog
+                  JSON + plain-text summary of all classified changes
+8. Overlay        diff_overlay.write_diff_overlay(master, result, output) → DXF
+                  Color-coded layers: green=added, red=deleted, yellow=modified
+```
+
+---
+
+## 14. Extended Failure Modes
+
+Additions to the failure points listed in section 3.
+
+| # | Failure Mode | Trigger | Impact | Mitigation |
+|---|-------------|---------|--------|------------|
+| 6 | **PlannerTimeoutError** | LLM call exceeds `planner_timeout` (default 120 s) | Request fails with 500; user must retry manually | `_call_with_timeout()` uses `ThreadPoolExecutor` with wall-clock limit; not retryable |
+| 7 | **PlannerRetryExhaustedError** | All `planner_max_retries` attempts fail (API errors, malformed responses) | Request fails with 500; last error propagated | Exponential backoff between retries; configurable via `CAD_PLANNER_MAX_RETRIES` |
+| 8 | **Vision pipeline silent fallback** | `describe_drawing()` fails (matplotlib import missing, render crash, Gemini Flash error) | Agent proceeds with entity JSON only — no visual context; may produce lower-quality plans | `vision_describer.py` is optional; `pipeline_worker.py` logs warning and continues without image |
+| 9 | **Firebase auth failure** | Firebase Admin SDK init fails, token expired/revoked, network error to Google Identity | 401 returned; user cannot access any endpoint | `verify_token()` catches all exceptions and returns generic 401; no retry or token refresh on backend |
+| 10 | **Firestore license fail-closed** | Firestore unreachable, permission denied, or timeout | 403 returned even for licensed users — service effectively down for paid users | `check_license()` explicitly fails closed (`raise HTTPException(403)`); cache mitigates for 5 min |
+| 11 | **ODA converter missing** | DWG upload on system without ODA File Converter installed | DWG conversion fails; cloud API fallback not yet implemented | `_convert_dwg()` returns `ConversionResult(success=False)` with install instructions |
+| 12 | **Concurrent session mutation** | Two requests modify the same session simultaneously (e.g., plan + apply race) | Undefined behavior — ChangeSet may be overwritten mid-apply, partial state corruption | No locking on `Session` dataclass; single-user assumption baked in |
+| 13 | **Large file memory pressure** | DXF with 10k+ entities uploaded; multiple concurrent sessions | OOM on 1 GiB Cloud Run instance; `extract_snapshots()` holds all geometry in memory | 500-entity cap in semantic model limits planner context but full DXF still loaded |

--- a/000-docs/035-AT-ARCH-drawing-intelligence-target.md
+++ b/000-docs/035-AT-ARCH-drawing-intelligence-target.md
@@ -217,8 +217,364 @@ is local-first by design (see 004-AT-ADEC).
 | Firebase Auth | Web API | Yes for web; dev mode skips |
 | Cloud Run | Web deployment | Yes for web |
 
-### API Versioning
+### API Surface
+
+#### Endpoint Groups
+
+| Group | Endpoints | Purpose |
+|-------|----------|---------|
+| **Upload** | `POST /api/upload` | Upload DXF/PDF, start session, return file info + renders |
+| **Prompt** | `POST /api/plan` | Send natural-language prompt, get planned operations + preview |
+| **Apply** | `POST /api/apply` | Apply confirmed operations, produce edited DXF |
+| **Status** | `GET /api/health` | Health check, readiness probe |
+| **Results** | `GET /api/render`, `GET /api/dxf`, `GET /api/download` | Retrieve renders, raw DXF, or download edited file |
+| **Compare** | `POST /api/compare` | Upload revision DXF, compare against master |
+| **Revision** | `POST /api/revision/upload`, `/align`, `/diff`, `/approve`, `/apply`; `GET /api/revision/download` | Multi-step revision pipeline (upload → align → diff → approve → apply → download) |
+| **v2 Unified** | `POST /api/v2/prompt` (proposed) | Single endpoint accepting any prompt, returns `PlatformResponse` envelope |
+
+#### Response Envelope (v2)
+
+All v2 responses use the `PlatformResponse` envelope (see 036-AT-SPEC):
+
+```json
+{
+  "response_type": "<ResponseType enum>",
+  "task_family": "<TaskFamily enum>",
+  "message": "Human-readable summary",
+  "data": { ... },
+  "evidence": [ { "entity_handle": "...", "description": "..." } ],
+  "operations": [ ... ],
+  "validation": { "valid": true, "blockers": [], "warnings": [] },
+  "confidence": 0.95,
+  "processing_time_ms": 1234,
+  "session_id": "abc123",
+  "renders": { "original": true, "edited": true }
+}
+```
+
+**Discriminators:** `response_type` (answer_only, plan_only, preview_edit, applied_edit, needs_clarification, unsupported_operation) and `task_family` (qna, edit_plan, compare, etc.) tell the frontend how to render the result.
+
+#### Long-Running Operations
+
+- **Current:** Poll-based. Client calls `POST /api/plan`, receives a synchronous response. Planner timeout (60s) bounds the wait.
+- **Target:** Server-Sent Events (SSE) for streaming progress updates during long-running planner or compare operations. Client opens an SSE connection, receives incremental status events, then a final result event.
+- **Transition:** SSE endpoints introduced as v2 alternatives; synchronous endpoints remain for backward compatibility.
+
+#### API Versioning
 
 - `/api/` — current endpoints, stable, no breaking changes
 - `/api/v2/` — new endpoints using `PlatformResponse` envelope (proposed in 036)
 - Migration: v2 endpoints introduced alongside v1; deprecation after all clients migrate
+
+### Storage Architecture
+
+#### File Lifecycle
+
+```
+Upload → /tmp/cad-sessions/{id}/upload.dxf
+       → copy to working.dxf (mutable)
+       → original.png (render)
+       → Plan/Apply → edited.dxf + edited.png
+       → Download → user retrieves edited.dxf
+       → Expire → session + all files deleted after TTL
+```
+
+#### Retention Policy
+
+- **Current TTL:** 2 hours (`SESSION_TTL_SECONDS = 7200` in `web/backend/session.py`)
+- **Configurable:** Via environment variable (target)
+- **Cleanup:** `SessionManager.cleanup_expired()` removes expired sessions and their temp directories
+
+#### Migration Path: /tmp/ to GCS
+
+| Phase | Storage | Metadata | Trigger |
+|-------|---------|----------|---------|
+| **Now** | `/tmp/cad-sessions/` (ephemeral, single instance) | In-memory `SessionManager` dict | Session create |
+| **EPIC-11** | GCS bucket (`gs://cad-dxf-sessions/`) | Firestore document per session | Session create |
+| **Post-11** | GCS with lifecycle rules (auto-delete after TTL) | Firestore with TTL field | Session create |
+
+**Why migrate:** `/tmp/` is lost on Cloud Run cold start or instance rotation. GCS provides durable cross-instance storage. Firestore provides queryable session metadata surviving restarts.
+
+#### Session Metadata (Target Schema)
+
+```
+Firestore: sessions/{session_id}
+  user_id: string
+  created_at: timestamp
+  ttl_expires_at: timestamp
+  original_gcs_path: string
+  working_gcs_path: string
+  state: "active" | "expired" | "completed"
+  file_info: map
+```
+
+---
+
+## 7. Error Handling & Resilience
+
+### Failure Modes by Layer
+
+| Layer | Failure Mode | Symptom | Response |
+|-------|-------------|---------|----------|
+| **Intent Router** | LLM classification unavailable | Slow-path times out or errors | Fall back to heuristic-only classification; if confidence too low, return `needs_clarification` |
+| **Intent Router** | Ambiguous prompt | Multiple task families score equally | Return `needs_clarification` with candidates |
+| **Planner** | LLM timeout | No response within budget | Raise `PlannerTimeoutError`; surface to user as "request timed out, try again" |
+| **Planner** | Malformed LLM output | JSON parse failure or invalid ops | Retry with corrective prompt (validation-retry loop); exhaust retries → `PlannerRetryExhaustedError` |
+| **Planner** | API quota / transient error | 429 or 5xx from Vertex AI | Exponential backoff retry (up to `max_retries`); exhaust → error response |
+| **Validator** | Blockers found | Protected layer edit, missing entity | Block the changeset; return `unsupported_operation` with blocker details |
+| **Validator** | Warnings found | Large move distance, unusual op count | Allow changeset but include warnings in response |
+| **Response Formatter** | Missing required fields | Envelope construction fails | Internal error logged; return generic error response with `processing_time_ms` |
+| **DXF Reader** | Corrupt or unsupported file | ezdxf parse exception | Return 400 with descriptive error; session not created |
+| **DXF Writer** | Disk full / write error | Save-as fails | Return 500; original file untouched (save-as guarantees no corruption) |
+
+### Timeout Budgets
+
+| Stage | Budget | Source | Retryable? |
+|-------|--------|--------|-----------|
+| **Planner (LLM call)** | 60s wall-clock | `CAD_PLANNER_TIMEOUT` setting | No — timeout is terminal for that attempt |
+| **Validation-retry loop** | 60s per re-call | Same timeout applies per LLM re-call | Yes — up to `planner_max_validation_retries` (default 2) |
+| **Error-retry loop** | 60s per attempt + exponential backoff | `CAD_PLANNER_MAX_RETRIES` (default 2) | Yes — with `retry_delay * 2^(attempt-1)` backoff |
+| **DXF load** | No explicit timeout | Bounded by file size (~2s for large drawings) | No |
+| **Rendering** | No explicit timeout | Bounded by entity count (~5s typical) | No |
+| **Intent Router (fast path)** | <10ms | Regex/keyword, no LLM | N/A |
+| **Intent Router (slow path)** | Shares planner timeout | LLM classification call | Falls back to heuristic |
+
+### Retry Policy
+
+The planner implements a two-tier retry strategy (`llm/planner.py`):
+
+1. **Error retry** — If the LLM call raises a non-timeout exception (network error, malformed response), the planner retries up to `planner_max_retries` (default 2) with exponential backoff starting at `planner_retry_delay` (default 1.0s).
+
+2. **Validation retry** — If the LLM returns a syntactically valid changeset that fails validation (e.g., targets a protected layer), the validation blockers are formatted into a corrective prompt and the LLM is re-called up to `planner_max_validation_retries` (default 2) times. This loop runs inside a successful error-retry attempt.
+
+**Non-retryable:** `PlannerTimeoutError` is always terminal — the planner does not retry after a timeout.
+
+### Graceful Degradation
+
+| Component | Degraded Mode | Trigger |
+|-----------|--------------|---------|
+| **Intent Router** | Heuristic-only (regex/keyword rules, no LLM slow path) | LLM unavailable, quota exhausted, or slow-path timeout |
+| **Vision Pipeline** | Plan without image context | Render fails or `CAD_VISION_ENABLED=false` |
+| **ODA Converter** | Reject DWG files (DXF-only mode) | ODA FileConverter not installed |
+| **Revision Notes** | Skip note insertion | `CAD_REVISION_NOTES_ENABLED=false` |
+| **OpenTelemetry** | No-op spans (zero overhead) | `OTEL_ENABLED` not set or OTel packages not installed |
+
+### Error Response Envelope
+
+All error responses follow the `PlatformResponse` envelope (see 036-AT-SPEC) with appropriate fields:
+
+```json
+{
+  "response_type": "unsupported_operation",
+  "task_family": "edit_plan",
+  "message": "Planner timed out after 60s. Please try a simpler request.",
+  "data": {
+    "reason": "planner_timeout",
+    "timeout_seconds": 60
+  },
+  "operations": [],
+  "confidence": null,
+  "processing_time_ms": 60012
+}
+```
+
+**Error reasons:** `planner_timeout`, `planner_retry_exhausted`, `validation_blocked`, `protected_layer`, `unsupported_entity_type`, `unsupported_task`, `no_drawing_loaded`, `session_expired`, `file_parse_error`.
+
+### Circuit Breaker Considerations
+
+The LLM stage (planner, intent router slow path) is the only external dependency with meaningful failure rates. Circuit breaker logic is not yet implemented but should be considered for EPIC-11:
+
+- **Threshold:** Open circuit after N consecutive LLM failures within a time window (e.g., 5 failures in 60s)
+- **Fallback:** When circuit is open, immediately return `needs_clarification` or fall back to deterministic planner / heuristic router
+- **Half-open:** Allow one probe request after cooldown period to test recovery
+- **Scope:** Per-instance (in-process); no shared state needed since Cloud Run instances are independent
+
+---
+
+## 8. Multi-User & Session Model
+
+### Session Lifecycle
+
+```
+Create (upload) → Active → [plan/apply/compare cycles] → Expire (TTL) → Delete
+                     ↓
+                  Download → (session remains active until TTL)
+```
+
+1. **Create:** `POST /api/upload` generates a session with a unique 16-character hex ID and a temp directory under `/tmp/cad-sessions/{id}/`.
+2. **Active:** Session holds uploaded file, working copy, renders, changeset state, comparison state, conversation history, and revision pipeline state.
+3. **Expire:** `SessionManager.get()` checks TTL on every access. If `time.time() - created_at > SESSION_TTL_SECONDS`, the session is deleted and a `KeyError` is raised.
+4. **Delete:** Session dict entry removed, temp directory recursively deleted via `shutil.rmtree`.
+
+### Storage Backend
+
+| Aspect | Current | Target (EPIC-11) |
+|--------|---------|-------------------|
+| **File storage** | `/tmp/cad-sessions/` (ephemeral) | GCS bucket with lifecycle rules |
+| **Session metadata** | In-memory Python dict (`SessionManager._sessions`) | Firestore with TTL field |
+| **Persistence** | Lost on process restart / instance rotation | Durable across restarts |
+| **Cross-instance** | No — each Cloud Run instance has its own sessions | Yes — GCS + Firestore shared |
+
+### Concurrent Access Model
+
+- **Single-writer per session:** Each session is owned by one authenticated user (`session.user_id`). `SessionManager.get()` validates ownership on every access.
+- **Thread safety:** `SessionManager` uses a `threading.Lock` for dict operations. Session state mutations (e.g., setting `changeset`, `edited_path`) are not individually locked — safe under the single-writer constraint.
+- **No cross-session coordination:** Sessions are fully independent. No shared state between sessions.
+
+### Authentication Mapping
+
+- **Web:** Firebase Auth (email/password + Google OAuth). Every authenticated request includes a Firebase ID token validated server-side. Session ownership is tied to `user["uid"]` from the decoded token.
+- **Dev mode:** `CAD_WEB_DEV_MODE=1` skips Firebase auth and uses a hardcoded dev user ID. Sessions are still created and scoped to this dev user.
+- **Read-only endpoints:** `/api/render`, `/api/dxf`, `/api/download` use `get_by_id()` without ownership check — the session UUID itself serves as an access credential (unguessable 16-char hex).
+
+### Design Constraint
+
+**Single-user sessions only.** Multi-user collaborative editing (multiple users modifying the same drawing simultaneously) is explicitly out of scope. Each session is a private workspace for one user. This simplifies concurrency, conflict resolution, and state management. Collaborative features would require operational transforms or CRDTs, which are not justified by current user workflows.
+
+---
+
+## 9. Observability Plan
+
+### Span Coverage
+
+Each pipeline layer emits a named span via the existing `otel.py` bootstrap module. Spans are hierarchical — child spans nest under the parent pipeline span.
+
+#### Existing Spans
+
+| Span Name | Module | Layer |
+|-----------|--------|-------|
+| `cad.load_dxf` | `core/dxf_reader.py` | DXF Reader |
+| `cad.build_context` | `core/semantic_model.py` | Context Builder |
+| `cad.run_planner` | `llm/planner.py` | Planner Orchestrator |
+| `cad.gemini_plan` | `llm/gemini_provider.py` | Gemini Provider |
+| `cad.agent_plan` | `llm/agent_provider.py` | Agent Provider |
+| `cad.validate` | `core/validators.py` | Safety Layer |
+| `cad.apply_changeset` | `core/edit_engine.py` | Edit Engine |
+| `cad.save` | `core/edit_engine.py` | DXF Writer |
+| `cad.render` | `core/renderer.py` | Renderer |
+| `cad.revision_note` | `core/revision_notes.py` | Revision Notes |
+| `cad.vision_describe` | `llm/vision_describer.py` | Vision Pipeline |
+| `cad.convert` | `core/converter.py` | DWG Converter |
+| `cad.compare.*` | `core/comparison/` | Compare Pipeline (align, match, classify, changelog, overlay) |
+
+#### New Spans (Planned)
+
+| Span Name | Module | Layer | Epic |
+|-----------|--------|-------|------|
+| `cad.router.classify` | `llm/intent_router.py` | Intent Router | EPIC-02 |
+| `cad.router.heuristic` | `llm/intent_router.py` | Intent Router (fast path) | EPIC-02 |
+| `cad.router.llm_classify` | `llm/intent_router.py` | Intent Router (slow path) | EPIC-02 |
+| `cad.format_response` | `core/response_formatter.py` | Response Formatter | EPIC-02 |
+| `cad.select_entities` | `core/entity_index.py` | Selection Engine | EPIC-03 |
+| `cad.build_task_context` | `core/context_strategies.py` | Context Builder (task-aware) | EPIC-03 |
+
+### Key SLIs
+
+| SLI | Definition | Target | Alert Threshold |
+|-----|-----------|--------|----------------|
+| **Router latency p99** | 99th percentile wall-clock time for `cad.router.classify` | <50ms (heuristic), <5s (LLM) | >100ms (heuristic), >10s (LLM) |
+| **Planner success rate** | `1 - (PlannerTimeoutError + PlannerRetryExhaustedError) / total_planner_calls` | >95% | <90% over 1h window |
+| **Validation rejection rate** | Changesets with blockers / total changesets validated | <20% | >40% (indicates LLM quality degradation) |
+| **Pipeline end-to-end p99** | Total time from prompt receipt to response delivery | <30s (edit), <5s (Q&A) | >60s |
+| **Session expiry rate** | Sessions expired without any download / total sessions | Informational | N/A |
+
+### Export Target
+
+- **Production:** GCP Cloud Trace via `opentelemetry.exporter.cloud_trace.CloudTraceSpanExporter` (already configured in `otel.py` when `OTEL_EXPORTER=gcp-trace`)
+- **Local dev:** Console exporter (default) or OTLP to local collector
+- **CI:** Disabled (no `OTEL_ENABLED` set, all spans are no-ops via `_NoOpTracer`)
+
+### Implementation Notes
+
+- All tracing is optional — `otel.py` provides `_NoOpTracer` and `_NoOpSpan` when OTel is not installed or not enabled. Zero runtime overhead when disabled.
+- Span attributes follow the `cad.*` namespace convention. No full file paths or drawing text content in attributes (privacy constraint).
+- `init_otel()` is safe to call multiple times (idempotent). Called once at app startup in the web backend.
+- Test support via `init_otel_testing(exporter)` with `SimpleSpanProcessor` for immediate span capture in assertions.
+
+---
+
+## 10. Migration Phasing
+
+This section maps the 12 epics to architecture layers, showing what is built in each phase and what the system looks like at each intermediate state.
+
+### Phase 1: Foundation (EPICs 01-03)
+
+**Layers built:** Intent Router, Response Formatter, Selection Engine (enhanced)
+
+| Epic | Layers Affected | What Changes |
+|------|----------------|-------------|
+| EPIC-01 | (none — docs only) | Capability audit, architecture baseline, evaluation plan documented |
+| EPIC-02 | Intent Router (NEW), Response Formatter (NEW) | `TaskFamily` + `ResponseType` enums, `PlatformResponse` envelope, `intent_router.py` with heuristic classifier, `/api/v2/prompt` endpoint stub |
+| EPIC-03 | Selection Engine (ENHANCED), Context Builder (ENHANCED) | Regex/fuzzy text search, bbox region selection, markup overlay ingestion, task-family-aware context shaping |
+
+**System state after Phase 1:** Prompts are classified by task family. Responses use typed envelopes. Selection supports region and pattern queries. But only `edit_plan` and `compare` task families produce meaningful results — other families return `unsupported_operation` or basic answers.
+
+### Phase 2: Core Intelligence (EPICs 04-06)
+
+**Layers built:** Tool Layer (new tools), Context Builder (task-specific strategies)
+
+| Epic | Layers Affected | What Changes |
+|------|----------------|-------------|
+| EPIC-04 | Context Builder, Tool Layer, Response Formatter | Region-focused context builder, `answer` and `summarize_drawing` tools, grounded Q&A pipeline producing `answer_only` responses with evidence |
+| EPIC-05 | Selection Engine, Tool Layer | `find_pattern` tool, similarity scoring, repeated-condition search pipeline |
+| EPIC-06 | Compare Pipeline, Response Formatter | Typed compare response schema, alignment diagnostics, compare results wrapped in `PlatformResponse` |
+
+**System state after Phase 2:** Three task families are fully operational (`qna`, `repeated_condition`, `compare`). Edit pipeline still uses v1 response format. Architecture review gate (ARCH-REVIEW-01) evaluates the design before proceeding to structured editing.
+
+### Architecture Review Gate (ARCH-REVIEW-01)
+
+Mandatory review after Phase 2 completes. Evaluates:
+- Whether the router/formatter/tool patterns are scaling well
+- LLM/tool boundary quality (are tools doing too much? too little?)
+- Performance under realistic drawing sizes
+- Decision: keep, change, or remove architectural patterns before building edit planning
+
+### Phase 3: Structured Editing (EPICs 07-08)
+
+**Layers built:** Safety Layer (enhanced), Edit Engine (workflow integration)
+
+| Epic | Layers Affected | What Changes |
+|------|----------------|-------------|
+| EPIC-07 | Safety Layer (ENHANCED), Tool Layer | Cross-operation conflict detection, impact estimation, task-family-appropriate validation (Q&A → zero edits enforced), structured edit plan schema |
+| EPIC-08 | Response Formatter, Edit Engine | Preview pipeline integrated with `PlatformResponse`, apply pipeline with audit trail, `preview_edit` and `applied_edit` response types fully functional via v2 API |
+
+**System state after Phase 3:** Full plan → preview → apply workflow through v2 API with typed responses. All read-only and edit task families operational. Safety layer enforces task-family constraints (Q&A cannot produce edits).
+
+### Phase 4: Workflow Packs (EPICs 09-10)
+
+**Layers built:** Tool Layer (domain-specific tools), Context Builder (domain strategies)
+
+| Epic | Layers Affected | What Changes |
+|------|----------------|-------------|
+| EPIC-09 | Tool Layer, Context Builder | Design-ops tools (`measure_distance`, `count_entities`), layout recommendations, takeoff estimation, `summary` and `takeoff_estimate` families fully operational |
+| EPIC-10 | Tool Layer, Selection Engine | Construction-drawing tools (`annotate`), grid/bay summaries, markup-to-redline interpretation, batch repeated-condition plans, `markup_interpretation` and `design_assist` families operational |
+
+**System state after Phase 4:** All 9 task families operational (excluding `unsupported_operation` catch-all). Both user workflow classes (Design Operations, Construction Drawing) have dedicated tooling. Platform is feature-complete.
+
+### Phase 5: Production Readiness (EPICs 11-12)
+
+**Layers built:** Storage (durable), Observability (full), Eval Layer
+
+| Epic | Layers Affected | What Changes |
+|------|----------------|-------------|
+| EPIC-11 | Storage (NEW — GCS + Firestore), Observability | Migrate sessions from `/tmp/` to GCS, session metadata in Firestore, circuit breaker for LLM stage, scale smoke tests, full span coverage for all new layers |
+| EPIC-12 | Eval Layer (NEW) | Capability scorecard runner, domain fixture packs, confidence tracking, CI regression suite, live scorecard on push to main |
+
+**System state after Phase 5:** Production-grade platform with durable storage, comprehensive tracing, and quality governance. All 9 task families tested via golden trajectories and scorecard. Regression rate <5% on live API.
+
+### Layer Build Timeline
+
+```
+                  Phase 1    Phase 2    Review   Phase 3    Phase 4    Phase 5
+                 (01-03)    (04-06)    (AR-01)  (07-08)    (09-10)    (11-12)
+                 --------   --------   ------   --------   --------   --------
+Intent Router    [BUILD ]   [stable ]           [stable ]  [stable ]  [stable ]
+Selection Eng    [ENHANCE]  [ENHANCE]           [stable ]  [ENHANCE]  [stable ]
+Context Builder  [ENHANCE]  [EXTEND ]           [stable ]  [EXTEND ]  [stable ]
+Tool Layer       [       ]  [EXTEND ]           [EXTEND ]  [EXTEND ]  [stable ]
+Safety Layer     [       ]  [       ]           [ENHANCE]  [stable ]  [stable ]
+Response Fmt     [BUILD ]   [EXTEND ]           [EXTEND ]  [stable ]  [stable ]
+Eval Layer       [       ]  [       ]           [       ]  [       ]  [BUILD  ]
+Storage          [       ]  [       ]           [       ]  [       ]  [BUILD  ]
+Observability    [spans  ]  [spans  ]           [spans  ]  [spans  ]  [HARDEN ]
+```

--- a/000-docs/036-AT-SPEC-response-contracts-taxonomy.md
+++ b/000-docs/036-AT-SPEC-response-contracts-taxonomy.md
@@ -31,6 +31,7 @@ class TaskFamily(str, Enum):
     SUMMARY                  = "summary"                    # Drawing statistics/overview
     TAKEOFF_ESTIMATE         = "takeoff_estimate"           # Quantity/material estimation
     DESIGN_ASSIST            = "design_assist"              # Suggest improvements
+    UNSUPPORTED              = "unsupported_operation"      # Catch-all for unclassifiable prompts
 ```
 
 **Location:** `src/cad_dxf_agent/models/response_schema.py` (proposed)
@@ -124,6 +125,7 @@ Each task family produces a predictable set of response types.
 | `summary` | `answer_only` | — |
 | `takeoff_estimate` | `answer_only` | `needs_clarification` |
 | `design_assist` | `answer_only` or `plan_only` | `needs_clarification` |
+| `unsupported_operation` | `unsupported_operation` | — |
 
 **Invariants:**
 - `answer_only` responses MUST have zero operations
@@ -343,6 +345,20 @@ These rules should be enforced by tests (see 037-TQ-SPEC).
 | **Example prompt** | "Suggest improvements to this floor layout" |
 | **Status** | MISSING (0%) — no suggestion pipeline, domain rules, or improvement heuristics |
 
+### 10.10 Unsupported Operation (`unsupported_operation`)
+
+| Dimension | Detail |
+|-----------|--------|
+| **Intent signals** | Prompt does not match any known task family pattern; or explicitly out-of-scope request |
+| **Inputs** | Raw prompt text (drawing context may or may not be available) |
+| **Outputs** | `unsupported_operation` response with reason code and suggestion |
+| **Confidence model** | Always 1.0 — the system is certain the request is unsupported |
+| **Failure modes** | False positive — a legitimate prompt misclassified as unsupported (router confidence too low for all families). Mitigated by tuning router thresholds and adding `needs_clarification` as an intermediate step. |
+| **Deterministic tooling** | Not required — classification is the router's responsibility |
+| **Example prompt** | "Generate a 3D rendering of this floor plan" |
+| **Example response** | `unsupported_operation` with `data.reason = "unsupported_task"` and helpful suggestion |
+| **Status** | PARTIAL — `unsupported_operation` ResponseType exists, but no dedicated router fallback path yet |
+
 ---
 
 ## 11. Per-Response-Type Detail
@@ -500,6 +516,250 @@ Request cannot be fulfilled by the platform.
 
 **Reasons:** `protected_layer`, `unsupported_entity_type`, `unsupported_task`, `no_drawing_loaded`, `session_expired`.
 **Safety:** No operations executed. Clear explanation of why the request was blocked.
+
+---
+
+## 12. Required vs Optional Fields Matrix
+
+Each `PlatformResponse` field is classified per response type as **REQ** (required — must be present and non-empty), **OPT** (optional — may be present), or **N/A** (not applicable — should be absent or empty).
+
+| Field | `answer_only` | `plan_only` | `preview_edit` | `applied_edit` | `needs_clarification` | `unsupported_operation` |
+|-------|:---:|:---:|:---:|:---:|:---:|:---:|
+| `message` | REQ | REQ | REQ | REQ | REQ | REQ |
+| `data` | REQ | OPT | OPT | OPT | OPT | REQ |
+| `evidence` | REQ (qna, compare) / OPT (others) | OPT | OPT | OPT | OPT | N/A |
+| `operations` | N/A (must be empty) | REQ (>=1) | REQ (>=1) | REQ (>=1) | N/A (must be empty) | N/A (must be empty) |
+| `validation` | N/A | REQ | REQ | REQ (valid=true) | N/A | N/A |
+| `confidence` | REQ | REQ | REQ | REQ | REQ | REQ |
+| `renders` | N/A | N/A | REQ (preview=true) | REQ (edited=true) | N/A | N/A |
+| `warnings` | OPT | OPT (in validation) | OPT (in validation) | OPT (in validation) | OPT | OPT |
+
+**Notes:**
+- `message` is universally required — every response must be explainable in natural language.
+- `data` is required for `answer_only` (carries the answer payload) and `unsupported_operation` (carries reason code). Optional elsewhere for supplemental metadata.
+- `operations` being N/A means the field must be an empty list (`[]`), not absent.
+- `validation` is required for any response that includes operations, even if all checks pass.
+
+---
+
+## 13. Confidence Model
+
+### 13.1 Confidence Sources
+
+Confidence values in `PlatformResponse.confidence` originate from different sources depending on the pipeline stage.
+
+| Source | Description | Produces |
+|--------|-------------|----------|
+| **Router confidence** | How certain the intent classifier is about the selected `TaskFamily` | Float 0.0–1.0 |
+| **LLM confidence** | Self-reported certainty from the LLM provider (when available) | Float 0.0–1.0 |
+| **Validation confidence** | Deterministic — binary pass/fail from the validator | 1.0 (pass) or 0.0 (fail) |
+| **Matching confidence** | Per-entity confidence from the comparison/matching pipeline | Float 0.0–1.0 |
+
+### 13.2 Confidence by Response Type
+
+| ResponseType | Confidence Source | Calculation |
+|-------------|------------------|-------------|
+| `answer_only` | Router + LLM | `min(router_confidence, llm_confidence)` — both must agree |
+| `plan_only` | Router + LLM | `min(router_confidence, llm_confidence)` — entity resolution factors in |
+| `preview_edit` | Router + LLM | Same as `plan_only` |
+| `applied_edit` | Validation | Always 1.0 — validation passed, operations applied successfully |
+| `needs_clarification` | Router | Router confidence that triggered the clarification request |
+| `unsupported_operation` | Router or Validation | 1.0 — the system is certain the request is unsupported or blocked |
+
+### 13.3 Thresholds
+
+| Threshold | Value | Effect |
+|-----------|-------|--------|
+| **Clarification trigger** | Router confidence < 0.5 | Prompt is routed to `needs_clarification` instead of a task family |
+| **Low confidence warning** | confidence < 0.7 | Response includes `data.ambiguity_note` explaining uncertainty |
+| **High confidence** | confidence >= 0.9 | Response is presented without caveats |
+
+### 13.4 Per-Task-Family Acceptable Ranges
+
+| TaskFamily | Typical Range | Notes |
+|-----------|--------------|-------|
+| `qna` | 0.7–1.0 | High when entities found; drops for ambiguous references |
+| `markup_interpretation` | 0.5–0.9 | Depends on markup entity detection quality |
+| `repeated_condition_search` | 0.6–1.0 | Exact text matches = high; fuzzy/spatial = lower |
+| `compare` | 0.6–1.0 | Per-change confidence aggregated to overall |
+| `edit_plan` | 0.7–1.0 | High when entities resolved and ops valid |
+| `apply_edit` | 1.0 | Always 1.0 — validation is binary pass/fail |
+| `summary` | 0.9–1.0 | Deterministic aggregation, always high |
+| `takeoff_estimate` | 0.6–0.9 | Block counts = high; inferred quantities = lower |
+| `design_assist` | 0.4–0.8 | Advisory nature means lower baseline |
+| `unsupported_operation` | 1.0 | Always certain |
+
+### 13.5 Propagation Rules
+
+- **Router confidence** is computed deterministically by the intent classifier (heuristic or hybrid). It is NOT an LLM-generated value.
+- **LLM confidence** is extracted from the provider response when available (e.g., Gemini function-call confidence). If unavailable, defaults to 0.8.
+- **Final confidence** on the `PlatformResponse` is the minimum of all contributing sources — the weakest link determines overall confidence.
+- Confidence values MUST NOT be fabricated. If no meaningful confidence can be computed, the field should be omitted (`None`) rather than set to an arbitrary value.
+
+---
+
+## 14. Schema Versioning
+
+### 14.1 Version Field
+
+The `PlatformResponse` envelope includes a `schema_version` field to support forward-compatible evolution.
+
+```python
+class PlatformResponse(BaseModel):
+    schema_version: str = "1.0"  # Semantic version of the response schema
+    # ... all other fields as defined in section 5
+```
+
+### 14.2 Versioning Rules
+
+1. **Additive-only within a major version.** New optional fields may be added to `PlatformResponse` or `data` payloads without bumping the major version. Existing fields never change type or meaning within a major version.
+2. **Breaking changes require a major version bump.** Removing a field, changing a field's type, renaming a field, or altering enum semantics constitutes a breaking change and requires incrementing the major version (e.g., `1.x` → `2.0`).
+3. **Minor versions for additions.** Adding a new optional field bumps the minor version (e.g., `1.0` → `1.1`). Adding a new `TaskFamily` or `ResponseType` enum value bumps the minor version.
+4. **Clients must tolerate unknown fields.** Pydantic's `model_config = ConfigDict(extra="ignore")` ensures that newer responses with additional fields do not break older clients.
+5. **Version announced in response.** Every `PlatformResponse` includes `schema_version` so clients can detect and adapt to schema changes programmatically.
+
+### 14.3 Migration Path
+
+- v1.0: Initial schema as defined in this document
+- Future additions (new task families, new data fields) increment minor version
+- If the envelope structure itself changes (different discriminator pattern, nested envelopes), that triggers v2.0
+
+---
+
+## 15. Data Payload Schemas for Unimplemented Task Families
+
+These schemas define the target `data` shape for task families not yet implemented. They serve as contracts for future development — implementations MUST conform to these shapes.
+
+### 15.1 Markup Interpretation Data
+
+```python
+{
+    "markups": [
+        {
+            "markup_type": "revision_cloud",       # revision_cloud | arrow | callout | strikethrough
+            "entity_handles": ["4D1", "4D2"],      # Handles of entities forming the markup
+            "layer": "MARKUP",                      # Layer the markup resides on
+            "bounding_box": {"min": [10, 20], "max": [30, 40]},
+            "affected_entities": ["1A3", "2B7"],   # Entities the markup references/surrounds
+            "interpretation": "These walls should be moved 5 units north.",
+            "confidence": 0.75
+        }
+    ],
+    "total_markups": 3,
+    "unresolved_markups": 1,                       # Markups that could not be interpreted
+    "suggested_operations": []                      # Optional: derived edit ops if markup implies changes
+}
+```
+
+**Status:** MISSING — requires EPIC-03 (markup entity detection and interpretation pipeline).
+
+### 15.2 Repeated Condition Search Data
+
+```python
+{
+    "matches": [
+        {
+            "entity_handle": "3C1",
+            "layer": "NOTES",
+            "entity_type": "TEXT",
+            "text_content": "SEE DETAIL A",
+            "location": [45.0, 22.5],
+            "match_type": "exact_text",            # exact_text | fuzzy_text | block_name | spatial_pattern
+            "match_score": 1.0
+        }
+    ],
+    "total_matches": 7,
+    "search_pattern": "SEE DETAIL A",              # The pattern that was searched for
+    "search_scope": {                               # Filters applied during search
+        "layers": null,                             # null = all layers searched
+        "entity_types": ["TEXT", "MTEXT"],
+        "spatial_bounds": null                      # null = entire drawing
+    },
+    "match_methods_used": ["exact_text"]            # Which methods produced results
+}
+```
+
+**Status:** PARTIAL (5%) — literal text search only. Fuzzy, regex, and spatial pattern matching not yet implemented.
+
+### 15.3 Design Assist Data
+
+```python
+{
+    "suggestions": [
+        {
+            "category": "spacing",                 # spacing | alignment | accessibility | code_compliance | efficiency
+            "severity": "recommendation",          # recommendation | warning | critical
+            "description": "Door swing overlaps with adjacent wall segment.",
+            "affected_entities": ["2B7", "1A3"],
+            "suggested_action": "Move door 2B7 by (2, 0) to clear wall 1A3.",
+            "proposed_operations": [               # Optional: concrete ops if suggestion is actionable
+                {"op_type": "move_entity", "target_handle": "2B7", "params": {"dx": 2, "dy": 0}}
+            ],
+            "confidence": 0.6
+        }
+    ],
+    "total_suggestions": 3,
+    "domain": "architectural_floor_plan",          # Detected or user-specified domain context
+    "analysis_scope": "full_drawing"               # full_drawing | selected_region | selected_layer
+}
+```
+
+**Status:** MISSING (0%) — no suggestion pipeline, domain rules, or improvement heuristics.
+
+---
+
+## 16. Risk Model
+
+### 16.1 Risk Level Field
+
+Each `PlatformResponse` carries a `risk_level` field indicating the potential for irreversible or destructive changes.
+
+```python
+class RiskLevel(str, Enum):
+    """Classification of response risk to the user's drawing."""
+    NONE        = "none"          # Read-only, no modification possible
+    LOW         = "low"           # Proposed changes, not yet applied; easily reversible
+    DESTRUCTIVE = "destructive"   # Changes have been applied to a file on disk
+```
+
+```python
+class PlatformResponse(BaseModel):
+    risk_level: RiskLevel = RiskLevel.NONE
+    # ... all other fields as defined in section 5
+```
+
+### 16.2 Risk Classification by Response Type
+
+| ResponseType | Risk Level | Rationale |
+|-------------|-----------|-----------|
+| `answer_only` | `none` | Read-only — no drawing modification possible |
+| `plan_only` | `low` | Proposed operations are not applied; user can discard |
+| `preview_edit` | `low` | Same as `plan_only` — preview renders but does not persist changes |
+| `applied_edit` | `destructive` | Operations applied and written to a new file. Original is preserved (save-as) but the edit is committed. |
+| `needs_clarification` | `none` | No operations executed; informational only |
+| `unsupported_operation` | `none` | No operations executed; request was blocked |
+
+### 16.3 Risk Classification by Task Family
+
+| TaskFamily | Max Risk Level | Notes |
+|-----------|---------------|-------|
+| `qna` | `none` | Always read-only |
+| `markup_interpretation` | `low` | May propose derived edits, never auto-applies |
+| `repeated_condition_search` | `none` | Always read-only search |
+| `compare` | `none` | Read-only diff; revision ops are `plan_only` at most |
+| `edit_plan` | `low` | Proposes but does not apply |
+| `apply_edit` | `destructive` | Applies edits to file (save-as workflow preserves original) |
+| `summary` | `none` | Always read-only |
+| `takeoff_estimate` | `none` | Always read-only |
+| `design_assist` | `low` | May propose edits, never auto-applies |
+| `unsupported_operation` | `none` | No processing occurs |
+
+### 16.4 Safety Invariants
+
+1. **No silent writes.** A response with `risk_level = "destructive"` MUST have been preceded by a `plan_only` or `preview_edit` response that the user explicitly confirmed.
+2. **Original preserved.** Even `destructive` responses use save-as workflow — the original DXF file is never overwritten.
+3. **Protected layers block destructive ops.** Any operation targeting a protected layer (TITLE, TITLEBLOCK, SEAL, REVISION) is rejected before reaching `destructive` risk level.
+4. **Risk level is deterministic.** It is set by the response formatter based on `response_type`, never by the LLM.
 
 ---
 

--- a/000-docs/037-TQ-SPEC-evaluation-plan.md
+++ b/000-docs/037-TQ-SPEC-evaluation-plan.md
@@ -285,6 +285,198 @@ schemas and pipelines are implemented.
 
 ---
 
+## 9. Evaluation by Workflow Class
+
+Each user persona maps to a set of critical task families. Minimum pass rates
+are defined per workflow class to ensure the platform meets the needs of its
+primary audiences.
+
+### Design Operations User
+
+Persona focused on editing, planning, and design assistance workflows.
+
+| Task Family | Description | Minimum Pass Rate |
+|-------------|-------------|-------------------|
+| edit_plan | Move, delete, edit text, add block planning | >= 90% |
+| apply_edit | Confirm and apply a previously planned changeset | >= 90% |
+| design_assist | Suggest improvements, layout optimizations | >= 90% |
+
+**Aggregate requirement:** All three task families must individually meet >= 90%
+pass rate before the Design Operations workflow class is considered ready.
+
+### Construction Drawing User
+
+Persona focused on revision comparison, markup reading, and quantity takeoff.
+
+| Task Family | Description | Minimum Pass Rate |
+|-------------|-------------|-------------------|
+| compare | Diff two drawing revisions, identify changes | >= 85% |
+| markup_interpretation | Detect revision clouds, arrows, markup annotations | >= 85% |
+| takeoff_estimate | Count blocks, measure linear elements | >= 85% |
+
+**Aggregate requirement:** All three task families must individually meet >= 85%
+pass rate before the Construction Drawing workflow class is considered ready.
+
+### General Drawing Review User
+
+Persona focused on querying, summarizing, and searching drawing content.
+
+| Task Family | Description | Minimum Pass Rate |
+|-------------|-------------|-------------------|
+| qna | Layer queries, entity lookups, metadata questions | >= 80% |
+| summary | Drawing summaries, layer/type breakdowns | >= 80% |
+| repeated_condition_search | Find repeated text patterns, block patterns | >= 80% |
+
+**Aggregate requirement:** All three task families must individually meet >= 80%
+pass rate before the General Drawing Review workflow class is considered ready.
+
+---
+
+## 10. Quality Gates (Go/No-Go)
+
+Concrete aggregate thresholds that must be met before merging or releasing.
+Failures at any tier block progression until resolved.
+
+### Per-Tier Gate Criteria
+
+| Tier | Gate | Threshold | On Failure |
+|------|------|-----------|------------|
+| 2 — Golden Trajectory | All trajectories pass | 100% pass rate (deterministic with mock) | Block merge; fix immediately |
+| 3 — Mock Scorecard | All scorecard entries pass | 100% pass rate (deterministic with mock) | Block merge; file issue if systemic |
+| 4 — Live Scorecard | Aggregate pass rate | >= 85% overall, no task family below 70% | Block release; investigate regressions |
+| 5 — End-to-End Workflow | All workflow scenarios | Complete without blockers | Block release; file issue per failing scenario |
+
+### Failure Response Protocol
+
+1. **Tier 2/3 failure (deterministic):** These use mock providers and must be
+   100% reproducible. A failure indicates a code regression, not LLM variance.
+   Block the PR merge. The author must fix before re-requesting review.
+
+2. **Tier 4 failure (live LLM):** LLM variance is expected, but sustained
+   failures indicate prompt or schema regressions. If aggregate drops below 85%
+   or any task family drops below 70%:
+   - Block the release.
+   - Re-run the scorecard 3 times to rule out transient variance.
+   - If failure persists, file an investigation issue with the failing entries
+     and tag the responsible epic owner.
+
+3. **Tier 5 failure (workflow):** A workflow blocker means a user-facing flow is
+   broken end-to-end. Block the release. File an issue per failing scenario
+   with severity `critical`.
+
+### Per-Phase Exit Criteria
+
+| Phase | Exit Gate | "Good Enough to Continue" Criteria |
+|-------|-----------|-----------------------------------|
+| Phase 1 | Contracts + routing foundation | Tier 2: 100%. Tier 3: 100% for `edit_plan` and `qna` families only. No live scorecard required yet. |
+| Phase 2 | Selection + region Q&A + compare | Tier 2: 100%. Tier 3: 100% for all implemented families. Tier 4: >= 80% aggregate (relaxed from 85% — early LLM integration). |
+| Phase 3 | Structured edit + preview/apply | Tier 2: 100%. Tier 3: 100%. Tier 4: >= 85% aggregate, no family below 70%. Design Operations class meets >= 90%. |
+| Phase 4 | Workflow packs (design + construction) | All tiers at full thresholds. All three workflow classes meet their per-class minimums. Tier 5: all scenarios pass. |
+| Phase 5 | Session durability + eval governance | All tiers at full thresholds. Regression detection operational. Scorecard trend data covers >= 30 days. |
+
+---
+
+## 11. Scoring Dimensions
+
+Binary pass/fail is insufficient for tracking quality trends. Each scorecard
+entry is evaluated across multiple dimensions on a 0–1 numeric scale.
+
+### Dimension Definitions
+
+| Dimension | Weight | Scale | Description |
+|-----------|--------|-------|-------------|
+| Intent classification accuracy | 0.20 | 0–1 | Did the router assign the correct `TaskFamily`? 1.0 = exact match, 0.0 = wrong family. |
+| Entity targeting precision | 0.20 | 0–1 | Did operations target the correct entities? 1.0 = all targets correct, 0.0 = all wrong. For non-edit responses, score is 1.0 (not applicable). |
+| Operation correctness | 0.20 | 0–1 | Are the operations valid and semantically correct? 1.0 = all ops correct, 0.0 = all ops wrong. For answer-only responses, score is 1.0. |
+| Response quality | 0.15 | 0–1 | For Q&A: factual correctness of the answer. For edits: completeness of the changeset. 1.0 = fully correct/complete, 0.0 = entirely wrong/missing. |
+| Safety | 0.15 | 0–1 | No operations on protected layers, no destructive unintended side effects. 1.0 = fully safe, 0.0 = violated a protected layer or caused unintended changes. Any safety score below 1.0 forces the entry to fail regardless of composite. |
+| Latency | 0.10 | 0–1 | Response time relative to budget. 1.0 = under 2s, linear decay to 0.0 at 30s. Mock-provider entries always score 1.0. |
+
+### Composite Score
+
+```
+composite = sum(dimension_score * weight for each dimension)
+```
+
+- **Pass threshold:** composite >= 0.70
+- **Safety override:** if `safety < 1.0`, the entry fails regardless of composite
+- **Per-entry output:** all six dimension scores plus the composite are recorded
+
+### Scorecard Result Schema (Extended)
+
+```python
+class ScorecardResult(BaseModel):
+    entry: ScorecardEntry
+    actual_response_type: ResponseType | None
+    actual_op_count: int
+    actual_evidence_count: int
+    passed: bool
+    failure_reason: str | None
+    latency_ms: int
+    # Scoring dimensions (0.0–1.0)
+    score_intent: float
+    score_targeting: float
+    score_operations: float
+    score_quality: float
+    score_safety: float
+    score_latency: float
+    score_composite: float
+```
+
+---
+
+## 12. Regression Detection
+
+### Result Persistence
+
+Scorecard results are persisted as JSON files in `tests/eval/results/` with
+timestamped filenames:
+
+```
+tests/eval/results/
+  scorecard-2026-03-05T14:30:00-mock.json
+  scorecard-2026-03-05T14:35:00-live.json
+```
+
+Each file contains the full list of `ScorecardResult` entries plus run metadata
+(provider, git SHA, timestamp, aggregate scores). These files are committed to
+the repository to maintain a historical record.
+
+### Baseline Establishment
+
+- The first full scorecard run after a phase exit becomes the **baseline** for
+  that phase.
+- Baselines are recorded in `tests/eval/baselines/` as a JSON file per phase:
+  `baseline-phase-1.json`, `baseline-phase-2.json`, etc.
+- Each baseline contains per-task-family aggregate scores and per-dimension
+  averages.
+
+### Regression Definition
+
+A **regression** is detected when any of the following conditions are met
+relative to the most recent baseline:
+
+| Condition | Threshold | Severity |
+|-----------|-----------|----------|
+| Task family aggregate drop | > 5 percentage points from baseline | `warning` if 5–10 points, `critical` if > 10 points |
+| Individual dimension drop (any family) | > 10 percentage points from baseline | `warning` |
+| Safety score drop (any entry) | Any decrease below 1.0 | `critical` (always) |
+| Overall composite drop | > 5 percentage points from baseline | `warning` |
+
+### Alerting
+
+- **CI integration:** The scorecard runner compares results against the active
+  baseline and emits warnings/failures in the test output.
+- **PR blocking:** A `critical` regression blocks the PR merge (same as a
+  Tier 4 gate failure).
+- **Warning behavior:** A `warning` regression does not block merge but is
+  surfaced in the PR check summary. Two consecutive `warning` regressions on
+  the same dimension auto-escalate to `critical`.
+- **Trend tracking:** A summary of per-family scores over the last 10 runs is
+  printed at the end of each scorecard execution to surface gradual drift.
+
+---
+
 ## Related Documents
 
 - 034-AT-AUDT — Capability audit (current test inventory)

--- a/000-docs/038-PM-PLAN-drawing-intelligence-roadmap.md
+++ b/000-docs/038-PM-PLAN-drawing-intelligence-roadmap.md
@@ -12,54 +12,54 @@
 
 Lock contracts, build routing and response infrastructure. No new user-visible features.
 
-| Epic | Title | Deliverables | Gate |
-|------|-------|-------------|------|
-| **EPIC-01** | Capability Audit + Architecture Baseline | 6 docs (034-039), capability matrix | Docs reviewed, `make check` green |
-| **EPIC-02** | Core Contracts + Routing Foundation | `response_schema.py`, `intent_router.py`, TaskFamily/ResponseType enums, unit tests | All contract invariant tests pass |
-| **EPIC-03** | Selection + Markup Interpretation Foundation | Region model, markup overlay ingestion, entity association, debug tooling | New query tests pass, existing tests unbroken |
+| Epic | Title | Size | Deliverables | Gate |
+|------|-------|------|-------------|------|
+| **EPIC-01** | Capability Audit + Architecture Baseline | S | 6 docs (034-039), capability matrix | Docs reviewed, `make check` green |
+| **EPIC-02** | Core Contracts + Routing Foundation | M | `response_schema.py`, `intent_router.py`, TaskFamily/ResponseType enums, unit tests | All contract invariant tests pass |
+| **EPIC-03** | Selection + Markup Interpretation Foundation | L | Region model, markup overlay ingestion, entity association, debug tooling | New query tests pass, existing tests unbroken |
 
 ### Phase 2: Core Intelligence (EPICs 04-06)
 
 First new task families: Q&A, repeated-condition detection, compare hardening.
 
-| Epic | Title | Deliverables | Gate |
-|------|-------|-------------|------|
-| **EPIC-04** | Region Q&A Vertical Slice | Region context builder, grounded Q&A pipeline, UI rendering, golden tests | 5+ Q&A golden trajectories pass |
-| **EPIC-05** | Repeated-Condition Detection | Similarity scoring, candidate search, preview/approval workflow, realistic fixtures | Repeated-condition scorecard entries pass |
-| **EPIC-06** | Compare + Diff Service Hardening | Typed compare schema, alignment diagnostics, changelog, export bundle, regression fixtures | Compare golden trajectories pass |
+| Epic | Title | Size | Deliverables | Gate |
+|------|-------|------|-------------|------|
+| **EPIC-04** | Region Q&A Vertical Slice | L | Region context builder, grounded Q&A pipeline, UI rendering, golden tests | 5+ Q&A golden trajectories pass |
+| **EPIC-05** | Repeated-Condition Detection | M | Similarity scoring, candidate search, preview/approval workflow, realistic fixtures | Repeated-condition scorecard entries pass |
+| **EPIC-06** | Compare + Diff Service Hardening | M | Typed compare schema, alignment diagnostics, changelog, export bundle, regression fixtures | Compare golden trajectories pass |
 
 ### Mandatory Architecture Review (after Phase 2)
 
-| Review | Title | Deliverables | Gate |
-|--------|-------|-------------|------|
-| **ARCH-REVIEW-01** | Post-EPIC-06 Architecture Review | Quality assessment, scalability review, LLM/tool boundary review, published decision | Written review with keep/change/remove recommendations |
+| Review | Title | Size | Deliverables | Gate |
+|--------|-------|------|-------------|------|
+| **ARCH-REVIEW-01** | Post-EPIC-06 Architecture Review | S | Quality assessment, scalability review, LLM/tool boundary review, published decision | Written review with keep/change/remove recommendations |
 
 ### Phase 3: Structured Editing (EPICs 07-08)
 
 Safe edit planning and apply workflows.
 
-| Epic | Title | Deliverables | Gate |
-|------|-------|-------------|------|
-| **EPIC-07** | Structured Edit Planning | Edit plan schema, plan builder, constraint validation, golden tests | Safe/unsafe edit plan cases covered |
-| **EPIC-08** | Preview + Apply Workflow | Preview pipeline, apply pipeline, audit trail, UI approval/export | Applied edits produce audit metadata |
+| Epic | Title | Size | Deliverables | Gate |
+|------|-------|------|-------------|------|
+| **EPIC-07** | Structured Edit Planning | L | Edit plan schema, plan builder, constraint validation, golden tests | Safe/unsafe edit plan cases covered |
+| **EPIC-08** | Preview + Apply Workflow | M | Preview pipeline, apply pipeline, audit trail, UI approval/export | Applied edits produce audit metadata |
 
 ### Phase 4: Workflow Packs (EPICs 09-10)
 
-Domain-specific features for both user workflow classes.
+Domain-specific features for three user workflow classes: Design Operations, Construction Drawing, and General Review. EPIC-09 and EPIC-10 provide dedicated workflow packs for Design Ops and Construction respectively. General Review users are served by capabilities already delivered in earlier phases — Q&A (EPIC-04), compare/diff (EPIC-06), and summary capabilities — so no dedicated workflow pack is needed for that class.
 
-| Epic | Title | Deliverables | Gate |
-|------|-------|-------------|------|
-| **EPIC-09** | Design Operations Workflow Pack | Layout recommendations, revision summaries, takeoff candidates, scope outputs | Design-ops scorecard entries pass |
-| **EPIC-10** | Construction Drawing Workflow Pack | Grid/bay summaries, markup-to-redline, batch repeated-condition plans, field summaries | Construction scorecard entries pass |
+| Epic | Title | Size | Deliverables | Gate |
+|------|-------|------|-------------|------|
+| **EPIC-09** | Design Operations Workflow Pack | L | Layout recommendations, revision summaries, takeoff candidates, scope outputs | Design-ops scorecard entries pass |
+| **EPIC-10** | Construction Drawing Workflow Pack | L | Grid/bay summaries, markup-to-redline, batch repeated-condition plans, field summaries | Construction scorecard entries pass |
 
 ### Phase 5: Production Readiness (EPICs 11-12)
 
 Scale hardening and evaluation governance.
 
-| Epic | Title | Deliverables | Gate |
-|------|-------|-------------|------|
-| **EPIC-11** | Session Durability + Scale Readiness | State audit, durable metadata model, tracing/metrics, scale smoke tests | Clear path beyond in-process sessions |
-| **EPIC-12** | Evaluation Harness + Quality Governance | Capability scorecard, domain fixture packs, confidence tracking, CI regression | Full scorecard green, live regression <5% failure |
+| Epic | Title | Size | Deliverables | Gate |
+|------|-------|------|-------------|------|
+| **EPIC-11** | Session Durability + Scale Readiness | XL | State audit, durable metadata model, tracing/metrics, scale smoke tests | Clear path beyond in-process sessions |
+| **EPIC-12** | Evaluation Harness + Quality Governance | M | Capability scorecard, domain fixture packs, confidence tracking, CI regression | Full scorecard green, live regression <5% failure |
 
 ---
 
@@ -104,7 +104,8 @@ EPIC-02 (Contracts + Router)
 **Parallel tracks after EPIC-02:**
 - Track A: Selection → Q&A → Repeated-Condition (read-only features)
 - Track B: Compare Hardening (existing pipeline upgrade)
-- Both converge at ARCH-REVIEW-01 before edit planning begins
+- Track C: General Review — served by Q&A (EPIC-04) + Compare (EPIC-06) + summaries; no dedicated workflow pack required
+- All three tracks converge at ARCH-REVIEW-01 before edit planning begins
 
 ---
 
@@ -125,16 +126,16 @@ Each epic must satisfy its gate before the next dependent epic begins.
 
 ## 4. Risk Register
 
-| Risk | Impact | Likelihood | Mitigation |
-|------|--------|-----------|------------|
-| **Response contract churn** | High — breaks frontend/tests | Medium | Mark all 036 schemas as "proposed" until EPIC-02 stabilizes |
-| **Intent router accuracy** | High — wrong pipeline = bad results | Medium | Conservative confidence threshold (0.9), fallback to edit_plan |
-| **Gemini API changes** | Medium — breaks live provider | Low | Provider ABC insulates; mock tests always run |
-| **Scope creep per epic** | Medium — delays cascade | High | Each epic has explicit deliverables list; no unplanned features |
-| **Markup entity detection** | High — no training data exists | High | EPIC-09 deferred to Phase 3; collect real markup samples first |
-| **V2 entity types** | Medium — 9 types read-only | Low | V2 types loaded but not edited; expand incrementally per epic |
-| **Eval cost** | Low — API calls cost money | Low | Mock scorecard free; live scorecard only on push to main |
-| **Large drawing perf** | Medium — 500 entity cap | Medium | Context builder token budgeting in EPIC-03 |
+| Risk | Impact | Likelihood | Phase(s) | Mitigation |
+|------|--------|-----------|----------|------------|
+| **Response contract churn** | High — breaks frontend/tests | Medium | 1 | Mark all 036 schemas as "proposed" until EPIC-02 stabilizes |
+| **Intent router accuracy** | High — wrong pipeline = bad results | Medium | 1-2 | Conservative confidence threshold (0.9), fallback to edit_plan |
+| **Gemini API changes** | Medium — breaks live provider | Low | All | Provider ABC insulates; mock tests always run |
+| **Scope creep per epic** | Medium — delays cascade | High | All | Each epic has explicit deliverables list; no unplanned features |
+| **Markup entity detection** | High — no training data exists | High | 1, 4 | EPIC-03 builds foundation; EPIC-09 deferred to Phase 4; collect real markup samples first |
+| **V2 entity types** | Medium — 9 types read-only | Low | 2-3 | V2 types loaded but not edited; expand incrementally per epic |
+| **Eval cost** | Low — API calls cost money | Low | 2-5 | Mock scorecard free; live scorecard only on push to main |
+| **Large drawing perf** | Medium — 500 entity cap | Medium | 1-2 | Context builder token budgeting in EPIC-03 |
 
 ---
 
@@ -153,6 +154,82 @@ When all 12 epics are complete:
 | Coverage | >= 70% |
 | API versions | v1 (stable) + v2 (PlatformResponse) |
 | Response types | 6 (all with typed envelopes) |
+
+---
+
+## 6. Per-Phase Success Criteria
+
+### Phase 1: Foundation
+
+1. Intent router classifies all 9 task families with >= 90% accuracy on mock inputs
+2. `PlatformResponse` envelope adopted as the sole response contract for new capabilities
+3. 10+ golden trajectories passing (baseline set covering routing and selection)
+4. Region model can associate entities to a user-selected area in test fixtures
+5. All Phase 1 gate criteria met; `make check` green, coverage >= 65%
+
+### Phase 2: Core Intelligence
+
+1. 3 new task families operational: Q&A, repeated-condition detection, compare
+2. 15+ golden trajectories passing across all implemented families
+3. Capability scorecard pass rate >= 50% on mock provider
+4. No regressions in existing edit pipeline tests
+5. ARCH-REVIEW-01 completed with published keep/change/remove recommendations
+
+### Phase 3: Structured Editing
+
+1. Edit workflows pass >= 85% of golden trajectories on live Gemini
+2. End-to-end scenarios complete: prompt -> plan -> validate -> preview -> apply -> save-as
+3. Unsafe edit plans reliably rejected by constraint validation
+4. Audit trail metadata attached to every applied edit
+5. 20+ golden trajectories passing
+
+### Phase 4: Workflow Packs
+
+1. Design Operations scorecard entries pass per-class quality bars
+2. Construction Drawing scorecard entries pass per-class quality bars
+3. General Review users covered by Q&A + compare + summary (no gaps)
+4. 25+ golden trajectories passing across all task families
+5. Domain-specific fixture packs created for both workflow packs
+
+### Phase 5: Production Readiness
+
+1. Session durability implemented — state survives process restart
+2. Eval harness runs automatically in CI on every push to main
+3. Full capability scorecard green at mock tier, >= 95% at live tier
+4. Tracing and metrics operational in production (Cloud Trace)
+5. Scale smoke tests pass with drawings containing 500+ entities
+
+---
+
+## 7. Release Strategy
+
+### Shippable Milestones
+
+| Milestone | Phase | Description |
+|-----------|-------|-------------|
+| **Internal Alpha** | Phase 1 | Contracts and routing validated internally. Not user-visible. |
+| **Beta (Read-Only Intelligence)** | Phase 2 | Q&A, compare, and repeated-condition detection available to users. No editing capabilities exposed. Safe to deploy — all features are read-only. |
+| **GA (Safe Editing)** | Phase 3 | Structured edit planning and preview/apply workflows enabled. Full pipeline operational with audit trail. First release where users can modify drawings. |
+| **Domain Packs** | Phase 4 | Design Ops and Construction workflow packs shipped incrementally. Each pack is independently deployable once its scorecard entries pass. |
+| **Production Hardened** | Phase 5 | Session durability, automated eval governance, and scale readiness. Platform considered production-grade. |
+
+### Hold Conditions
+
+The following conditions would cause a release hold:
+
+- **ARCH-REVIEW-01 finds fundamental issues** — If the architecture review identifies structural problems (e.g., LLM/tool boundary violations, unscalable patterns), Phase 3 work pauses until remediation is complete.
+- **Quality gate failures** — Any phase whose scorecard pass rate drops below its target blocks progression to the next phase.
+- **Edit safety regression** — If applied edits corrupt DXF output or violate protected-layer rules, editing features are disabled until root cause is fixed.
+- **Live API pass rate below 85%** — Indicates prompt/schema drift; requires investigation before GA release.
+
+### Incremental vs Full Launch
+
+Releases are incremental, not big-bang:
+
+- **Phase 2 (Beta)** is the first external release point. Read-only intelligence features (Q&A, compare, repeated-condition) can ship independently as each epic completes.
+- **Phase 3 (GA)** gates on all edit safety tests passing. EPIC-07 (planning) and EPIC-08 (preview/apply) ship together since planning without apply has no user value.
+- **Phase 4** workflow packs are independently deployable — EPIC-09 (Design Ops) and EPIC-10 (Construction) can ship on separate timelines based on which domain has more user demand.
+- **Phase 5** is operational hardening. The platform is functional after Phase 4; Phase 5 makes it durable and governable at scale.
 
 ---
 

--- a/000-docs/039-AT-ADEC-intent-router-design.md
+++ b/000-docs/039-AT-ADEC-intent-router-design.md
@@ -80,6 +80,24 @@ Rules operate on lowercased, whitespace-normalized prompt text.
 
 Rules with confidence < 0.9 fall through to LLM classification for confirmation.
 
+### Heuristic Priority Order
+
+When a prompt matches multiple heuristic rules, the highest-priority (lowest number)
+family wins. Rules are evaluated in this explicit order:
+
+1. `compare` — most specific; requires two-file context signals
+2. `markup_interpretation` — graphical annotation keywords are unambiguous
+3. `edit_plan` — move/delete/add/edit-text verbs with entity references
+4. `takeoff_estimate` — quantity/cost language distinct from Q&A
+5. `repeated_condition` — pattern/recurrence keywords
+6. `design_assist` — suggest/optimize/recommend
+7. `summary` — overview/statistics language
+8. `qna` — broadest read-only bucket; matches last
+9. `needs_clarification` — nothing matched above threshold
+
+If two rules from different families both exceed 0.9 confidence, the higher-priority
+family is selected and the secondary match is logged as a diagnostic attribute.
+
 ## Task Family Boundaries
 
 | Boundary | Rule |
@@ -114,9 +132,170 @@ class IntentRouter:
         if self.llm_provider:
             return self._llm_classify(prompt, session)
 
-        # Fallback: default to edit_plan (backward compatible)
-        return IntentResult(task_family=TaskFamily.EDIT_PLAN, confidence=0.5, source="default")
+        # Fallback: low confidence → ask for clarification (never default to a write-capable pipeline)
+        return IntentResult(task_family=TaskFamily.NEEDS_CLARIFICATION, confidence=0.0, source="default")
 ```
+
+## Edge Cases
+
+| Scenario | Strategy |
+|----------|----------|
+| **Multi-intent prompt** ("count all doors and move them left") | Classify by primary/dominant intent (the action verb `move` dominates over `count`). The secondary intent is noted in `IntentResult.params["secondary_intent"]` for downstream use. |
+| **Ambiguous prompt matching multiple families equally** | If the confidence spread between the top two heuristic matches is < 0.1, skip heuristic result and route to LLM classification. If LLM also returns a spread < 0.1, route to `needs_clarification`. |
+| **Adversarial or nonsense input** | Heuristic stage produces no match. LLM fallback classifies as `unsupported_operation` or `needs_clarification` depending on whether it detects malformed intent or complete gibberish. |
+| **Empty prompt** (whitespace-only or zero-length) | Immediate `needs_clarification` return from the heuristic stage — no LLM call needed. |
+| **Non-English prompt** | Heuristic rules (English keyword patterns) will not match; prompt falls through to LLM classification, which handles multilingual input natively. |
+| **Contradictory signals** (edit verbs + question structure, e.g., "should I move this wall?") | Heuristic stage defers (low confidence due to mixed signals). LLM resolves by interpreting pragmatic intent — in this example, `qna` (the user is asking, not commanding). |
+
+## LLM Classification Specification
+
+When the heuristic stage produces confidence < 0.9, the router invokes the LLM
+classification stage.
+
+### System Prompt Skeleton
+
+```
+You are a task classifier for a CAD drawing assistant.
+
+Classify the following user prompt into exactly one of these task families:
+  edit_plan, compare, qna, summary, takeoff_estimate,
+  markup_interpretation, repeated_condition, design_assist,
+  unsupported_operation, needs_clarification
+
+Respond with JSON only. No explanation outside the JSON object.
+```
+
+### Expected JSON Response Schema
+
+```json
+{
+  "task_family": "edit_plan",
+  "confidence": 0.92,
+  "reasoning": "Prompt contains 'move' verb targeting a named entity with explicit coordinates."
+}
+```
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `task_family` | string | Must be one of the enumerated family names |
+| `confidence` | float | 0.0–1.0 |
+| `reasoning` | string | One-sentence justification (logged, not shown to user) |
+
+### Mapping to IntentResult
+
+The LLM JSON response maps directly to `IntentResult`:
+
+- `task_family` → `IntentResult.task_family` (validated against `TaskFamily` enum)
+- `confidence` → `IntentResult.confidence`
+- `reasoning` → stored in `IntentResult.params["llm_reasoning"]`
+- `source` → set to `"llm"`
+
+If the LLM returns an unrecognized `task_family` value or malformed JSON, the router
+treats it as a classification failure and returns `needs_clarification`.
+
+### Timeout and Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| LLM response within budget (< 2s) | Parse and return classification |
+| LLM timeout (> 2s) | Return `needs_clarification` with `source="default"` |
+| LLM returns malformed JSON | Log error, return `needs_clarification` |
+| LLM provider unavailable | Heuristic result used regardless of confidence; if no heuristic match, return `needs_clarification` |
+
+## Performance Budget
+
+| Stage | Target | Rationale |
+|-------|--------|-----------|
+| Heuristic classification | p99 < 5ms | Regex/keyword matching on short strings; no I/O |
+| LLM classification | p95 < 500ms | Single short-prompt LLM call; timeout at 2s |
+| Overall router (end-to-end) | p95 < 50ms | ~80% of prompts resolve at heuristic stage; LLM invoked for ~20% |
+
+The overall p95 target reflects the weighted mix: 80% of requests at <5ms and 20% at
+<500ms yields a blended p95 well under 50ms.
+
+## Observability
+
+The router emits OpenTelemetry spans for each classification stage.
+
+| Span Name | When | Key Attributes |
+|-----------|------|----------------|
+| `cad.router.classify` | Wraps entire `classify()` call | `router.task_family`, `router.confidence`, `router.source`, `router.latency_ms` |
+| `cad.router.heuristic` | Heuristic stage execution | `router.source="heuristic"`, `router.confidence`, `router.task_family`, `router.latency_ms` |
+| `cad.router.llm_fallback` | LLM stage (only when invoked) | `router.source="llm"`, `router.confidence`, `router.task_family`, `router.latency_ms` |
+
+Attributes follow the existing `cad.*` namespace convention (see `otel.py`). No prompt
+text is recorded in span attributes to avoid PII/data leakage.
+
+## Testability
+
+### Unit Tests — Heuristic Rules
+
+Each heuristic rule is tested in isolation: pattern-in, family-out. Tests cover exact
+keyword matches, partial matches, and near-miss patterns that should not match.
+
+### Mock-Based Tests — LLM Stage
+
+The LLM classification stage is tested with a `MockPlannerProvider` that returns
+predetermined JSON responses, verifying correct parsing, enum mapping, and error handling
+(malformed JSON, timeout simulation, unrecognized family names).
+
+### Integration Tests — Two-Stage Flow
+
+End-to-end tests exercise the full `classify()` method with prompts that:
+- Resolve at heuristic stage (verify LLM is never called)
+- Fall through to LLM stage (verify heuristic confidence < 0.9 triggers LLM)
+- Hit both stages and still return `needs_clarification`
+
+### Golden-File Test Suite
+
+A suite of ~50 prompts with expected classifications lives in
+`tests/fixtures/router_golden.json`. Each entry specifies:
+
+```json
+{
+  "prompt": "move the north wall 2 feet left",
+  "expected_family": "edit_plan",
+  "expected_source": "heuristic",
+  "min_confidence": 0.9
+}
+```
+
+CI runs all golden-file entries on every push. New prompts from production logs are
+periodically added to this file to prevent regressions.
+
+## Versioning & Evolution
+
+### Adding a New Task Family
+
+1. Add the family to the `TaskFamily` enum in `ops_schema.py`
+2. Add heuristic rules (keyword patterns + confidence) to the rule list
+3. Update the LLM classification system prompt to include the new family
+4. Add entries to `tests/fixtures/router_golden.json`
+5. Document the family in 036-AT-SPEC (response contracts)
+
+### Deprecating a Heuristic Rule
+
+Rules are never silently removed. To deprecate:
+1. Set the rule's confidence to 0.0 (effectively disabling it)
+2. Add a `deprecated` flag to the rule metadata
+3. Log a warning when a deprecated rule would have matched
+4. Remove after two release cycles with no matches in production logs
+
+### Feedback Loop from Production
+
+Production prompt logs (with classification results) feed back into rule improvement:
+- Prompts where heuristic and LLM disagree are flagged for review
+- Prompts that reach `needs_clarification` are candidates for new rules
+- Classification accuracy is tracked as a monthly metric
+
+### Path to ML-Only Classification
+
+As production prompt logs accumulate (target: 10k+ classified prompts), the hybrid
+router can transition to an ML-only classifier:
+1. Train a lightweight classifier (e.g., fine-tuned embedding model) on logged prompts
+2. Run in shadow mode alongside hybrid router, comparing accuracy
+3. Once ML accuracy exceeds hybrid accuracy on the golden-file suite, promote to primary
+4. Retain LLM fallback for low-confidence ML predictions (hybrid-ML instead of hybrid-heuristic)
 
 ## Consequences
 

--- a/000-docs/040-AT-AUDT-scale-readiness.md
+++ b/000-docs/040-AT-AUDT-scale-readiness.md
@@ -69,7 +69,160 @@ request thread.
 
 ---
 
-## 3. Durable State Migration Path
+## 3. What Breaks First
+
+Explicit failure cascade as concurrent load increases:
+
+| Load Level | What Breaks | Why |
+|------------|------------|-----|
+| **5 concurrent users** | matplotlib rendering contention | matplotlib is not thread-safe; concurrent renders corrupt state or segfault. Memory pressure on 1Gi instance with multiple DXF loads + renders in flight. |
+| **10 concurrent users** | Session dict lock contention, `/tmp/` fills | In-memory session dict has no locking; concurrent writes cause race conditions. Uploaded DXF files accumulate in `/tmp/` with no cleanup under load. |
+| **50+ concurrent users** | Gemini API rate limits, stateless autoscaling | Vertex AI quota exhausted. Cloud Run autoscaling spawns new instances but all session state is lost — users on recycled instances get 404s. |
+| **Large files (>50MB DXF)** | OOM kill on 1Gi instance | `ezdxf` loads the full document into memory; combined with semantic model construction and matplotlib rendering, a single large file exceeds the memory limit. |
+| **Malicious upload** | Instance crash, no recovery | No `MAX_UPLOAD_SIZE` validation exists on the upload endpoint. A single oversized upload can OOM the instance and kill all active sessions. |
+
+### Upload Size Limit (Missing)
+
+The `/api/upload` endpoint in `web/backend/main.py` accepts files without any size
+validation. There is no `MAX_UPLOAD_SIZE` setting, no `Content-Length` check, and
+no streaming size guard. A single multi-hundred-megabyte upload will be buffered
+entirely into memory before any processing begins, likely triggering an OOM kill.
+
+**Recommendation:** Add a `MAX_UPLOAD_SIZE` setting (default 25MB), enforce via
+`Content-Length` header check and streaming byte-count guard. Reject oversized
+uploads with 413 before buffering.
+
+---
+
+## 4. Cost Analysis
+
+Rough monthly cost estimates by scale tier (USD, as of 2026-03):
+
+### Per-Request Cost Breakdown
+
+- **Gemini API:** ~2,000 input tokens + ~500 output tokens per planner call.
+  At Gemini 1.5 Pro pricing (~$1.25/1M input, ~$5.00/1M output): ~$0.005/request.
+- **Cloud Run:** ~0.5 vCPU-seconds per request (CPU-on-request billing).
+- **GCS:** ~$0.02/GB/month storage, $0.004/10K reads.
+- **Firestore:** $0.06/100K reads, $0.18/100K writes.
+
+### Monthly Projections
+
+| Resource | 10 DAU | 100 DAU | 1,000 DAU |
+|----------|--------|---------|-----------|
+| **Cloud Run** (CPU-on-request) | ~$2 | ~$15 | ~$120 |
+| **Cloud Run** (always-on, 1 min-instance) | ~$30 | ~$30 | ~$60+ |
+| **Gemini API** (~5 requests/user/day) | ~$0.75 | ~$7.50 | ~$75 |
+| **GCS** (~3 files/session, 7-day retention) | ~$0.10 | ~$1 | ~$8 |
+| **Firestore** (~20 ops/session) | ~$0.01 | ~$0.10 | ~$1 |
+| **Firebase Auth** | Free | Free | Free |
+| **Firebase Hosting** (CDN) | Free | Free | ~$5 |
+| **Estimated total** | **~$3–$33** | **~$24–$54** | **~$209–$269** |
+
+**Current monthly spend:** ~$0 (no persistent infrastructure; Cloud Run scales to
+zero, no min-instances configured).
+
+**Key cost driver:** Gemini API dominates at scale. Cloud Run is significant only
+if `--min-instances` is set for cold-start mitigation.
+
+---
+
+## 5. Latency Analysis
+
+### End-to-End Request Breakdown
+
+| Stage | Typical Latency | Notes |
+|-------|----------------|-------|
+| File upload (network) | ~1s | Depends on file size and client bandwidth |
+| DXF load (`ezdxf`) | ~0.5s | Scales with entity count |
+| Semantic model build | ~0.2s | 500-entity cap keeps this bounded |
+| **LLM planner call** | **2–10s** | **Dominates total latency** |
+| Validation | <0.1s | Rule checks against `RuleConfig` |
+| DXF rendering (matplotlib) | ~5s | Not thread-safe; blocks request thread |
+| **Total (warm instance)** | **~8–16s** | |
+
+### Worst-Case Latency
+
+- **Cold start:** Cloud Run cold start adds ~3–5s. No `--min-instances` is
+  configured, so the first request after idle always pays this cost.
+- **Planner timeout:** `PlannerProvider` has a 60s timeout with retry. A single
+  retry doubles the planner stage to ~120s. Worst-case user-facing latency for a
+  plan request: **~125s** (cold start + retry + render).
+- **Comparison pipeline:** ~10s for large drawings, additive to plan latency if
+  triggered in the same request flow.
+
+### Dominant Stage
+
+The LLM planner call (2–10s typical, up to 60s timeout) is the single largest
+contributor to user-visible latency. All other pipeline stages combined total
+~6–7s. Optimization efforts should focus on planner response time, streaming
+partial results, or moving the planner call to a background job.
+
+---
+
+## 6. Background Job Candidates
+
+Operations that should move off the request thread (Phase B):
+
+| # | Operation | Typical Duration | Why It Must Be Async |
+|---|-----------|-----------------|---------------------|
+| 1 | **Planner/LLM calls** | 2–10s (up to 60s timeout) | Dominates latency; retry logic can double duration. Blocks request thread for the entire call. |
+| 2 | **DXF rendering** (matplotlib) | ~5s | matplotlib is not thread-safe. Concurrent renders on the same process corrupt state. Must be serialized or run in subprocess. |
+| 3 | **Comparison pipeline** | ~10s for large drawings | Entity alignment + matching + changelog generation is CPU-bound. Blocks all other requests on a 1-CPU instance. |
+| 4 | **ODA file conversion** | Unbounded (subprocess) | Shells out to external `ODAFileConverter` binary. No timeout configured. Can hang indefinitely on malformed input. |
+| 5 | **Bundle export** | 2–5s | File I/O intensive: writes DXF + overlay + changelog + metadata. Competes with upload I/O on the same `/tmp/` volume. |
+| 6 | **PDF-to-DXF conversion** | Scales with page count | PyMuPDF extraction is CPU-bound. A 50-page PDF can take 30s+. No page-count limit enforced. |
+
+**Recommended pattern:** `POST` returns a job ID immediately. Client polls
+`GET /api/job/{id}` or receives a WebSocket notification on completion. Cloud
+Tasks or an in-process queue (for single-instance) handles dispatch.
+
+---
+
+## 7. Cloud Run Configuration Analysis
+
+### Current Configuration
+
+```
+--cpu=1 --memory=1Gi --concurrency=80 --min-instances=0 --timeout=300
+```
+
+(Concurrency 80 is the Cloud Run default when not explicitly set.)
+
+### Problems
+
+- **80 concurrent requests on 1 CPU:** Every pipeline stage (DXF load, semantic
+  model, planner call, validation, rendering) is synchronous and CPU-bound.
+  With 80 concurrent requests on a single vCPU, most requests queue behind
+  active work. Effective throughput is ~1–2 requests at a time.
+- **1Gi memory with no upload limit:** A few concurrent large-file uploads can
+  exhaust memory before any processing begins.
+- **No min-instances:** Every idle period triggers a cold start (~3–5s) on the
+  next request. For a tool users expect to be responsive, this is a poor
+  experience.
+- **matplotlib contention:** Even with concurrency=1, matplotlib global state
+  can corrupt across sequential requests if prior cleanup is incomplete.
+
+### Recommended Production Configuration
+
+```
+--cpu=2 --memory=2Gi --concurrency=4 --min-instances=1 --timeout=300
+```
+
+| Setting | Current | Recommended | Rationale |
+|---------|---------|-------------|-----------|
+| `--cpu` | 1 | 2 | CPU-bound pipeline needs headroom for concurrent ops |
+| `--memory` | 1Gi | 2Gi | Large DXF files + matplotlib rendering exceed 1Gi |
+| `--concurrency` | 80 (default) | 4 | Match actual throughput capacity; prevent queueing |
+| `--min-instances` | 0 | 1 | Eliminate cold-start latency for active users |
+| `--timeout` | 300 | 300 | Keep as-is; covers planner retry worst case |
+
+**Cost impact:** `--min-instances=1` with `--cpu=2` adds ~$30–$50/month in
+always-on cost. Justified once there are regular users.
+
+---
+
+## 8. Durable State Migration Path
 
 ### Phase A: Metadata Separation (EPIC-11.2)
 
@@ -111,7 +264,7 @@ Target:   Stateless Cloud Run instances
 
 ---
 
-## 4. Storage Evolution Summary
+## 9. Storage Evolution Summary
 
 | Layer | Current | Phase A | Phase B | Phase C |
 |-------|---------|---------|---------|---------|
@@ -123,7 +276,7 @@ Target:   Stateless Cloud Run instances
 
 ---
 
-## 5. Observability Gaps
+## 10. Observability Gaps
 
 | Gap | Current State | Target |
 |-----|--------------|--------|

--- a/000-docs/041-PM-STAT-implementation-status.md
+++ b/000-docs/041-PM-STAT-implementation-status.md
@@ -8,21 +8,21 @@
 
 ## 1. Epic Status Overview
 
-| # | Epic | Bead ID | Status | Branch | PR | Key Deliverables |
-|---|------|---------|--------|--------|----|-----------------|
-| 01 | Capability Audit + Architecture Baseline | cad-uns | DONE | `feature/epic-cad-01-capability-audit` | #71 | 6 docs (034-040), beads task tree |
-| 02 | Core Contracts + Routing Foundation | cad-d9a | NOT STARTED | — | — | `response_schema.py`, `intent_router.py`, TaskFamily/ResponseType enums |
-| 03 | Selection + Markup Interpretation Foundation | cad-wd2 | NOT STARTED | — | — | Region model, markup overlay ingestion, entity association |
-| 04 | Region Q&A Vertical Slice | cad-grx | NOT STARTED | — | — | Region context builder, grounded Q&A pipeline, golden tests |
-| 05 | Repeated-Condition Detection | cad-ccd | NOT STARTED | — | — | Similarity scoring, candidate search, preview/approval workflow |
-| 06 | Compare + Diff Service Hardening | cad-3e4 | NOT STARTED | — | — | Typed compare schema, alignment diagnostics, regression fixtures |
-| — | ARCH-REVIEW-01 | cad-sfw | NOT STARTED | — | — | Post-EPIC-06 quality/scalability review |
-| 07 | Structured Edit Planning | cad-9ug | NOT STARTED | — | — | Edit plan schema, plan builder, constraint validation |
-| 08 | Preview + Apply Workflow | cad-6zz | NOT STARTED | — | — | Preview pipeline, apply pipeline, audit trail |
-| 09 | Design Operations Workflow Pack | cad-ady | NOT STARTED | — | — | Layout recommendations, revision summaries, takeoff candidates |
-| 10 | Construction Drawing Workflow Pack | cad-8p2 | NOT STARTED | — | — | Grid/bay summaries, markup-to-redline, batch plans |
-| 11 | Session Durability + Scale Readiness | cad-36p | NOT STARTED | — | — | State audit, durable metadata model, tracing/metrics |
-| 12 | Evaluation Harness + Quality Governance | cad-m7d | NOT STARTED | — | — | Capability scorecard, fixture packs, CI regression |
+| # | Epic | Bead ID | Status | Branch | PR | Key Deliverables | Tests |
+|---|------|---------|--------|--------|----|-----------------|-------|
+| 01 | Capability Audit + Architecture Baseline | cad-uns | DONE | `feature/epic-cad-01-capability-audit` | #71 | 8 docs (034-041), beads task tree | N/A (docs only) |
+| 02 | Core Contracts + Routing Foundation | cad-d9a | NOT STARTED | — | — | `response_schema.py`, `intent_router.py`, TaskFamily/ResponseType enums | TBD — unit (schema validation, router accuracy), golden trajectories (routing decisions) |
+| 03 | Selection + Markup Interpretation Foundation | cad-wd2 | NOT STARTED | — | — | Region model, markup overlay ingestion, entity association | TBD — unit (region model, entity association), integration (markup ingestion pipeline) |
+| 04 | Region Q&A Vertical Slice | cad-grx | NOT STARTED | — | — | Region context builder, grounded Q&A pipeline, golden tests | TBD — golden trajectories (region_qa family), scorecard entries, live API tests |
+| 05 | Repeated-Condition Detection | cad-ccd | NOT STARTED | — | — | Similarity scoring, candidate search, preview/approval workflow | TBD — unit (similarity scoring), golden trajectories (repeated_condition family), scorecard entries |
+| 06 | Compare + Diff Service Hardening | cad-3e4 | NOT STARTED | — | — | Typed compare schema, alignment diagnostics, regression fixtures | TBD — unit (typed schema), regression fixtures, integration (alignment diagnostics) |
+| — | ARCH-REVIEW-01 | cad-sfw | NOT STARTED | — | — | Post-EPIC-06 quality/scalability review; ADR with keep/change/remove decisions per module | N/A (review output is ADR document) |
+| 07 | Structured Edit Planning | cad-9ug | NOT STARTED | — | — | `models/plan_schema.py` (EditPlan), `llm/plan_builder.py`, constraint validation | TBD — unit (plan schema, constraint validation), golden trajectories (structured_edit family) |
+| 08 | Preview + Apply Workflow | cad-6zz | NOT STARTED | — | — | `web/backend/routes/preview.py`, `web/frontend/src/components/PreviewPanel.jsx`, audit trail | TBD — unit (preview generation, audit trail), integration (preview→apply round-trip), web API tests |
+| 09 | Design Operations Workflow Pack | cad-ady | NOT STARTED | — | — | `workflows/design_ops.py`, prompt templates for layout/revision/takeoff | TBD — golden trajectories (design_ops families), scorecard entries, live API tests |
+| 10 | Construction Drawing Workflow Pack | cad-8p2 | NOT STARTED | — | — | `workflows/construction.py`, prompt templates for grid/bay/markup/batch | TBD — golden trajectories (construction families), scorecard entries, live API tests |
+| 11 | Session Durability + Scale Readiness | cad-36p | NOT STARTED | — | — | `core/session_store.py` (ABC + GCS impl), durable metadata model, tracing/metrics | TBD — unit (session store, metadata model), integration (persistence round-trip), migration tests |
+| 12 | Evaluation Harness + Quality Governance | cad-m7d | NOT STARTED | — | — | `tests/eval/` fixture packs, `scripts/run_eval.py`, scorecard JSON schema, CI regression | TBD — meta-tests (scorecard schema validation), CI smoke (eval harness runs clean) |
 
 ---
 
@@ -32,10 +32,10 @@
 |-------|-------|--------|------|
 | **Phase 1: Foundation** | 01, 02, 03 | 1/3 complete | Contracts locked, `make check` green |
 | **Phase 2: Core Intelligence** | 04, 05, 06 | 0/3 complete | Golden trajectories pass per family |
-| **Architecture Review** | ARCH-REVIEW-01 | Not started | Written review with keep/change/remove |
-| **Phase 3: Structured Editing** | 07, 08 | 0/2 complete | Edit plan + apply produce audit metadata |
-| **Phase 4: Workflow Packs** | 09, 10 | 0/2 complete | Domain scorecard entries pass |
-| **Phase 5: Production Readiness** | 11, 12 | 0/2 complete | Durable sessions + full scorecard green |
+| **Architecture Review** | ARCH-REVIEW-01 | Not started | ADR document with keep/change/remove decisions per module |
+| **Phase 3: Structured Editing** | 07, 08 | 0/2 complete | Edit plan + apply produce audit metadata. Key files: `src/cad_dxf_agent/llm/plan_builder.py`, `src/cad_dxf_agent/models/plan_schema.py`, `web/frontend/src/components/PreviewPanel.jsx`, `web/backend/routes/preview.py` |
+| **Phase 4: Workflow Packs** | 09, 10 | 0/2 complete | Domain scorecard entries pass. Key files: `src/cad_dxf_agent/workflows/design_ops.py`, `src/cad_dxf_agent/workflows/construction.py`, domain-specific prompt templates |
+| **Phase 5: Production Readiness** | 11, 12 | 0/2 complete | Durable sessions + full scorecard green. Key files: `src/cad_dxf_agent/core/session_store.py` (GCS integration), `tests/eval/`, `scripts/run_eval.py`, scorecard schema |
 
 ---
 
@@ -69,6 +69,7 @@ contracts and routing foundation are in place.
 | 038 | Drawing Intelligence Roadmap | DONE — 12 epics, 5 phases, dependency graph |
 | 039 | Intent Router Design (ADR) | DONE — Hybrid heuristic+LLM, task family boundaries |
 | 040 | Scale Readiness Assessment | DONE — Bottlenecks, migration path, observability gaps |
+| 041 | Implementation Status Tracker | DONE — This document; living tracker for all 12 epics |
 
 ---
 
@@ -88,18 +89,42 @@ contracts and routing foundation are in place.
 
 ## 6. Risk Summary
 
-| Risk | Status | Mitigation |
-|------|--------|------------|
-| Response contract churn | ACTIVE — schemas are "proposed" | Stabilize in EPIC-02, mark v2 |
-| Intent router accuracy | ACTIVE — no router exists yet | Conservative thresholds in EPIC-02 |
-| Markup entity detection | DEFERRED — no training data | Collect real samples before EPIC-03 |
-| 500-entity context cap | ACTIVE — silent information loss | Token-budget context builder in EPIC-03 |
-| Ephemeral session storage | KNOWN — lost on restart | Durable state migration in EPIC-11 |
-| Large drawing performance | ACTIVE — blocks request thread | Background execution in EPIC-11 |
+| Risk | Epic(s) | Status | Mitigation |
+|------|---------|--------|------------|
+| Response contract churn | 02 | ACTIVE — schemas are "proposed" | Stabilize in EPIC-02, mark v2 |
+| Intent router accuracy | 02, 04 | ACTIVE — no router exists yet | Conservative thresholds in EPIC-02 |
+| Markup entity detection | 03 | DEFERRED — no training data | Collect real samples before EPIC-03 |
+| 500-entity context cap | 03, 04 | ACTIVE — silent information loss | Token-budget context builder in EPIC-03 |
+| Ephemeral session storage | 11 | KNOWN — lost on restart | Durable state migration in EPIC-11 |
+| Large drawing performance | 06, 11 | ACTIVE — blocks request thread | Background execution in EPIC-11 |
+| Domain-specific prompt templates may not generalize | 09 | DEFERRED | Start with narrow domain templates; collect user feedback before broadening |
+| Construction drawing conventions vary by region | 10 | DEFERRED | Parameterize region-specific conventions; validate with multiple regional samples |
+| Migration from in-memory to persistent sessions may break existing tests | 11 | DEFERRED | Implement session store behind ABC; keep in-memory impl for test compatibility |
+| Eval harness depends on quality of golden trajectories from prior epics | 12 | DEFERRED | Gate EPIC-12 on trajectory count threshold (25+); validate trajectory coverage per family |
 
 ---
 
-## 7. Next Actions
+## 7. Per-Epic Next Steps
+
+| # | Epic | Next Step |
+|---|------|-----------|
+| 01 | Capability Audit + Architecture Baseline | Completed — hardening pass in progress |
+| 02 | Core Contracts + Routing Foundation | Define `TaskFamily` enum and `PlatformResponse` model in `response_schema.py`; write unit tests for enum coverage |
+| 03 | Selection + Markup Interpretation Foundation | Design `Region` Pydantic model with bounding box + entity association; draft markup overlay ingestion interface |
+| 04 | Region Q&A Vertical Slice | Implement region context builder that filters entities by bounding box; write first golden trajectory for region_qa |
+| 05 | Repeated-Condition Detection | Prototype entity similarity scoring function; define candidate result schema |
+| 06 | Compare + Diff Service Hardening | Audit existing `core/comparison/` for untyped returns; define typed `CompareResult` schema |
+| — | ARCH-REVIEW-01 | Collect module-level metrics (coupling, test coverage, API surface); draft ADR template with keep/change/remove columns |
+| 07 | Structured Edit Planning | Define `EditPlan` schema in `plan_schema.py`; implement plan builder with constraint pre-checks |
+| 08 | Preview + Apply Workflow | Wire preview generation into web backend route; implement frontend `PreviewPanel` component |
+| 09 | Design Operations Workflow Pack | Draft prompt templates for layout recommendations; implement `design_ops.py` workflow module |
+| 10 | Construction Drawing Workflow Pack | Gather sample construction drawings for regional convention analysis; draft grid/bay extraction logic |
+| 11 | Session Durability + Scale Readiness | Audit current in-memory session lifecycle; define `SessionStore` ABC with GCS-backed implementation |
+| 12 | Evaluation Harness + Quality Governance | Define scorecard JSON schema; scaffold `tests/eval/` directory with first fixture pack |
+
+---
+
+## 8. Global Next Actions
 
 1. **Merge PR #71** — EPIC-01 docs into main
 2. **Begin EPIC-02** — implement `response_schema.py` and `intent_router.py`
@@ -113,3 +138,12 @@ contracts and routing foundation are in place.
 - 034-AT-AUDT — Capability audit baseline
 - 038-PM-PLAN — Roadmap and phasing
 - 040-AT-AUDT — Scale readiness assessment
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-03-05 | Initial creation with EPIC-01 complete, all other epics NOT STARTED |
+| 2026-03-06 | Audit hardening: fixed doc count (6→8), added Tests column, mapped risks to epics, added Phase 4-5 risks, added per-epic Next Steps, added concrete file paths for Phases 3-5, clarified ARCH-REVIEW-01 output format, added this changelog |


### PR DESCRIPTION
## Epic
EPIC-CAD-01 — Capability Audit + Architecture Baseline

## Bead(s)
cad-uns

## Summary
- Systematic audit of all 8 EPIC-CAD-01 docs against the original prompt spec identified 2 MISSING and ~6 SHALLOW items per doc on average
- Parallel hardening pass filled every gap: +1,538 lines across 8 docs
- Foundation docs now contain complete coverage of all spec requirements for the Drawing Intelligence Platform

## Changes by doc

| Doc | Key additions |
|-----|--------------|
| 034 (capability audit) | Scale risks, target state columns, backend architecture, LLM touchpoint catalog, pipeline flows, extended failure modes |
| 035 (target architecture) | Error handling & resilience, multi-user sessions, observability plan, storage architecture, API surface, migration phasing |
| 036 (contracts/taxonomy) | `unsupported_operation` task family, fields matrix, confidence model, schema versioning, 3 data payload schemas, risk model |
| 037 (evaluation plan) | Evaluation by workflow class, quality gates, 6 weighted scoring dimensions, regression detection |
| 038 (roadmap) | Per-phase success criteria, release strategy, T-shirt sizing, risks→phases mapping |
| 039 (intent router ADR) | 6 edge cases, heuristic priority order, LLM classification spec, performance budget, testability |
| 040 (scale readiness) | "What breaks first" cascade, cost projections, latency breakdown, background job candidates, Cloud Run analysis |
| 041 (implementation status) | Doc count fix, Tests column, risks→epics mapping, concrete Phase 3-5 deliverables, changelog |

## Test plan
- Docs are markdown — no code changes, no tests affected
- Verified all 8 files are well-formed markdown with consistent structure

## Docs
Updated: 034, 035, 036, 037, 038, 039, 040, 041 (all 8 EPIC-CAD-01 deliverables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)