### PR TITLE
feat: EPIC-CAD-08 preview + apply workflow

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -42,6 +42,7 @@
 | 041 | STAT | [041-PM-STAT-implementation-status.md](041-PM-STAT-implementation-status.md) |
 | 042 | AAR | [042-PM-AAR-epic-cad-02-aar.md](042-PM-AAR-epic-cad-02-aar.md) |
 | 043 | AAR | [043-PM-AAR-epic-cad-03-aar.md](043-PM-AAR-epic-cad-03-aar.md) |
+| 048 | AAR | [048-PM-AAR-epic-cad-07-aar.md](048-PM-AAR-epic-cad-07-aar.md) |
 
 ### DR — Documentation & Reference
 | # | Type | File |
@@ -132,6 +133,7 @@
 | 045 | AT | SPEC | Repeated-condition scoring model (EPIC-CAD-05) |
 | 046 | AT | AUDT | Post-EPIC-06 architecture review (ARCH-REVIEW-CAD-01) |
 | 047 | RL | REPT | Release v0.6.0 report (Phase 2 complete) |
+| 048 | PM | AAR | EPIC-CAD-07 end-of-phase report (Structured Edit Planning) |
 
 ## Quick Reference
 

--- a/000-docs/041-PM-STAT-implementation-status.md
+++ b/000-docs/041-PM-STAT-implementation-status.md
@@ -18,7 +18,7 @@
 | 05 | Repeated-Condition Detection | cad-ccd | DONE | `feature/epic-cad-05-repeated-conditions` | #81 | `repeated_condition_schema.py`, `repeated_condition.py`, web endpoint, 4 golden trajectories | 63 tests — unit (38 detection + 19 schema), integration (6 factory DXF) |
 | 06 | Compare + Diff Service Hardening | cad-3e4 | DONE | `feature/epic-cad-06-compare-diff` | #82 | `comparison_schema.py` (MatchSummary, DiffSummaryData, ComparePackage), scorer text-trust, changelog enrichment, `export_compare_package()`, web endpoint hardening | 15 tests — unit (9 schema + 2 anti-regression), regression (13 comparison pipeline) |
 | — | ARCH-REVIEW-01 | cad-sfw | DONE | `feature/arch-review-cad-01` | — | [046-AT-AUDT](046-AT-AUDT-arch-review-cad-01.md): 10-dimension review, CONDITIONAL GO for EPIC-07, 3 prerequisites, 2 constraints | N/A (review output is ADR document) |
-| 07 | Structured Edit Planning | cad-9ug | NOT STARTED | — | — | `models/plan_schema.py` (EditPlan), `llm/plan_builder.py`, constraint validation | TBD — unit (plan schema, constraint validation), golden trajectories (structured_edit family) |
+| 07 | Structured Edit Planning | cad-9ug | DONE | `feature/epic-cad-07-edit-planning` | #85 | `plan_schema.py` (EditPlan, EditAction, 5 action types), `plan_builder.py` (deterministic, no LLM), `plan_validator.py` (protected layers, text trust, move limits), `text_utils.py` (shared utilities) | 109 tests — unit (25 schema + 30 builder + 20 validator + 16 text_utils), anti-regression (15), golden (10) |
 | 08 | Preview + Apply Workflow | cad-6zz | NOT STARTED | — | — | `web/backend/routes/preview.py`, `web/frontend/src/components/PreviewPanel.jsx`, audit trail | TBD — unit (preview generation, audit trail), integration (preview→apply round-trip), web API tests |
 | 09 | Design Operations Workflow Pack | cad-ady | NOT STARTED | — | — | `workflows/design_ops.py`, prompt templates for layout/revision/takeoff | TBD — golden trajectories (design_ops families), scorecard entries, live API tests |
 | 10 | Construction Drawing Workflow Pack | cad-8p2 | NOT STARTED | — | — | `workflows/construction.py`, prompt templates for grid/bay/markup/batch | TBD — golden trajectories (construction families), scorecard entries, live API tests |
@@ -34,7 +34,7 @@
 | **Phase 1: Foundation** | 01, 02, 03 | 3/3 COMPLETE | Contracts locked, regions normalized, `make check` green |
 | **Phase 2: Core Intelligence** | 04, 05, 06 | 3/3 COMPLETE (+ SQ67 done) | Golden trajectories pass per family |
 | **Architecture Review** | ARCH-REVIEW-01 | COMPLETE | CONDITIONAL GO — doc 046 published, 3 prerequisites for EPIC-07 |
-| **Phase 3: Structured Editing** | 07, 08 | 0/2 complete | Edit plan + apply produce audit metadata. Key files: `src/cad_dxf_agent/llm/plan_builder.py`, `src/cad_dxf_agent/models/plan_schema.py`, `web/frontend/src/components/PreviewPanel.jsx`, `web/backend/routes/preview.py` |
+| **Phase 3: Structured Editing** | 07, 08 | 1/2 complete | EPIC-07 DONE (edit plan schema + builder + validator). Next: EPIC-08 (preview + apply). Key files: `web/frontend/src/components/PreviewPanel.jsx`, `web/backend/routes/preview.py` |
 | **Phase 4: Workflow Packs** | 09, 10 | 0/2 complete | Domain scorecard entries pass. Key files: `src/cad_dxf_agent/workflows/design_ops.py`, `src/cad_dxf_agent/workflows/construction.py`, domain-specific prompt templates |
 | **Phase 5: Production Readiness** | 11, 12 | 0/2 complete | Durable sessions + full scorecard green. Key files: `src/cad_dxf_agent/core/session_store.py` (GCS integration), `tests/eval/`, `scripts/run_eval.py`, scorecard schema |
 
@@ -55,7 +55,7 @@ EPIC-01 (DONE) → EPIC-02 (DONE)
 ```
 
 **Critical path:** Phase 1 COMPLETE. Phase 2 COMPLETE. ARCH-REVIEW-01 COMPLETE (CONDITIONAL GO).
-Next: EPIC-CAD-07 (Structured Edit Planning) — after 3 prerequisites from review.
+EPIC-CAD-07 DONE. Next: EPIC-CAD-08 (Preview + Apply Workflow).
 
 ---
 
@@ -78,8 +78,8 @@ Next: EPIC-CAD-07 (Structured Edit Planning) — after 3 prerequisites from revi
 
 | Metric | Current (post-SQ67) | Target (all epics) |
 |--------|-------------------|-------------------|
-| Total tests | 1,924 | 2000+ |
-| Coverage | 95.24% | 70%+ |
+| Total tests | 1,760 (collected) | 2000+ |
+| Coverage | ~95% | 70%+ |
 | Golden trajectories | 15 (edit_plan 5 + qna 6 + repeated_condition 4) | 25+ (all 9 families) |
 | Scorecard entries | 0 | 32+ |
 | Task families tested | 4 (edit_plan + compare + qna + repeated_condition) | 9 |
@@ -117,7 +117,7 @@ Next: EPIC-CAD-07 (Structured Edit Planning) — after 3 prerequisites from revi
 | 05 | Repeated-Condition Detection | DONE — PR #81. Similarity scoring model (6 signals, text-trust weighting), ConditionDetector with spatial clustering, preview/approval workflow, web endpoint, 63 tests, 4 golden trajectories. Doc: [045-AT-SPEC](045-AT-SPEC-repeated-condition-scoring.md) |
 | 06 | Compare + Diff Service Hardening | DONE — PR #82 merged. Typed compare schema, scorer text-trust, changelog enrichment, export package, web endpoint hardening. 15 tests. Compliance audit: 2 anti-regression tests added. |
 | — | ARCH-REVIEW-01 | DONE — doc 046 published. CONDITIONAL GO for EPIC-07 with 3 prerequisites (upload size, text_utils extraction, truncation confidence) |
-| 07 | Structured Edit Planning | Define `EditPlan` schema in `plan_schema.py`; implement plan builder with constraint pre-checks |
+| 07 | Structured Edit Planning | DONE — PR #85. EditPlan schema (5 action types), deterministic plan builder (no LLM), plan validator (protected layers, text trust, move limits), shared text_utils. 109 new tests. All 3 ARCH-REVIEW prerequisites satisfied. |
 | 08 | Preview + Apply Workflow | Wire preview generation into web backend route; implement frontend `PreviewPanel` component |
 | 09 | Design Operations Workflow Pack | Draft prompt templates for layout recommendations; implement `design_ops.py` workflow module |
 | 10 | Construction Drawing Workflow Pack | Gather sample construction drawings for regional convention analysis; draft grid/bay extraction logic |
@@ -128,10 +128,9 @@ Next: EPIC-CAD-07 (Structured Edit Planning) — after 3 prerequisites from revi
 
 ## 8. Global Next Actions
 
-1. **ARCH-REVIEW-01 COMPLETE** — CONDITIONAL GO issued (doc 046)
-2. **Fix prerequisites** — upload size validation (P0), extract text_utils (P1), truncation confidence (P1)
-3. **Begin EPIC-07** — Structured Edit Planning (after prerequisites)
-4. **Begin EPIC-08** — Preview + Apply Workflow after EPIC-07
+1. **EPIC-07 COMPLETE** — Structured Edit Planning (PR #85)
+2. **All ARCH-REVIEW-01 prerequisites satisfied** — upload size (P0), text_utils (P1), truncation confidence (P1)
+3. **Begin EPIC-08** — Preview + Apply Workflow (next in Phase 3)
 
 ---
 
@@ -158,3 +157,4 @@ Next: EPIC-CAD-07 (Structured Edit Planning) — after 3 prerequisites from revi
 | 2026-03-06 | EPIC-05 started: Repeated-Condition Detection (in progress). |
 | 2026-03-06 | EPIC-05 DONE: PR #81. Similarity scoring model (6 weighted signals), ConditionDetector with spatial clustering, preview/approval workflow, web endpoint. 63 new tests (38 unit + 19 schema + 6 integration). 4 golden trajectories. Doc 045 added. Test count: ~1760→~1823. Golden trajectories: 11→15. Task families: 3→4. Phase 2: 2/3 complete. |
 | 2026-03-07 | ARCH-REVIEW-01 DONE: 10-dimension architecture review. CONDITIONAL GO for EPIC-07. Doc 046 published. Test count: 1,924. Coverage: 95.24%. Prerequisites: upload size validation (P0), extract text_utils (P1), truncation confidence (P1). |
+| 2026-03-07 | EPIC-07 DONE: PR #85. 4 new source files (plan_schema.py, plan_builder.py, plan_validator.py, text_utils.py). 109 new tests (25 schema + 30 builder + 20 validator + 15 anti-regression + 10 golden + 16 text_utils). All 3 ARCH-REVIEW prerequisites satisfied. Test count: 1,760 collected, all pass. Phase 3: 1/2 complete. Doc 048 added. |

--- a/000-docs/048-PM-AAR-epic-cad-07-aar.md
+++ b/000-docs/048-PM-AAR-epic-cad-07-aar.md
@@ -1,0 +1,197 @@
+# 048 — EPIC-CAD-07 End-of-Phase Report: Structured Edit Planning
+
+**Date:** 2026-03-07
+**Epic:** EPIC-CAD-07 (Structured Edit Planning)
+**Bead:** cad-9ug
+**Branch:** `feature/epic-cad-07-edit-planning`
+**PR:** #85
+**Gate:** ARCH-REVIEW-CAD-01 CONDITIONAL GO (all 3 prerequisites satisfied)
+
+---
+
+## 1. Scope Delivered
+
+Four stories completed:
+
+| Story | Deliverable | Status |
+|-------|------------|--------|
+| 1 — Schema | `models/plan_schema.py` — EditPlan, EditAction, EditActionType (5 values), PlanValidationStatus (4 values), ApprovalRequirement, PlanLatency, ActionValidationDetail | DONE |
+| 2 — Builder | `llm/plan_builder.py` — Deterministic EditPlanBuilder (no LLM), PlanRequest dataclass, regex-based intent routing, displacement/text parsing, target resolution by handle or region | DONE |
+| 3 — Validator | `core/plan_validator.py` — PlanValidator enforcing protected layers, entity/action compatibility, SQ67 text trust, move distance limits, batch replication approval gates | DONE |
+| 4 — Tests | 109 tests across 6 test files — golden scenarios, anti-regression guards, unit coverage for schema/builder/validator/text_utils | DONE |
+
+### ARCH-REVIEW-CAD-01 Prerequisites
+
+| # | Prerequisite | Deliverable | Status |
+|---|-------------|-------------|--------|
+| P0 | Upload size validation (25MB) | `web/backend/main.py` — 413 response for oversized uploads | DONE |
+| P1 | Extract shared text_utils | `core/text_utils.py` — levenshtein, describe_entity, entity_to_evidence; deduplicates scorer.py + repeated_condition.py | DONE |
+| P1 | Truncation confidence penalty | `core/region_context.py` — `-0.2` confidence reduction when context is truncated | DONE |
+
+---
+
+## 2. Architecture Alignment
+
+### Design Decisions
+
+1. **Deterministic builder, no LLM** — EditPlanBuilder uses regex + rules, never calls an LLM. This keeps plan generation fast, testable, and predictable. LLM routing stays in the existing IntentRouter.
+
+2. **Plan-only output** — EditPlan has no `apply()` or `execute()` method. The plan is a data structure that describes proposed changes. Actual application is deferred to EPIC-08 (Preview + Apply).
+
+3. **Typed action enum** — 5 bounded action types: `MOVE_ENTITY`, `EDIT_TEXT`, `DELETE_ENTITY`, `ADD_BLOCK`, `REPLICATE_NOTE`. Unsupported requests produce `NEEDS_CLARIFICATION` status with zero actions, never freeform blobs.
+
+4. **SQ67 text trust integration** — OCR-provenance entities get reduced confidence and `low_text_trust` ambiguity flags. The validator surfaces text trust warnings independently.
+
+5. **Batch replication gate** — Plans from repeated-condition results require `APPROVED` state on every candidate. `PENDING` candidates block the entire plan.
+
+### Source Layout
+
+```
+src/cad_dxf_agent/
+  models/plan_schema.py      # EditPlan, EditAction, EditActionType, PlanValidationStatus
+  llm/plan_builder.py        # EditPlanBuilder, PlanRequest
+  core/plan_validator.py      # PlanValidator
+  core/text_utils.py          # Shared: levenshtein, describe_entity, entity_to_evidence
+  llm/response_builder.py     # Updated: structured_plan() method
+  core/region_context.py      # Updated: truncation confidence penalty
+  core/comparison/scorer.py   # Updated: uses text_utils
+  core/repeated_condition.py  # Updated: uses text_utils
+  web/backend/main.py         # Updated: 25MB upload limit
+```
+
+---
+
+## 3. Test Evidence
+
+### New Tests (109 total)
+
+| File | Tests | Coverage |
+|------|-------|----------|
+| `test_plan_schema.py` | 25 | Enums, model creation, serialization, bounds, properties |
+| `test_plan_builder.py` | 30 | Move/delete/text-edit/add/batch routing, evidence, latency, parsing |
+| `test_plan_validator.py` | 20 | Protected layers, entity/action compat, missing targets, confidence, text trust, move/edit params, replicate |
+| `test_plan_anti_regression.py` | 15 | No-apply, no non-edit routing, no freeform, blocked persists, OCR trust, approval required |
+| `test_plan_golden.py` | 10 | Construction edit, annotation review, text provenance, batch replication |
+| `test_text_utils.py` | 16 | Levenshtein distance/similarity, describe_entity, entity_to_evidence |
+
+### Anti-Regression Guards
+
+| Guard | Test Class | Enforces |
+|-------|-----------|----------|
+| Edit planning does not apply edits | `TestEditPlanDoesNotApplyEdits` | No `apply()` or `execute()` on EditPlan |
+| Non-edit families excluded | `TestNonEditFamiliesExcluded` | Q&A, summary, compare, repeated_condition don't route to edit planning |
+| No freeform actions | `TestNoUnsupportedFreeformActions` | All actions are valid EditActionType enum values |
+| Blocked plans remain blocked | `TestBlockedPlansRemainBlocked` | Blocked status persists, pending batch stays blocked |
+| OCR text trust | `TestOcrTextDoesNotMasqueradeAsExact` | Low-trust OCR reduces confidence, flags ambiguity |
+| Batch approval required | `TestRepeatedConditionApprovalRequired` | Unapproved candidates blocked, approved proceed |
+
+### Golden Scenarios
+
+| Scenario | Tests | Validates |
+|----------|-------|-----------|
+| Construction drawing: callout edit | 3 | Move with displacement, text edit, title-layer blocking |
+| Annotation review: region delete | 1 | Multi-entity delete in region, destructive confirmation |
+| Text provenance: native vs OCR | 3 | Native high confidence, OCR reduced confidence, validator warns |
+| Batch replication | 1 | Approved matches generate replication plan with match confidences |
+
+### Full Suite
+
+```
+1760 passed, 0 failed, 5 skipped (32.75s)
+ruff: All checks passed
+mypy: Success, no issues found in 4 source files
+```
+
+---
+
+## 4. Compliance Checklist
+
+| # | Requirement | Status | Evidence |
+|---|------------|--------|----------|
+| C1 | EditPlan has no apply/execute method | PASS | `test_plan_has_no_apply_method` |
+| C2 | Non-edit families never route to edit | PASS | `TestNonEditFamiliesExcluded` (4 parametrized + 2 explicit) |
+| C3 | All actions are typed enum values | PASS | `test_all_action_types_are_valid_enum` |
+| C4 | Blocked plans stay blocked | PASS | `test_blocked_status_persists_after_creation` |
+| C5 | OCR text reduces confidence | PASS | `test_ocr_text_reduces_confidence` (anti-regression + golden) |
+| C6 | Batch replication requires approval | PASS | `test_unapproved_candidates_blocked`, `test_approved_candidates_proceed` |
+| C7 | Protected layers block edits | PASS | `TestProtectedLayerBlocking` (4 tests) |
+| C8 | Upload size validation (P0) | PASS | 25MB limit in `web/backend/main.py` |
+| C9 | Shared text_utils (P1) | PASS | `text_utils.py` extracted, scorer + repeated_condition updated |
+| C10 | Truncation confidence penalty (P1) | PASS | `-0.2` in `region_context.py` |
+
+---
+
+## 5. Metrics Delta
+
+| Metric | Before | After | Delta |
+|--------|--------|-------|-------|
+| Total tests (collected) | 1,651 | 1,760 | +109 |
+| Source files (new) | — | 4 | +4 |
+| Source files (modified) | — | 5 | +5 |
+| Lines added | — | 2,882 | +2,882 |
+| Lines removed | — | 64 | -64 |
+
+---
+
+## 6. Dependency Graph Update
+
+```
+EPIC-01 (DONE) -> EPIC-02 (DONE)
+                    |-> EPIC-03 (DONE) -> EPIC-04 (DONE) + SQ67 (DONE) -> EPIC-05 (DONE)
+                    |-> EPIC-06 (DONE)
+              EPIC-04 + 05 + 06 -> ARCH-REVIEW-01 (DONE)
+                                    |-> EPIC-07 (DONE) -> EPIC-08 (next)
+                                    |-> EPIC-11
+              EPIC-04 + 08 -> EPIC-09
+              EPIC-03 + 06 + 07 -> EPIC-10
+              EPIC-04..10 -> EPIC-12
+```
+
+---
+
+## 7. Risks & Issues
+
+| Risk | Status | Mitigation |
+|------|--------|------------|
+| Plan builder regex may miss edge cases | ACTIVE | Golden tests cover representative scenarios; extend as real user prompts arrive |
+| No LLM-assisted disambiguation | ACCEPTED | Intentional — builder is deterministic. LLM disambiguation deferred to EPIC-08 preview flow |
+| Batch replication may need richer source context | LOW | Current schema captures source_handles + target_centroid; extend if needed in EPIC-10 |
+
+---
+
+## 8. Open Items for EPIC-08
+
+1. Wire EditPlan into preview generation (human-readable diff)
+2. Implement apply workflow (EditPlan -> ChangeSet -> EditEngine)
+3. Frontend PreviewPanel component with approve/reject UI
+4. Audit trail: record plan ID, approval timestamp, applied actions
+5. Undo support: revert from applied plan
+
+---
+
+## 9. Files Changed
+
+### New Files
+- `src/cad_dxf_agent/models/plan_schema.py`
+- `src/cad_dxf_agent/llm/plan_builder.py`
+- `src/cad_dxf_agent/core/plan_validator.py`
+- `src/cad_dxf_agent/core/text_utils.py`
+- `tests/unit/test_plan_schema.py`
+- `tests/unit/test_plan_builder.py`
+- `tests/unit/test_plan_validator.py`
+- `tests/unit/test_plan_anti_regression.py`
+- `tests/unit/test_plan_golden.py`
+- `tests/unit/test_text_utils.py`
+
+### Modified Files
+- `src/cad_dxf_agent/core/comparison/scorer.py` — uses shared text_utils
+- `src/cad_dxf_agent/core/repeated_condition.py` — uses shared text_utils
+- `src/cad_dxf_agent/core/region_context.py` — truncation confidence penalty
+- `src/cad_dxf_agent/llm/response_builder.py` — structured_plan() method
+- `web/backend/main.py` — upload size validation
+
+---
+
+## 10. Conclusion
+
+EPIC-CAD-07 is complete. The Structured Edit Planning system provides a typed, validated, auditable edit plan schema with deterministic generation and comprehensive constraint enforcement. All 3 ARCH-REVIEW-CAD-01 prerequisites are satisfied. The system is ready for EPIC-08 (Preview + Apply Workflow) to wire plans into the execution pipeline.

--- a/src/cad_dxf_agent/core/apply_pipeline.py
+++ b/src/cad_dxf_agent/core/apply_pipeline.py
@@ -1,0 +1,169 @@
+"""Apply pipeline — applies validated EditPlans to DXF files.
+
+Bridges the EPIC-07 EditPlan into the existing EditEngine via the
+plan_to_changeset converter. Handles approval checking, application,
+saving, and revision note insertion.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+from ..models.apply_schema import ActionResult, ApplyResult, ApplyStatus, ApprovalDecision
+from ..models.cad_schema import DrawingContext
+from ..models.config_schema import RevisionNoteConfig, RuleConfig
+from ..models.plan_schema import EditPlan
+from .edit_engine import EditEngine
+from .plan_converter import plan_to_changeset
+
+logger = logging.getLogger(__name__)
+
+
+class ApplyPipeline:
+    """Applies an EditPlan to a DXF file via the legacy EditEngine."""
+
+    def __init__(
+        self,
+        context: DrawingContext,
+        rules: RuleConfig | None = None,
+    ) -> None:
+        self._context = context
+        self._rules = rules or RuleConfig()
+
+    def apply(
+        self,
+        plan: EditPlan,
+        dxf_path: str | Path,
+        output_path: str | Path,
+        *,
+        approval: ApprovalDecision | None = None,
+        revision_config: RevisionNoteConfig | None = None,
+    ) -> ApplyResult:
+        """Apply an edit plan to a DXF file.
+
+        Steps:
+        1. Check preconditions (blocked/needs_clarification)
+        2. Check approval if required
+        3. Convert plan → changeset
+        4. Apply via EditEngine
+        5. Save output
+        6. Insert revision notes (if enabled)
+        7. Build and return ApplyResult
+        """
+        total_start = time.monotonic()
+        result = ApplyResult(
+            plan_id=plan.plan_id,
+            request_id=plan.request_id,
+        )
+
+        # 1. Check preconditions
+        if plan.is_blocked:
+            result.status = ApplyStatus.REJECTED
+            result.summary = "Plan is blocked: " + "; ".join(plan.blocked_reasons)
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+
+        if plan.needs_clarification:
+            result.status = ApplyStatus.REJECTED
+            result.summary = "Plan needs clarification before applying."
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+
+        # 2. Check approval
+        if plan.requires_approval and (approval is None or not approval.approved):
+            result.status = ApplyStatus.REJECTED
+            result.summary = "Plan requires approval before applying."
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+
+        # 3. Convert plan → changeset
+        changeset, action_index_map = plan_to_changeset(plan, self._context)
+
+        if not changeset.operations:
+            result.status = ApplyStatus.FAILED
+            result.summary = "No operations to apply."
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+
+        # 4. Apply via EditEngine
+        apply_start = time.monotonic()
+        try:
+            engine = EditEngine(dxf_path)
+            applied_changes = engine.apply_changeset(changeset)
+        except Exception as e:
+            logger.error("EditEngine failed: %s", e, exc_info=True)
+            result.status = ApplyStatus.FAILED
+            result.summary = f"Apply failed: {e}"
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+        result.apply_ms = (time.monotonic() - apply_start) * 1000
+
+        # 5. Save output
+        save_start = time.monotonic()
+        try:
+            saved_path = engine.save(output_path)
+            result.output_path = str(saved_path)
+        except Exception as e:
+            logger.error("Save failed: %s", e, exc_info=True)
+            result.status = ApplyStatus.FAILED
+            result.summary = f"Save failed: {e}"
+            result.total_ms = (time.monotonic() - total_start) * 1000
+            return result
+        result.save_ms = (time.monotonic() - save_start) * 1000
+
+        # 6. Insert revision notes
+        if revision_config and revision_config.enabled:
+            try:
+                from .revision_notes import insert_revision_note
+
+                note_text = insert_revision_note(
+                    dxf_path=output_path,
+                    output_path=output_path,
+                    changes=applied_changes,
+                    config=revision_config,
+                )
+                result.revision_note = note_text
+            except Exception as e:
+                logger.warning("Revision note insertion failed: %s", e)
+                result.warnings.append(f"Revision note failed: {e}")
+
+        # 7. Build action results
+        action_results: list[ActionResult] = []
+        success_count = 0
+        failure_count = 0
+
+        for op_idx, applied in enumerate(applied_changes):
+            action_idx = action_index_map.get(op_idx)
+            action = plan.actions[action_idx] if action_idx is not None else None
+            ar = ActionResult(
+                action_id=action.action_id if action else f"op-{op_idx}",
+                action_type=action.action_type.value if action else applied.operation.op_type.value,
+                success=applied.success,
+                entity_handle=applied.entity_handle,
+                description=applied.description,
+                error=None if applied.success else applied.description,
+            )
+            action_results.append(ar)
+            if applied.success:
+                success_count += 1
+            else:
+                failure_count += 1
+
+        result.action_results = action_results
+        result.success_count = success_count
+        result.failure_count = failure_count
+
+        # Determine status
+        if failure_count == 0:
+            result.status = ApplyStatus.SUCCESS
+        elif success_count > 0:
+            result.status = ApplyStatus.PARTIAL
+        else:
+            result.status = ApplyStatus.FAILED
+
+        result.summary = f"Applied {success_count}/{success_count + failure_count} operations."
+        result.total_ms = (time.monotonic() - total_start) * 1000
+
+        return result

--- a/src/cad_dxf_agent/core/comparison/scorer.py
+++ b/src/cad_dxf_agent/core/comparison/scorer.py
@@ -6,6 +6,7 @@ import math
 
 from ...models.cad_schema import EntityType, Point2D
 from ...models.comparison_schema import GeometrySnapshot, MatchExplanation, MatchMethod
+from ..text_utils import levenshtein_similarity as _levenshtein_similarity
 from .canonical import GeometrySignature, QuantizationConfig, compute_signature
 
 # --- Weight constants (alignment.py pattern) ---
@@ -340,36 +341,5 @@ def _proximity_score(a: Point2D, b: Point2D, tolerance: float) -> float:
     return max(0.0, 1.0 - d / tolerance)
 
 
-def _levenshtein_similarity(s1: str, s2: str) -> float:
-    """Levenshtein similarity ratio (0-1, where 1 = identical)."""
-    if s1 == s2:
-        return 1.0
-    if not s1 or not s2:
-        return 0.0
 
-    max_len = max(len(s1), len(s2))
-    distance = _levenshtein_distance(s1, s2)
-    return 1.0 - distance / max_len
-
-
-def _levenshtein_distance(s1: str, s2: str) -> int:
-    """Compute Levenshtein edit distance between two strings."""
-    if len(s1) < len(s2):
-        return _levenshtein_distance(s2, s1)
-
-    prev_row = list(range(len(s2) + 1))
-    for i, c1 in enumerate(s1):
-        curr_row = [i + 1]
-        for j, c2 in enumerate(s2):
-            # Insert, delete, or substitute
-            cost = 0 if c1 == c2 else 1
-            curr_row.append(
-                min(
-                    curr_row[j] + 1,  # insert
-                    prev_row[j + 1] + 1,  # delete
-                    prev_row[j] + cost,  # substitute
-                )
-            )
-        prev_row = curr_row
-
-    return prev_row[-1]
+# _levenshtein_similarity and _levenshtein_distance moved to core/text_utils.py

--- a/src/cad_dxf_agent/core/comparison/scorer.py
+++ b/src/cad_dxf_agent/core/comparison/scorer.py
@@ -341,5 +341,4 @@ def _proximity_score(a: Point2D, b: Point2D, tolerance: float) -> float:
     return max(0.0, 1.0 - d / tolerance)
 
 
-
 # _levenshtein_similarity and _levenshtein_distance moved to core/text_utils.py

--- a/src/cad_dxf_agent/core/plan_converter.py
+++ b/src/cad_dxf_agent/core/plan_converter.py
@@ -1,0 +1,98 @@
+"""Plan converter — bridges EditPlan (EPIC-07) to legacy ChangeSet.
+
+Converts typed EditAction objects into EditOperation objects that the
+existing EditEngine can apply. Preserves action order and returns an
+index map for correlating results back to actions.
+"""
+
+from __future__ import annotations
+
+from ..models.cad_schema import DrawingContext
+from ..models.ops_schema import ChangeSet, EditOperation, OpType
+from ..models.plan_schema import EditAction, EditActionType, EditPlan, PlanValidationStatus
+
+_ACTION_TO_OP: dict[EditActionType, OpType] = {
+    EditActionType.MOVE_ENTITY: OpType.MOVE_ENTITY,
+    EditActionType.EDIT_TEXT: OpType.EDIT_TEXT,
+    EditActionType.DELETE_ENTITY: OpType.DELETE_ENTITY,
+    EditActionType.ADD_BLOCK: OpType.ADD_BLOCK,
+    EditActionType.REPLICATE_NOTE: OpType.ADD_BLOCK,
+}
+
+
+def plan_to_changeset(
+    plan: EditPlan,
+    context: DrawingContext | None = None,
+) -> tuple[ChangeSet, dict[int, int]]:
+    """Convert an EditPlan into a ChangeSet for the legacy EditEngine.
+
+    Returns (changeset, action_index_map) where action_index_map maps
+    changeset operation index → plan action index.
+
+    Blocked actions are skipped. REPLICATE_NOTE is converted to ADD_BLOCK
+    by looking up the source entity's block_name via context.
+    """
+    operations: list[EditOperation] = []
+    action_index_map: dict[int, int] = {}
+
+    for action_idx, action in enumerate(plan.actions):
+        if action.validation.status == PlanValidationStatus.BLOCKED:
+            continue
+
+        op = _convert_action(action, context)
+        if op is not None:
+            op_idx = len(operations)
+            operations.append(op)
+            action_index_map[op_idx] = action_idx
+
+    changeset = ChangeSet(
+        operations=operations,
+        prompt=plan.prompt,
+    )
+    return changeset, action_index_map
+
+
+def _convert_action(
+    action: EditAction,
+    context: DrawingContext | None,
+) -> EditOperation | None:
+    """Convert a single EditAction to an EditOperation."""
+    op_type = _ACTION_TO_OP.get(action.action_type)
+    if op_type is None:
+        return None
+
+    params = dict(action.params)
+
+    if action.action_type == EditActionType.REPLICATE_NOTE:
+        params = _build_replicate_params(action, context)
+
+    return EditOperation(
+        op_type=op_type,
+        target_handle=action.target_handle,
+        target_layer=action.target_layer,
+        params=params,
+    )
+
+
+def _build_replicate_params(
+    action: EditAction,
+    context: DrawingContext | None,
+) -> dict:
+    """Build ADD_BLOCK params from a REPLICATE_NOTE action."""
+    params: dict = {}
+
+    # Get block_name from source entity via context
+    source_handles = action.params.get("source_handles", [])
+    block_name = action.params.get("block_name", "")
+
+    if not block_name and context and source_handles:
+        for handle in source_handles:
+            entity = context.get_entity_by_handle(handle)
+            if entity and entity.block_name:
+                block_name = entity.block_name
+                break
+
+    params["block_name"] = block_name
+    params["insert_point"] = action.params.get("target_centroid", {"x": 0, "y": 0})
+
+    return params

--- a/src/cad_dxf_agent/core/plan_validator.py
+++ b/src/cad_dxf_agent/core/plan_validator.py
@@ -13,6 +13,7 @@ Validates EditPlan actions against:
 from __future__ import annotations
 
 import logging
+import math
 
 from ..models.cad_schema import DrawingContext, EntityType
 from ..models.config_schema import RuleConfig
@@ -179,15 +180,16 @@ class PlanValidator:
         elif dx == 0 and dy == 0:
             warnings.append("Zero displacement — entity won't move")
 
-        if self._rules.max_move_distance is not None:
-            import math
-
-            if isinstance(dx, (int, float)) and isinstance(dy, (int, float)):
-                dist = math.sqrt(dx**2 + dy**2)
-                if dist > self._rules.max_move_distance:
-                    warnings.append(
-                        f"Move distance {dist:.1f} exceeds max {self._rules.max_move_distance}"
-                    )
+        if (
+            self._rules.max_move_distance is not None
+            and isinstance(dx, (int, float))
+            and isinstance(dy, (int, float))
+        ):
+            dist = math.sqrt(dx**2 + dy**2)
+            if dist > self._rules.max_move_distance:
+                warnings.append(
+                    f"Move distance {dist:.1f} exceeds max {self._rules.max_move_distance}"
+                )
 
     def _validate_edit_text_params(self, action: EditAction, blockers: list[str]) -> None:
         """Validate edit_text params."""

--- a/src/cad_dxf_agent/core/plan_validator.py
+++ b/src/cad_dxf_agent/core/plan_validator.py
@@ -1,0 +1,275 @@
+"""Plan validator — enforces drawing constraints on structured edit plans.
+
+Validates EditPlan actions against:
+- protected layer rules
+- unsupported entity/action combinations
+- low-confidence targeting
+- missing evidence/references
+- repeated-condition batch approval requirements
+- text trust issues (SQ67 provenance)
+- ambiguity that should block or require confirmation
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..models.cad_schema import DrawingContext, EntityType
+from ..models.config_schema import RuleConfig
+from ..models.plan_schema import (
+    ActionValidationDetail,
+    ApprovalRequirement,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+from .entity_index import EntityIndex
+
+logger = logging.getLogger(__name__)
+
+_TEXT_TYPES = frozenset({EntityType.TEXT, EntityType.MTEXT})
+
+# Actions that only make sense on specific entity types
+_ACTION_ENTITY_CONSTRAINTS: dict[EditActionType, frozenset[EntityType] | None] = {
+    EditActionType.EDIT_TEXT: _TEXT_TYPES,
+    EditActionType.MOVE_ENTITY: None,  # any entity can be moved
+    EditActionType.DELETE_ENTITY: None,  # any entity can be deleted
+    EditActionType.ADD_BLOCK: None,  # no existing entity needed
+    EditActionType.REPLICATE_NOTE: None,  # handled separately
+}
+
+
+class PlanValidator:
+    """Validates edit plans against drawing constraints and rules.
+
+    Does not modify the plan — returns validation results that can be
+    applied by the caller.
+    """
+
+    def __init__(
+        self,
+        context: DrawingContext,
+        rules: RuleConfig | None = None,
+    ) -> None:
+        self._context = context
+        self._rules = rules or RuleConfig()
+        self._index = EntityIndex(context)
+        self._protected_upper = [
+            layer.upper() for layer in self._rules.protected_layers
+        ]
+
+    def validate(self, plan: EditPlan) -> EditPlan:
+        """Validate all actions in a plan. Mutates and returns the plan.
+
+        Sets validation status, blockers, and warnings on each action
+        and on the plan itself.
+        """
+        plan_blockers: list[str] = []
+        plan_warnings: list[str] = []
+
+        for action in plan.actions:
+            detail = self._validate_action(action)
+            action.validation = detail
+
+        # Aggregate plan-level status
+        action_statuses = [a.validation.status for a in plan.actions]
+
+        if PlanValidationStatus.BLOCKED in action_statuses:
+            plan.validation_status = PlanValidationStatus.BLOCKED
+            for a in plan.actions:
+                plan_blockers.extend(a.validation.blockers)
+        elif PlanValidationStatus.NEEDS_CLARIFICATION in action_statuses:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+        elif PlanValidationStatus.VALID_WITH_WARNINGS in action_statuses:
+            plan.validation_status = PlanValidationStatus.VALID_WITH_WARNINGS
+        else:
+            plan.validation_status = PlanValidationStatus.VALID
+
+        # Check plan-level constraints
+        self._check_plan_level(plan, plan_blockers, plan_warnings)
+
+        plan.blocked_reasons.extend(plan_blockers)
+        for w in plan_warnings:
+            if w not in plan.ambiguity_flags:
+                plan.ambiguity_flags.append(w)
+
+        return plan
+
+    def _validate_action(self, action: EditAction) -> ActionValidationDetail:
+        """Validate a single action against drawing constraints."""
+        detail = ActionValidationDetail()
+        blockers: list[str] = []
+        warnings: list[str] = []
+
+        # ADD_BLOCK doesn't need existing entity validation
+        if action.action_type == EditActionType.ADD_BLOCK:
+            self._validate_add_block(action, blockers, warnings)
+        elif action.action_type == EditActionType.REPLICATE_NOTE:
+            self._validate_replicate(action, blockers, warnings)
+        else:
+            # All other actions need a target entity
+            if not action.target_handle:
+                blockers.append(
+                    f"{action.action_type.value} requires a target entity handle"
+                )
+            else:
+                entity = self._index.get_by_handle(action.target_handle)
+                if entity is None:
+                    blockers.append(
+                        f"Target entity not found: {action.target_handle}"
+                    )
+                else:
+                    # Protected layer check
+                    if entity.layer.upper() in self._protected_upper:
+                        blockers.append(
+                            f"Cannot edit entity on protected layer: {entity.layer}"
+                        )
+
+                    # Entity/action compatibility
+                    allowed_types = _ACTION_ENTITY_CONSTRAINTS.get(
+                        action.action_type
+                    )
+                    if allowed_types is not None and entity.entity_type not in allowed_types:
+                        blockers.append(
+                            f"{action.action_type.value} not supported on "
+                            f"{entity.entity_type.value} entities"
+                        )
+
+                    # Text trust check
+                    if (
+                        action.action_type == EditActionType.EDIT_TEXT
+                        and entity.text_geometry
+                        and entity.text_geometry.confidence_content < 0.5
+                    ):
+                        warnings.append(
+                            f"Low text trust ({entity.text_geometry.confidence_content:.2f}) — "
+                            "OCR-derived text may not match exact content"
+                        )
+
+                    # Move-specific validation
+                    if action.action_type == EditActionType.MOVE_ENTITY:
+                        self._validate_move_params(action, warnings)
+
+                    # Edit text validation
+                    if action.action_type == EditActionType.EDIT_TEXT:
+                        self._validate_edit_text_params(action, blockers)
+
+        # Low confidence check
+        if action.confidence < 0.5:
+            warnings.append(
+                f"Low confidence ({action.confidence:.2f}) — "
+                "result may not match intent"
+            )
+
+        # Missing evidence check
+        if not action.evidence and action.action_type not in (
+            EditActionType.ADD_BLOCK,
+            EditActionType.REPLICATE_NOTE,
+        ):
+            warnings.append("No evidence references for this action")
+
+        detail.blockers = blockers
+        detail.warnings = warnings
+
+        if blockers:
+            detail.status = PlanValidationStatus.BLOCKED
+        elif warnings:
+            detail.status = PlanValidationStatus.VALID_WITH_WARNINGS
+        else:
+            detail.status = PlanValidationStatus.VALID
+
+        return detail
+
+    def _validate_move_params(
+        self, action: EditAction, warnings: list[str]
+    ) -> None:
+        """Validate move_entity params."""
+        dx = action.params.get("dx")
+        dy = action.params.get("dy")
+        if dx is None or dy is None:
+            warnings.append("Move displacement (dx, dy) not specified")
+        elif dx == 0 and dy == 0:
+            warnings.append("Zero displacement — entity won't move")
+
+        if self._rules.max_move_distance is not None:
+            import math
+
+            if isinstance(dx, (int, float)) and isinstance(dy, (int, float)):
+                dist = math.sqrt(dx**2 + dy**2)
+                if dist > self._rules.max_move_distance:
+                    warnings.append(
+                        f"Move distance {dist:.1f} exceeds max "
+                        f"{self._rules.max_move_distance}"
+                    )
+
+    def _validate_edit_text_params(
+        self, action: EditAction, blockers: list[str]
+    ) -> None:
+        """Validate edit_text params."""
+        new_text = action.params.get("new_text")
+        if new_text is None:
+            blockers.append("edit_text requires new_text parameter")
+        elif not isinstance(new_text, str):
+            blockers.append("new_text must be a string")
+
+    def _validate_add_block(
+        self, action: EditAction, blockers: list[str], warnings: list[str]
+    ) -> None:
+        """Validate add_block action."""
+        if not action.params.get("block_name") and not action.params.get(
+            "insert_point"
+        ):
+            warnings.append("Block name and insert point not fully specified")
+
+        target_layer = action.target_layer
+        if target_layer and target_layer.upper() in self._protected_upper:
+            blockers.append(
+                f"Cannot insert on protected layer: {target_layer}"
+            )
+
+    def _validate_replicate(
+        self, action: EditAction, blockers: list[str], warnings: list[str]
+    ) -> None:
+        """Validate replicate_note action."""
+        source = action.params.get("source_handles")
+        target = action.params.get("target_centroid")
+        if not source:
+            blockers.append("Replicate requires source_handles")
+        if not target:
+            blockers.append("Replicate requires target_centroid")
+
+    def _check_plan_level(
+        self,
+        plan: EditPlan,
+        blockers: list[str],
+        warnings: list[str],
+    ) -> None:
+        """Check plan-level constraints."""
+        # Batch replication requires prior approval evidence
+        replicate_actions = [
+            a
+            for a in plan.actions
+            if a.action_type == EditActionType.REPLICATE_NOTE
+        ]
+        if replicate_actions:
+            has_approval = any(
+                req.category == "repeated_condition_approval" and req.satisfied
+                for req in plan.approval_requirements
+            )
+            if not has_approval and not any(
+                req.category == "batch_confirmation"
+                for req in plan.approval_requirements
+            ):
+                plan.approval_requirements.append(
+                    ApprovalRequirement(
+                        description="Batch replication requires approval of target locations",
+                        category="batch_confirmation",
+                    )
+                )
+
+        # Too many actions warning
+        if len(plan.actions) > 20:
+            warnings.append(
+                f"Large plan ({len(plan.actions)} actions) — review carefully"
+            )

--- a/src/cad_dxf_agent/core/plan_validator.py
+++ b/src/cad_dxf_agent/core/plan_validator.py
@@ -55,9 +55,7 @@ class PlanValidator:
         self._context = context
         self._rules = rules or RuleConfig()
         self._index = EntityIndex(context)
-        self._protected_upper = [
-            layer.upper() for layer in self._rules.protected_layers
-        ]
+        self._protected_upper = [layer.upper() for layer in self._rules.protected_layers]
 
     def validate(self, plan: EditPlan) -> EditPlan:
         """Validate all actions in a plan. Mutates and returns the plan.
@@ -110,26 +108,18 @@ class PlanValidator:
         else:
             # All other actions need a target entity
             if not action.target_handle:
-                blockers.append(
-                    f"{action.action_type.value} requires a target entity handle"
-                )
+                blockers.append(f"{action.action_type.value} requires a target entity handle")
             else:
                 entity = self._index.get_by_handle(action.target_handle)
                 if entity is None:
-                    blockers.append(
-                        f"Target entity not found: {action.target_handle}"
-                    )
+                    blockers.append(f"Target entity not found: {action.target_handle}")
                 else:
                     # Protected layer check
                     if entity.layer.upper() in self._protected_upper:
-                        blockers.append(
-                            f"Cannot edit entity on protected layer: {entity.layer}"
-                        )
+                        blockers.append(f"Cannot edit entity on protected layer: {entity.layer}")
 
                     # Entity/action compatibility
-                    allowed_types = _ACTION_ENTITY_CONSTRAINTS.get(
-                        action.action_type
-                    )
+                    allowed_types = _ACTION_ENTITY_CONSTRAINTS.get(action.action_type)
                     if allowed_types is not None and entity.entity_type not in allowed_types:
                         blockers.append(
                             f"{action.action_type.value} not supported on "
@@ -158,8 +148,7 @@ class PlanValidator:
         # Low confidence check
         if action.confidence < 0.5:
             warnings.append(
-                f"Low confidence ({action.confidence:.2f}) — "
-                "result may not match intent"
+                f"Low confidence ({action.confidence:.2f}) — result may not match intent"
             )
 
         # Missing evidence check
@@ -181,9 +170,7 @@ class PlanValidator:
 
         return detail
 
-    def _validate_move_params(
-        self, action: EditAction, warnings: list[str]
-    ) -> None:
+    def _validate_move_params(self, action: EditAction, warnings: list[str]) -> None:
         """Validate move_entity params."""
         dx = action.params.get("dx")
         dy = action.params.get("dy")
@@ -199,13 +186,10 @@ class PlanValidator:
                 dist = math.sqrt(dx**2 + dy**2)
                 if dist > self._rules.max_move_distance:
                     warnings.append(
-                        f"Move distance {dist:.1f} exceeds max "
-                        f"{self._rules.max_move_distance}"
+                        f"Move distance {dist:.1f} exceeds max {self._rules.max_move_distance}"
                     )
 
-    def _validate_edit_text_params(
-        self, action: EditAction, blockers: list[str]
-    ) -> None:
+    def _validate_edit_text_params(self, action: EditAction, blockers: list[str]) -> None:
         """Validate edit_text params."""
         new_text = action.params.get("new_text")
         if new_text is None:
@@ -217,16 +201,12 @@ class PlanValidator:
         self, action: EditAction, blockers: list[str], warnings: list[str]
     ) -> None:
         """Validate add_block action."""
-        if not action.params.get("block_name") and not action.params.get(
-            "insert_point"
-        ):
+        if not action.params.get("block_name") and not action.params.get("insert_point"):
             warnings.append("Block name and insert point not fully specified")
 
         target_layer = action.target_layer
         if target_layer and target_layer.upper() in self._protected_upper:
-            blockers.append(
-                f"Cannot insert on protected layer: {target_layer}"
-            )
+            blockers.append(f"Cannot insert on protected layer: {target_layer}")
 
     def _validate_replicate(
         self, action: EditAction, blockers: list[str], warnings: list[str]
@@ -248,9 +228,7 @@ class PlanValidator:
         """Check plan-level constraints."""
         # Batch replication requires prior approval evidence
         replicate_actions = [
-            a
-            for a in plan.actions
-            if a.action_type == EditActionType.REPLICATE_NOTE
+            a for a in plan.actions if a.action_type == EditActionType.REPLICATE_NOTE
         ]
         if replicate_actions:
             has_approval = any(
@@ -258,8 +236,7 @@ class PlanValidator:
                 for req in plan.approval_requirements
             )
             if not has_approval and not any(
-                req.category == "batch_confirmation"
-                for req in plan.approval_requirements
+                req.category == "batch_confirmation" for req in plan.approval_requirements
             ):
                 plan.approval_requirements.append(
                     ApprovalRequirement(
@@ -270,6 +247,4 @@ class PlanValidator:
 
         # Too many actions warning
         if len(plan.actions) > 20:
-            warnings.append(
-                f"Large plan ({len(plan.actions)} actions) — review carefully"
-            )
+            warnings.append(f"Large plan ({len(plan.actions)} actions) — review carefully")

--- a/src/cad_dxf_agent/core/preview_builder.py
+++ b/src/cad_dxf_agent/core/preview_builder.py
@@ -1,0 +1,206 @@
+"""Edit preview builder — generates before/after previews from EditPlans.
+
+Looks up entity state from the DrawingContext via EntityIndex and builds
+a typed EditPreview with per-action before/after diffs.
+"""
+
+from __future__ import annotations
+
+import time
+
+from ..models.cad_schema import DrawingContext
+from ..models.plan_schema import EditAction, EditActionType, EditPlan
+from ..models.preview_schema import ActionPreview, EditPreview, PreviewStatus
+from ..models.response_schema import RiskLevel
+from .entity_index import EntityIndex
+
+
+class EditPreviewBuilder:
+    """Builds EditPreview objects from EditPlan + DrawingContext."""
+
+    def __init__(self, context: DrawingContext) -> None:
+        self._context = context
+        self._index = EntityIndex(context)
+
+    def build(self, plan: EditPlan) -> EditPreview:
+        """Build a preview of what the plan will do."""
+        start = time.monotonic()
+
+        preview = EditPreview(
+            plan_id=plan.plan_id,
+            request_id=plan.request_id,
+            requires_approval=plan.requires_approval,
+            approval_requirements=[r.description for r in plan.approval_requirements],
+        )
+
+        # Early return for blocked/unclear plans
+        if plan.is_blocked:
+            preview.status = PreviewStatus.BLOCKED
+            preview.summary = "Plan is blocked: " + "; ".join(plan.blocked_reasons)
+            preview.warnings = list(plan.blocked_reasons)
+            preview.preview_build_ms = (time.monotonic() - start) * 1000
+            return preview
+
+        if plan.needs_clarification:
+            preview.status = PreviewStatus.NEEDS_CLARIFICATION
+            preview.summary = plan.rationale or "Plan needs clarification."
+            preview.warnings = list(plan.blocked_reasons)
+            preview.preview_build_ms = (time.monotonic() - start) * 1000
+            return preview
+
+        # Build per-action previews
+        action_previews: list[ActionPreview] = []
+        for action in plan.actions:
+            ap = self._build_action_preview(action)
+            action_previews.append(ap)
+
+        preview.actions = action_previews
+        preview.total_actions = len(action_previews)
+        preview.destructive_count = sum(1 for a in action_previews if a.is_destructive)
+        preview.blocked_count = sum(1 for a in action_previews if a.validation_status == "blocked")
+
+        # Aggregates
+        if action_previews:
+            preview.confidence = min(a.confidence for a in action_previews)
+            risk_order = {
+                RiskLevel.NONE: 0,
+                RiskLevel.LOW: 1,
+                RiskLevel.MEDIUM: 2,
+                RiskLevel.HIGH: 3,
+            }
+            preview.risk_level = max(
+                (a.risk_level for a in action_previews),
+                key=lambda r: risk_order.get(r, 0),
+            )
+
+        # Collect warnings
+        all_warnings: list[str] = []
+        for ap in action_previews:
+            all_warnings.extend(ap.warnings)
+        preview.warnings = all_warnings
+
+        # Summary
+        preview.summary = self._build_summary(action_previews)
+
+        preview.preview_build_ms = (time.monotonic() - start) * 1000
+        return preview
+
+    def _build_action_preview(self, action: EditAction) -> ActionPreview:
+        """Build preview for a single action."""
+        entity = None
+        if action.target_handle:
+            entity = self._index.get_by_handle(action.target_handle)
+
+        before: dict = {}
+        after: dict = {}
+        is_destructive = False
+        warnings: list[str] = []
+
+        if action.action_type == EditActionType.MOVE_ENTITY:
+            before, after = self._preview_move(action, entity)
+        elif action.action_type == EditActionType.EDIT_TEXT:
+            before, after = self._preview_edit_text(action, entity)
+        elif action.action_type == EditActionType.DELETE_ENTITY:
+            before, after, is_destructive = self._preview_delete(action, entity)
+        elif action.action_type == EditActionType.ADD_BLOCK:
+            before, after = self._preview_add_block(action)
+        elif action.action_type == EditActionType.REPLICATE_NOTE:
+            before, after = self._preview_replicate(action)
+
+        if action.target_handle and entity is None:
+            warnings.append(f"Entity {action.target_handle} not found in drawing")
+
+        # Forward action-level warnings
+        warnings.extend(action.validation.warnings)
+
+        return ActionPreview(
+            action_id=action.action_id,
+            action_type=action.action_type.value,
+            description=action.rationale,
+            target_handle=action.target_handle,
+            target_layer=action.target_layer or (entity.layer if entity else None),
+            target_entity_type=action.target_entity_type
+            or (entity.entity_type.value if entity else None),
+            before_state=before,
+            after_state=after,
+            confidence=action.confidence,
+            risk_level=action.risk_level,
+            is_destructive=is_destructive,
+            warnings=warnings,
+            ambiguity=list(action.ambiguity),
+            validation_status=action.validation.status.value,
+            blockers=list(action.validation.blockers),
+        )
+
+    def _preview_move(self, action: EditAction, entity) -> tuple[dict, dict]:
+        dx = action.params.get("dx", 0)
+        dy = action.params.get("dy", 0)
+        before: dict = {}
+        after: dict = {}
+
+        if entity and entity.insert_point:
+            before = {"position": {"x": entity.insert_point.x, "y": entity.insert_point.y}}
+            after = {
+                "position": {
+                    "x": entity.insert_point.x + dx,
+                    "y": entity.insert_point.y + dy,
+                },
+                "delta": {"dx": dx, "dy": dy},
+            }
+        else:
+            before = {"position": None}
+            after = {"delta": {"dx": dx, "dy": dy}}
+
+        return before, after
+
+    def _preview_edit_text(self, action: EditAction, entity) -> tuple[dict, dict]:
+        new_text = action.params.get("new_text", "")
+        old_text = entity.text_content if entity else None
+        before = {"text": old_text}
+        after = {"text": new_text}
+        return before, after
+
+    def _preview_delete(self, action: EditAction, entity) -> tuple[dict, dict, bool]:
+        before: dict = {}
+        if entity:
+            before = {
+                "entity_type": entity.entity_type.value,
+                "layer": entity.layer,
+            }
+            if entity.insert_point:
+                before["position"] = {
+                    "x": entity.insert_point.x,
+                    "y": entity.insert_point.y,
+                }
+            if entity.text_content:
+                before["text"] = entity.text_content
+        return before, {}, True
+
+    def _preview_add_block(self, action: EditAction) -> tuple[dict, dict]:
+        block_name = action.params.get("block_name", "")
+        insert_point = action.params.get("insert_point", {})
+        after = {"block_name": block_name, "insert_point": insert_point}
+        return {}, after
+
+    def _preview_replicate(self, action: EditAction) -> tuple[dict, dict]:
+        source_handles = action.params.get("source_handles", [])
+        target_centroid = action.params.get("target_centroid", {})
+        before = {"source_handles": source_handles}
+        after = {"target_centroid": target_centroid}
+        return before, after
+
+    @staticmethod
+    def _build_summary(previews: list[ActionPreview]) -> str:
+        if not previews:
+            return "No actions to preview."
+
+        parts: list[str] = []
+        type_counts: dict[str, int] = {}
+        for p in previews:
+            type_counts[p.action_type] = type_counts.get(p.action_type, 0) + 1
+
+        for atype, count in type_counts.items():
+            label = atype.replace("_", " ")
+            parts.append(f"{count} {label}" if count > 1 else label)
+
+        return ", ".join(parts).capitalize()

--- a/src/cad_dxf_agent/core/region_context.py
+++ b/src/cad_dxf_agent/core/region_context.py
@@ -90,11 +90,12 @@ class RegionContextBuilder:
         ambiguity_flags: list[str],
         bounds: BoundingBox | None,
     ) -> RegionContext:
-        # Cap entities
+        # Cap entities — reduce confidence when truncating (ARCH-REVIEW-CAD-01 P1)
         truncated = len(entities) > self._max_entities
         if truncated:
             entities = entities[: self._max_entities]
             ambiguity_flags.append("context_truncated")
+            confidence = max(0.0, confidence - 0.2)
 
         # Categorize by type
         text_entities = [e for e in entities if e.entity_type in _TEXT_TYPES]

--- a/src/cad_dxf_agent/core/repeated_condition.py
+++ b/src/cad_dxf_agent/core/repeated_condition.py
@@ -714,5 +714,4 @@ def _describe_entity(entity: EntityRef) -> str:
     return " ".join(parts)
 
 
-
 # _levenshtein_similarity and _levenshtein_distance moved to core/text_utils.py

--- a/src/cad_dxf_agent/core/repeated_condition.py
+++ b/src/cad_dxf_agent/core/repeated_condition.py
@@ -27,6 +27,7 @@ from ..models.repeated_condition_schema import (
 )
 from ..models.response_schema import EvidenceRef
 from .entity_index import EntityIndex
+from .text_utils import levenshtein_similarity as _levenshtein_similarity
 
 logger = logging.getLogger(__name__)
 
@@ -713,32 +714,5 @@ def _describe_entity(entity: EntityRef) -> str:
     return " ".join(parts)
 
 
-def _levenshtein_similarity(s1: str, s2: str) -> float:
-    """Normalized Levenshtein similarity [0-1]."""
-    if s1 == s2:
-        return 1.0
-    if not s1 or not s2:
-        return 0.0
-    max_len = max(len(s1), len(s2))
-    distance = _levenshtein_distance(s1, s2)
-    return 1.0 - distance / max_len
 
-
-def _levenshtein_distance(s1: str, s2: str) -> int:
-    """Levenshtein edit distance."""
-    if len(s1) < len(s2):
-        return _levenshtein_distance(s2, s1)
-    prev_row = list(range(len(s2) + 1))
-    for i, c1 in enumerate(s1):
-        curr_row = [i + 1]
-        for j, c2 in enumerate(s2):
-            cost = 0 if c1 == c2 else 1
-            curr_row.append(
-                min(
-                    curr_row[j] + 1,
-                    prev_row[j + 1] + 1,
-                    prev_row[j] + cost,
-                )
-            )
-        prev_row = curr_row
-    return prev_row[-1]
+# _levenshtein_similarity and _levenshtein_distance moved to core/text_utils.py

--- a/src/cad_dxf_agent/core/text_utils.py
+++ b/src/cad_dxf_agent/core/text_utils.py
@@ -70,10 +70,6 @@ def entity_to_evidence(entity: EntityRef) -> EvidenceRef:
         layer=entity.layer,
         entity_type=entity.entity_type.value,
         description=describe_entity(entity),
-        location=(
-            (entity.insert_point.x, entity.insert_point.y) if entity.insert_point else None
-        ),
-        text_excerpt=(
-            entity.text_content[:100] if entity.text_content else None
-        ),
+        location=((entity.insert_point.x, entity.insert_point.y) if entity.insert_point else None),
+        text_excerpt=(entity.text_content[:100] if entity.text_content else None),
     )

--- a/src/cad_dxf_agent/core/text_utils.py
+++ b/src/cad_dxf_agent/core/text_utils.py
@@ -1,0 +1,79 @@
+"""Shared text utilities — Levenshtein distance, entity description, evidence construction.
+
+Extracted from scorer.py and repeated_condition.py to eliminate duplication
+(ARCH-REVIEW-CAD-01 prerequisite P1).
+"""
+
+from __future__ import annotations
+
+from ..models.cad_schema import EntityRef
+from ..models.response_schema import EvidenceRef
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Compute Levenshtein edit distance between two strings."""
+    if len(s1) < len(s2):
+        return levenshtein_distance(s2, s1)
+
+    prev_row = list(range(len(s2) + 1))
+    for i, c1 in enumerate(s1):
+        curr_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            cost = 0 if c1 == c2 else 1
+            curr_row.append(
+                min(
+                    curr_row[j] + 1,
+                    prev_row[j + 1] + 1,
+                    prev_row[j] + cost,
+                )
+            )
+        prev_row = curr_row
+
+    return prev_row[-1]
+
+
+def levenshtein_similarity(s1: str, s2: str) -> float:
+    """Levenshtein similarity ratio (0-1, where 1 = identical)."""
+    if s1 == s2:
+        return 1.0
+    if not s1 or not s2:
+        return 0.0
+
+    max_len = max(len(s1), len(s2))
+    distance = levenshtein_distance(s1, s2)
+    return 1.0 - distance / max_len
+
+
+def describe_entity(entity: EntityRef) -> str:
+    """Canonical one-line description of an entity for evidence/explanations."""
+    parts = [entity.entity_type.value]
+    if entity.layer:
+        parts.append(f"on layer '{entity.layer}'")
+    if entity.text_content:
+        preview = entity.text_content[:50]
+        if len(entity.text_content) > 50:
+            preview += "..."
+        parts.append(f"text='{preview}'")
+    if entity.block_name:
+        parts.append(f"block='{entity.block_name}'")
+    if entity.insert_point:
+        parts.append(f"at ({entity.insert_point.x:.1f}, {entity.insert_point.y:.1f})")
+    if entity.text_geometry:
+        parts.append(f"provenance={entity.text_geometry.provenance.value}")
+    return " ".join(parts)
+
+
+def entity_to_evidence(entity: EntityRef) -> EvidenceRef:
+    """Convert an EntityRef to an EvidenceRef for response payloads."""
+    return EvidenceRef(
+        entity_handle=entity.handle,
+        layer=entity.layer,
+        entity_type=entity.entity_type.value,
+        description=describe_entity(entity),
+        location=(
+            (entity.insert_point.x, entity.insert_point.y) if entity.insert_point else None
+        ),
+        text_excerpt=(
+            entity.text_content[:100] if entity.text_content else None
+        ),
+    )

--- a/src/cad_dxf_agent/llm/plan_builder.py
+++ b/src/cad_dxf_agent/llm/plan_builder.py
@@ -106,20 +106,14 @@ class EditPlanBuilder:
 
     # --- Request classification ---
 
-    _MOVE_PATTERN = re.compile(
-        r"\b(move|shift|relocate|reposition)\b", re.IGNORECASE
-    )
-    _DELETE_PATTERN = re.compile(
-        r"\b(delete|remove|erase|clear)\b", re.IGNORECASE
-    )
+    _MOVE_PATTERN = re.compile(r"\b(move|shift|relocate|reposition)\b", re.IGNORECASE)
+    _DELETE_PATTERN = re.compile(r"\b(delete|remove|erase|clear)\b", re.IGNORECASE)
     _TEXT_EDIT_PATTERN = re.compile(
         r"\b(change\s+text|rename|update\s+text|edit\s+text|"
         r"replace\s+text|set\s+text|change\s+.*\s+to)\b",
         re.IGNORECASE,
     )
-    _ADD_PATTERN = re.compile(
-        r"\b(add|insert|place|create|replicate|copy\s+to)\b", re.IGNORECASE
-    )
+    _ADD_PATTERN = re.compile(r"\b(add|insert|place|create|replicate|copy\s+to)\b", re.IGNORECASE)
 
     def _is_move_request(self, prompt: str) -> bool:
         return bool(self._MOVE_PATTERN.search(prompt))
@@ -155,9 +149,7 @@ class EditPlanBuilder:
                 target_layer=entity.layer,
                 target_entity_type=entity.entity_type.value,
                 region_id=(
-                    request.selected_regions[0].region_id
-                    if request.selected_regions
-                    else None
+                    request.selected_regions[0].region_id if request.selected_regions else None
                 ),
                 params={"dx": dx, "dy": dy},
                 evidence=[entity_to_evidence(entity)],
@@ -196,9 +188,7 @@ class EditPlanBuilder:
                 target_layer=entity.layer,
                 target_entity_type=entity.entity_type.value,
                 region_id=(
-                    request.selected_regions[0].region_id
-                    if request.selected_regions
-                    else None
+                    request.selected_regions[0].region_id if request.selected_regions else None
                 ),
                 params={},
                 evidence=[entity_to_evidence(entity)],
@@ -217,9 +207,7 @@ class EditPlanBuilder:
             )
         )
 
-    def _build_text_edit_plan(
-        self, plan: EditPlan, request: PlanRequest
-    ) -> None:
+    def _build_text_edit_plan(self, plan: EditPlan, request: PlanRequest) -> None:
         """Build a text edit plan for TEXT/MTEXT entities."""
         targets = self._resolve_targets(request)
         text_targets = [t for t in targets if t.entity_type in _TEXT_TYPES]
@@ -227,9 +215,7 @@ class EditPlanBuilder:
         if not text_targets:
             if targets:
                 plan.validation_status = PlanValidationStatus.BLOCKED
-                plan.blocked_reasons.append(
-                    "Target entities are not text (TEXT/MTEXT)"
-                )
+                plan.blocked_reasons.append("Target entities are not text (TEXT/MTEXT)")
                 plan.rationale = "Cannot edit text on non-text entities."
             else:
                 plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
@@ -298,8 +284,7 @@ class EditPlanBuilder:
             },
             evidence=[],
             rationale=(
-                f"Add element at region center"
-                f" ({region.center.x:.1f}, {region.center.y:.1f})"
+                f"Add element at region center ({region.center.x:.1f}, {region.center.y:.1f})"
             ),
             confidence=0.7,
             ambiguity=["block_name_not_specified"],
@@ -321,12 +306,8 @@ class EditPlanBuilder:
         if rc_result is None:
             return
 
-        approved = [
-            c for c in rc_result.candidates if c.approval_state == ApprovalState.APPROVED
-        ]
-        pending = [
-            c for c in rc_result.candidates if c.approval_state == ApprovalState.PENDING
-        ]
+        approved = [c for c in rc_result.candidates if c.approval_state == ApprovalState.APPROVED]
+        pending = [c for c in rc_result.candidates if c.approval_state == ApprovalState.PENDING]
 
         if not approved and pending:
             plan.validation_status = PlanValidationStatus.BLOCKED
@@ -353,11 +334,7 @@ class EditPlanBuilder:
         for candidate in approved:
             action = EditAction(
                 action_type=EditActionType.REPLICATE_NOTE,
-                target_handle=(
-                    candidate.entity_handles[0]
-                    if candidate.entity_handles
-                    else None
-                ),
+                target_handle=(candidate.entity_handles[0] if candidate.entity_handles else None),
                 params={
                     "source_handles": list(rc_result.exemplar_handles),
                     "target_centroid": {
@@ -386,9 +363,7 @@ class EditPlanBuilder:
             )
         )
 
-    def _build_unsupported_plan(
-        self, plan: EditPlan, request: PlanRequest
-    ) -> None:
+    def _build_unsupported_plan(self, plan: EditPlan, request: PlanRequest) -> None:
         """Return a needs_clarification plan for unrecognized requests."""
         plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
         plan.blocked_reasons.append("Request does not map to a supported edit action")
@@ -502,9 +477,7 @@ class EditPlanBuilder:
         plan.risk_level = max_risk.risk_level
 
         # Override if many deletes
-        delete_count = sum(
-            1 for a in plan.actions if a.action_type == EditActionType.DELETE_ENTITY
-        )
+        delete_count = sum(1 for a in plan.actions if a.action_type == EditActionType.DELETE_ENTITY)
         if delete_count > 5 or len(plan.actions) > 20:
             plan.risk_level = RiskLevel.HIGH
 

--- a/src/cad_dxf_agent/llm/plan_builder.py
+++ b/src/cad_dxf_agent/llm/plan_builder.py
@@ -1,0 +1,524 @@
+"""Edit plan builder — converts routed edit requests into structured plans.
+
+Deterministic-first: parses user requests into bounded action plans using
+pattern matching and drawing context. LLM is not called in this module.
+
+Supported request types:
+- move entity to position / by offset
+- change text content
+- delete entity / entities in region
+- replicate note to approved target regions
+- batch plan from approved repeated-condition matches
+
+Unsupported requests return NEEDS_CLARIFICATION or BLOCKED plans.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+
+from ..core.text_utils import describe_entity, entity_to_evidence
+from ..models.cad_schema import DrawingContext, EntityRef, EntityType
+from ..models.plan_schema import (
+    ApprovalRequirement,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+from ..models.region_schema import NormalizedRegion
+from ..models.repeated_condition_schema import (
+    ApprovalState,
+    RepeatedConditionResult,
+)
+from ..models.response_schema import RiskLevel
+
+logger = logging.getLogger(__name__)
+
+_TEXT_TYPES = frozenset({EntityType.TEXT, EntityType.MTEXT})
+
+
+@dataclass
+class PlanRequest:
+    """Input bundle for the plan builder."""
+
+    prompt: str
+    drawing_context: DrawingContext
+    request_id: str = ""
+    source_drawing: str | None = None
+    selected_regions: list[NormalizedRegion] | None = None
+    target_handles: list[str] | None = None
+    repeated_condition_result: RepeatedConditionResult | None = None
+
+
+class EditPlanBuilder:
+    """Builds structured edit plans from user requests and drawing context.
+
+    Uses deterministic parsing to convert supported requests into bounded
+    action plans. Does not call the LLM — all planning is rule-based.
+    """
+
+    def build(self, request: PlanRequest) -> EditPlan:
+        """Build an edit plan from a plan request.
+
+        Routes to the appropriate action generator based on request analysis.
+        """
+        start = time.monotonic()
+
+        plan = EditPlan(
+            request_id=request.request_id,
+            source_drawing=request.source_drawing,
+            prompt=request.prompt,
+        )
+
+        if request.selected_regions:
+            plan.selected_region_ids = [r.region_id for r in request.selected_regions]
+        if request.target_handles:
+            plan.entity_handles = list(request.target_handles)
+
+        # Route to appropriate builder
+        prompt_lower = request.prompt.lower().strip()
+
+        if request.repeated_condition_result is not None:
+            self._build_batch_plan(plan, request)
+        elif self._is_delete_request(prompt_lower):
+            self._build_delete_plan(plan, request)
+        elif self._is_move_request(prompt_lower):
+            self._build_move_plan(plan, request)
+        elif self._is_text_edit_request(prompt_lower):
+            self._build_text_edit_plan(plan, request)
+        elif self._is_add_request(prompt_lower):
+            self._build_add_plan(plan, request)
+        else:
+            self._build_unsupported_plan(plan, request)
+
+        elapsed = (time.monotonic() - start) * 1000
+        plan.latency.plan_build_ms = elapsed
+        plan.latency.total_ms = elapsed
+
+        # Compute aggregate confidence and risk
+        self._compute_aggregates(plan)
+
+        return plan
+
+    # --- Request classification ---
+
+    _MOVE_PATTERN = re.compile(
+        r"\b(move|shift|relocate|reposition)\b", re.IGNORECASE
+    )
+    _DELETE_PATTERN = re.compile(
+        r"\b(delete|remove|erase|clear)\b", re.IGNORECASE
+    )
+    _TEXT_EDIT_PATTERN = re.compile(
+        r"\b(change\s+text|rename|update\s+text|edit\s+text|"
+        r"replace\s+text|set\s+text|change\s+.*\s+to)\b",
+        re.IGNORECASE,
+    )
+    _ADD_PATTERN = re.compile(
+        r"\b(add|insert|place|create|replicate|copy\s+to)\b", re.IGNORECASE
+    )
+
+    def _is_move_request(self, prompt: str) -> bool:
+        return bool(self._MOVE_PATTERN.search(prompt))
+
+    def _is_delete_request(self, prompt: str) -> bool:
+        return bool(self._DELETE_PATTERN.search(prompt))
+
+    def _is_text_edit_request(self, prompt: str) -> bool:
+        return bool(self._TEXT_EDIT_PATTERN.search(prompt))
+
+    def _is_add_request(self, prompt: str) -> bool:
+        return bool(self._ADD_PATTERN.search(prompt))
+
+    # --- Plan builders ---
+
+    def _build_move_plan(self, plan: EditPlan, request: PlanRequest) -> None:
+        """Build a move plan for targeted entities."""
+        targets = self._resolve_targets(request)
+        if not targets:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+            plan.blocked_reasons.append("No target entities identified for move")
+            plan.ambiguity_flags.append("no_move_target")
+            plan.rationale = "Could not identify which entity to move."
+            return
+
+        # Parse displacement from prompt
+        dx, dy = self._parse_displacement(request.prompt)
+
+        for entity in targets:
+            action = EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_entity_type=entity.entity_type.value,
+                region_id=(
+                    request.selected_regions[0].region_id
+                    if request.selected_regions
+                    else None
+                ),
+                params={"dx": dx, "dy": dy},
+                evidence=[entity_to_evidence(entity)],
+                rationale=f"Move {describe_entity(entity)} by ({dx}, {dy})",
+                confidence=1.0 if (dx != 0 or dy != 0) else 0.5,
+                risk_level=RiskLevel.LOW,
+            )
+            if dx == 0 and dy == 0:
+                action.ambiguity.append("displacement_not_specified")
+                action.confidence = 0.5
+                plan.ambiguity_flags.append("displacement_not_specified")
+            plan.actions.append(action)
+
+        plan.rationale = f"Move {len(targets)} entity(ies)"
+        plan.approval_requirements.append(
+            ApprovalRequirement(
+                description="Confirm move displacement and target entities",
+                category="user_confirmation",
+            )
+        )
+
+    def _build_delete_plan(self, plan: EditPlan, request: PlanRequest) -> None:
+        """Build a delete plan for targeted entities."""
+        targets = self._resolve_targets(request)
+        if not targets:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+            plan.blocked_reasons.append("No target entities identified for deletion")
+            plan.ambiguity_flags.append("no_delete_target")
+            plan.rationale = "Could not identify which entities to delete."
+            return
+
+        for entity in targets:
+            action = EditAction(
+                action_type=EditActionType.DELETE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_entity_type=entity.entity_type.value,
+                region_id=(
+                    request.selected_regions[0].region_id
+                    if request.selected_regions
+                    else None
+                ),
+                params={},
+                evidence=[entity_to_evidence(entity)],
+                rationale=f"Delete {describe_entity(entity)}",
+                confidence=1.0,
+                risk_level=RiskLevel.MEDIUM,
+            )
+            plan.actions.append(action)
+
+        plan.rationale = f"Delete {len(targets)} entity(ies)"
+        plan.risk_level = RiskLevel.HIGH if len(targets) > 5 else RiskLevel.MEDIUM
+        plan.approval_requirements.append(
+            ApprovalRequirement(
+                description=f"Confirm deletion of {len(targets)} entities",
+                category="destructive_confirmation",
+            )
+        )
+
+    def _build_text_edit_plan(
+        self, plan: EditPlan, request: PlanRequest
+    ) -> None:
+        """Build a text edit plan for TEXT/MTEXT entities."""
+        targets = self._resolve_targets(request)
+        text_targets = [t for t in targets if t.entity_type in _TEXT_TYPES]
+
+        if not text_targets:
+            if targets:
+                plan.validation_status = PlanValidationStatus.BLOCKED
+                plan.blocked_reasons.append(
+                    "Target entities are not text (TEXT/MTEXT)"
+                )
+                plan.rationale = "Cannot edit text on non-text entities."
+            else:
+                plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+                plan.blocked_reasons.append("No text entities identified")
+                plan.ambiguity_flags.append("no_text_target")
+                plan.rationale = "Could not identify which text to change."
+            return
+
+        new_text = self._parse_new_text(request.prompt)
+
+        for entity in text_targets:
+            confidence = 1.0
+            ambiguity: list[str] = []
+
+            # Text trust check: low-provenance text targeting is weaker
+            if entity.text_geometry and entity.text_geometry.confidence_content < 0.5:
+                confidence *= 0.6
+                ambiguity.append("low_text_trust")
+
+            action = EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_entity_type=entity.entity_type.value,
+                params={"new_text": new_text} if new_text else {},
+                evidence=[entity_to_evidence(entity)],
+                rationale=(
+                    f"Change text from '{entity.text_content or ''}' to '{new_text}'"
+                    if new_text
+                    else f"Edit text of {describe_entity(entity)}"
+                ),
+                confidence=confidence if new_text else 0.5,
+                ambiguity=ambiguity,
+                risk_level=RiskLevel.LOW,
+            )
+            if not new_text:
+                action.ambiguity.append("new_text_not_specified")
+                plan.ambiguity_flags.append("new_text_not_specified")
+            plan.actions.append(action)
+
+        plan.rationale = f"Edit text on {len(text_targets)} entity(ies)"
+        plan.approval_requirements.append(
+            ApprovalRequirement(
+                description="Confirm text changes",
+                category="user_confirmation",
+            )
+        )
+
+    def _build_add_plan(self, plan: EditPlan, request: PlanRequest) -> None:
+        """Build an add/replicate plan."""
+        # Check if we have region context for placement
+        if not request.selected_regions:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+            plan.blocked_reasons.append("No target region specified for placement")
+            plan.ambiguity_flags.append("no_placement_region")
+            plan.rationale = "Specify a target region for placement."
+            return
+
+        region = request.selected_regions[0]
+
+        action = EditAction(
+            action_type=EditActionType.ADD_BLOCK,
+            region_id=region.region_id,
+            params={
+                "insert_point": {"x": region.center.x, "y": region.center.y},
+            },
+            evidence=[],
+            rationale=(
+                f"Add element at region center"
+                f" ({region.center.x:.1f}, {region.center.y:.1f})"
+            ),
+            confidence=0.7,
+            ambiguity=["block_name_not_specified"],
+            risk_level=RiskLevel.LOW,
+        )
+        plan.actions.append(action)
+        plan.ambiguity_flags.append("block_name_not_specified")
+        plan.rationale = "Add element at specified region"
+        plan.approval_requirements.append(
+            ApprovalRequirement(
+                description="Confirm block name and placement",
+                category="user_confirmation",
+            )
+        )
+
+    def _build_batch_plan(self, plan: EditPlan, request: PlanRequest) -> None:
+        """Build a batch plan from approved repeated-condition matches."""
+        rc_result = request.repeated_condition_result
+        if rc_result is None:
+            return
+
+        approved = [
+            c for c in rc_result.candidates if c.approval_state == ApprovalState.APPROVED
+        ]
+        pending = [
+            c for c in rc_result.candidates if c.approval_state == ApprovalState.PENDING
+        ]
+
+        if not approved and pending:
+            plan.validation_status = PlanValidationStatus.BLOCKED
+            plan.blocked_reasons.append(
+                f"{len(pending)} candidates pending approval — "
+                "approve matches before generating batch plan"
+            )
+            plan.approval_requirements.append(
+                ApprovalRequirement(
+                    description="Approve repeated-condition matches before batch planning",
+                    category="repeated_condition_approval",
+                    satisfied=False,
+                )
+            )
+            plan.rationale = "Batch plan requires approved matches."
+            return
+
+        if not approved:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+            plan.blocked_reasons.append("No approved candidates for batch plan")
+            plan.rationale = "No approved matches to act on."
+            return
+
+        for candidate in approved:
+            action = EditAction(
+                action_type=EditActionType.REPLICATE_NOTE,
+                target_handle=(
+                    candidate.entity_handles[0]
+                    if candidate.entity_handles
+                    else None
+                ),
+                params={
+                    "source_handles": list(rc_result.exemplar_handles),
+                    "target_centroid": {
+                        "x": candidate.centroid.x,
+                        "y": candidate.centroid.y,
+                    },
+                },
+                evidence=list(candidate.evidence),
+                rationale=(
+                    f"Replicate from exemplar to match at "
+                    f"({candidate.centroid.x:.1f}, {candidate.centroid.y:.1f})"
+                ),
+                confidence=candidate.confidence,
+                risk_level=RiskLevel.LOW,
+            )
+            plan.actions.append(action)
+
+        plan.rationale = (
+            f"Batch replicate to {len(approved)} approved locations "
+            f"from {len(rc_result.exemplar_handles)} exemplar entities"
+        )
+        plan.approval_requirements.append(
+            ApprovalRequirement(
+                description=f"Confirm batch replication to {len(approved)} locations",
+                category="batch_confirmation",
+            )
+        )
+
+    def _build_unsupported_plan(
+        self, plan: EditPlan, request: PlanRequest
+    ) -> None:
+        """Return a needs_clarification plan for unrecognized requests."""
+        plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+        plan.blocked_reasons.append("Request does not map to a supported edit action")
+        plan.ambiguity_flags.append("unsupported_edit_request")
+        plan.rationale = (
+            "Could not map this request to a supported edit action. "
+            "Supported actions: move, delete, change text, add block, "
+            "replicate note to approved regions."
+        )
+
+    # --- Helpers ---
+
+    def _resolve_targets(self, request: PlanRequest) -> list[EntityRef]:
+        """Resolve target entities from handles or region context."""
+        entities: list[EntityRef] = []
+
+        # Direct handle references take priority
+        if request.target_handles:
+            handle_set = set(request.target_handles)
+            for entity in request.drawing_context.entities:
+                if entity.handle in handle_set:
+                    entities.append(entity)
+            return entities
+
+        # Fall back to entities in selected regions
+        if request.selected_regions:
+            for region in request.selected_regions:
+                for entity in request.drawing_context.entities:
+                    if entity.insert_point and region.contains_point(entity.insert_point):
+                        entities.append(entity)
+            return entities
+
+        return entities
+
+    @staticmethod
+    def _parse_displacement(prompt: str) -> tuple[float, float]:
+        """Try to extract dx, dy from a prompt string.
+
+        Patterns: "by (10, 20)", "10 units right", "move up 5", etc.
+        Returns (0, 0) if no displacement is found.
+        """
+        # Pattern: (dx, dy) or dx,dy
+        m = re.search(r"\(?\s*(-?\d+\.?\d*)\s*,\s*(-?\d+\.?\d*)\s*\)?", prompt)
+        if m:
+            return float(m.group(1)), float(m.group(2))
+
+        # Pattern: N units direction
+        m = re.search(
+            r"(-?\d+\.?\d*)\s*(?:units?\s+)?(right|left|up|down)",
+            prompt,
+            re.IGNORECASE,
+        )
+        if m:
+            val = float(m.group(1))
+            direction = m.group(2).lower()
+            dx = val if direction == "right" else (-val if direction == "left" else 0)
+            dy = val if direction == "up" else (-val if direction == "down" else 0)
+            return dx, dy
+
+        # Pattern: direction N
+        m = re.search(
+            r"(right|left|up|down)\s+(-?\d+\.?\d*)",
+            prompt,
+            re.IGNORECASE,
+        )
+        if m:
+            direction = m.group(1).lower()
+            val = float(m.group(2))
+            dx = val if direction == "right" else (-val if direction == "left" else 0)
+            dy = val if direction == "up" else (-val if direction == "down" else 0)
+            return dx, dy
+
+        return 0.0, 0.0
+
+    @staticmethod
+    def _parse_new_text(prompt: str) -> str | None:
+        """Try to extract new text value from a prompt.
+
+        Patterns: 'to "new value"', "to 'new value'", "change X to Y"
+        """
+        # Quoted text after "to"
+        m = re.search(r'\bto\s+["\']([^"\']+)["\']', prompt)
+        if m:
+            return m.group(1)
+
+        # Unquoted: "change ... to WORD" at end
+        m = re.search(r"\bto\s+(\S+)\s*$", prompt)
+        if m:
+            return m.group(1)
+
+        return None
+
+    @staticmethod
+    def _compute_aggregates(plan: EditPlan) -> None:
+        """Compute plan-level confidence, risk, and validation from actions."""
+        if not plan.actions:
+            return
+
+        # Confidence: minimum across actions
+        confidences = [a.confidence for a in plan.actions]
+        plan.confidence = min(confidences) if confidences else 1.0
+
+        # Risk: maximum across actions
+        risk_order = {
+            RiskLevel.NONE: 0,
+            RiskLevel.LOW: 1,
+            RiskLevel.MEDIUM: 2,
+            RiskLevel.HIGH: 3,
+        }
+        max_risk = max(plan.actions, key=lambda a: risk_order.get(a.risk_level, 0))
+        plan.risk_level = max_risk.risk_level
+
+        # Override if many deletes
+        delete_count = sum(
+            1 for a in plan.actions if a.action_type == EditActionType.DELETE_ENTITY
+        )
+        if delete_count > 5 or len(plan.actions) > 20:
+            plan.risk_level = RiskLevel.HIGH
+
+        # Collect ambiguity from actions
+        for action in plan.actions:
+            for flag in action.ambiguity:
+                if flag not in plan.ambiguity_flags:
+                    plan.ambiguity_flags.append(flag)
+
+        # Validation status: worst action status wins
+        statuses = [a.validation.status for a in plan.actions]
+        if PlanValidationStatus.BLOCKED in statuses:
+            plan.validation_status = PlanValidationStatus.BLOCKED
+        elif PlanValidationStatus.NEEDS_CLARIFICATION in statuses:
+            plan.validation_status = PlanValidationStatus.NEEDS_CLARIFICATION
+        elif PlanValidationStatus.VALID_WITH_WARNINGS in statuses:
+            plan.validation_status = PlanValidationStatus.VALID_WITH_WARNINGS

--- a/src/cad_dxf_agent/llm/response_builder.py
+++ b/src/cad_dxf_agent/llm/response_builder.py
@@ -11,7 +11,6 @@ from typing import Any
 from cad_dxf_agent.models.plan_schema import EditPlan
 from cad_dxf_agent.models.response_schema import (
     AuditMetadata,
-    EvidenceRef,
     PlatformResponse,
     ResponseType,
     RiskLevel,
@@ -230,6 +229,90 @@ class ResponseBuilder:
             message=message,
             operations=operations,
             risk_level=RiskLevel.NONE,
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
+    def structured_preview(
+        *,
+        preview: Any,
+        message: str | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build a preview_edit response from a structured EditPreview."""
+        preview_dict = preview.model_dump() if hasattr(preview, "model_dump") else preview
+        actions = preview_dict.get("actions", [])
+        operations = [
+            {
+                "action_id": a.get("action_id"),
+                "action_type": a.get("action_type"),
+                "description": a.get("description", ""),
+                "target_handle": a.get("target_handle"),
+                "target_layer": a.get("target_layer"),
+                "before_state": a.get("before_state", {}),
+                "after_state": a.get("after_state", {}),
+                "confidence": a.get("confidence"),
+                "risk_level": a.get("risk_level"),
+                "is_destructive": a.get("is_destructive", False),
+                "warnings": a.get("warnings", []),
+            }
+            for a in actions
+        ]
+        return PlatformResponse(
+            task_family=TaskFamily.EDIT_PLAN,
+            response_type=ResponseType.PREVIEW_EDIT,
+            message=message or preview_dict.get("summary", "Preview ready."),
+            operations=operations,
+            risk_level=RiskLevel(preview_dict.get("risk_level", "low")),
+            confidence=preview_dict.get("confidence"),
+            data={
+                "preview_id": preview_dict.get("preview_id"),
+                "plan_id": preview_dict.get("plan_id"),
+                "status": preview_dict.get("status"),
+                "total_actions": preview_dict.get("total_actions", 0),
+                "destructive_count": preview_dict.get("destructive_count", 0),
+                "blocked_count": preview_dict.get("blocked_count", 0),
+                "requires_approval": preview_dict.get("requires_approval", True),
+            },
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
+    def structured_apply_result(
+        *,
+        result: Any,
+        message: str | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build an applied_edit response from a structured ApplyResult."""
+        result_dict = result.model_dump() if hasattr(result, "model_dump") else result
+        action_results = result_dict.get("action_results", [])
+        operations = [
+            {
+                "action_id": ar.get("action_id"),
+                "action_type": ar.get("action_type"),
+                "success": ar.get("success"),
+                "entity_handle": ar.get("entity_handle"),
+                "description": ar.get("description", ""),
+                "error": ar.get("error"),
+            }
+            for ar in action_results
+        ]
+        return PlatformResponse(
+            task_family=TaskFamily.APPLY_EDIT,
+            response_type=ResponseType.APPLIED_EDIT,
+            message=message or result_dict.get("summary", "Applied."),
+            operations=operations,
+            risk_level=RiskLevel.NONE,
+            data={
+                "apply_id": result_dict.get("apply_id"),
+                "plan_id": result_dict.get("plan_id"),
+                "status": result_dict.get("status"),
+                "success_count": result_dict.get("success_count", 0),
+                "failure_count": result_dict.get("failure_count", 0),
+                "output_path": result_dict.get("output_path"),
+                "revision_note": result_dict.get("revision_note"),
+            },
             audit=audit or AuditMetadata(),
         )
 

--- a/src/cad_dxf_agent/llm/response_builder.py
+++ b/src/cad_dxf_agent/llm/response_builder.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from cad_dxf_agent.models.plan_schema import EditPlan
 from cad_dxf_agent.models.response_schema import (
     AuditMetadata,
+    EvidenceRef,
     PlatformResponse,
     ResponseType,
     RiskLevel,
@@ -139,6 +141,58 @@ class ResponseBuilder:
             data=data,
             ambiguity_flags=ambiguity_flags or [],
             risk_level=RiskLevel.NONE,
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
+    def structured_plan(
+        *,
+        plan: EditPlan,
+        message: str | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build a plan_only response from a structured EditPlan."""
+        operations = [
+            {
+                "action_id": a.action_id,
+                "action_type": a.action_type.value,
+                "target_handle": a.target_handle,
+                "target_layer": a.target_layer,
+                "params": a.params,
+                "confidence": a.confidence,
+                "risk_level": a.risk_level.value,
+                "rationale": a.rationale,
+                "validation_status": a.validation.status.value,
+            }
+            for a in plan.actions
+        ]
+        plan_message = message or plan.rationale or "Structured edit plan generated."
+        return PlatformResponse(
+            task_family=TaskFamily.EDIT_PLAN,
+            response_type=ResponseType.PLAN_ONLY,
+            message=plan_message,
+            operations=operations,
+            risk_level=plan.risk_level,
+            evidence=plan.evidence,
+            confidence=plan.confidence,
+            ambiguity_flags=plan.ambiguity_flags,
+            validation={
+                "status": plan.validation_status.value,
+                "blocked_reasons": plan.blocked_reasons,
+                "approval_requirements": [
+                    {
+                        "description": r.description,
+                        "category": r.category,
+                        "satisfied": r.satisfied,
+                    }
+                    for r in plan.approval_requirements
+                ],
+            },
+            data={
+                "plan_id": plan.plan_id,
+                "schema_version": plan.schema_version,
+                "action_count": plan.action_count,
+            },
             audit=audit or AuditMetadata(),
         )
 

--- a/src/cad_dxf_agent/models/apply_schema.py
+++ b/src/cad_dxf_agent/models/apply_schema.py
@@ -1,0 +1,77 @@
+"""Apply schema for structured edit plan application (EPIC-CAD-08).
+
+Defines typed models for the result of applying an EditPlan, approval
+decisions, and audit events.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ApplyStatus(StrEnum):
+    """Outcome of applying an edit plan."""
+
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    REJECTED = "rejected"
+
+
+class ActionResult(BaseModel):
+    """Result of applying a single edit action."""
+
+    action_id: str
+    action_type: str
+    success: bool = True
+    entity_handle: str | None = None
+    description: str = ""
+    error: str | None = None
+
+
+class ApplyResult(BaseModel):
+    """Complete result of applying an edit plan."""
+
+    apply_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
+    plan_id: str = ""
+    preview_id: str = ""
+    request_id: str = ""
+    status: ApplyStatus = ApplyStatus.SUCCESS
+    action_results: list[ActionResult] = Field(default_factory=list)
+    success_count: int = 0
+    failure_count: int = 0
+    output_path: str | None = None
+    revision_note: str | None = None
+    summary: str = ""
+    warnings: list[str] = Field(default_factory=list)
+    apply_ms: float | None = None
+    save_ms: float | None = None
+    total_ms: float | None = None
+
+
+class AuditEvent(BaseModel):
+    """Audit trail event for the preview/approve/apply workflow."""
+
+    event_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
+    event_type: str
+    timestamp: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    plan_id: str | None = None
+    preview_id: str | None = None
+    apply_id: str | None = None
+    actor: str = ""
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApprovalDecision(BaseModel):
+    """User approval or rejection of an edit plan."""
+
+    plan_id: str
+    approved: bool
+    approved_by: str = ""
+    approved_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    notes: str = ""

--- a/src/cad_dxf_agent/models/plan_schema.py
+++ b/src/cad_dxf_agent/models/plan_schema.py
@@ -1,0 +1,192 @@
+"""Edit plan schema for structured edit planning (EPIC-CAD-07).
+
+Defines the canonical typed edit plan model that represents a set of
+validated, bounded edit actions ready for preview/apply in the next epic.
+Plans are plan_only — they describe changes but do not execute them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from .response_schema import EvidenceRef, RiskLevel
+
+
+class EditActionType(StrEnum):
+    """Supported edit action types for structured planning.
+
+    Each action maps to a concrete V1 operation that the edit engine
+    can execute. Unsupported operations must not be planned.
+    """
+
+    MOVE_ENTITY = "move_entity"
+    EDIT_TEXT = "edit_text"
+    DELETE_ENTITY = "delete_entity"
+    ADD_BLOCK = "add_block"
+    REPLICATE_NOTE = "replicate_note"
+
+
+class PlanValidationStatus(StrEnum):
+    """Validation outcome for an edit plan or individual action."""
+
+    VALID = "valid"
+    VALID_WITH_WARNINGS = "valid_with_warnings"
+    BLOCKED = "blocked"
+    NEEDS_CLARIFICATION = "needs_clarification"
+
+
+class ActionValidationDetail(BaseModel):
+    """Per-action validation result."""
+
+    status: PlanValidationStatus = PlanValidationStatus.VALID
+    blockers: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class EditAction(BaseModel):
+    """A single edit action within a structured edit plan.
+
+    Each action is typed, bounded, and traceable — with explicit
+    confidence, evidence, and validation status.
+    """
+
+    action_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
+    action_type: EditActionType
+    target_handle: str | None = Field(
+        default=None, description="Handle of the entity to act on"
+    )
+    target_layer: str | None = None
+    target_entity_type: str | None = None
+    region_id: str | None = Field(
+        default=None, description="Source region for this action"
+    )
+    params: dict = Field(
+        default_factory=dict,
+        description="Action-specific parameters (dx/dy, new_text, block_name, etc.)",
+    )
+    evidence: list[EvidenceRef] = Field(
+        default_factory=list, description="Supporting evidence for this action"
+    )
+    rationale: str = Field(
+        default="", description="Why this action was planned"
+    )
+    confidence: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="Confidence in this action"
+    )
+    ambiguity: list[str] = Field(
+        default_factory=list, description="Ambiguity flags for this action"
+    )
+    risk_level: RiskLevel = RiskLevel.LOW
+    validation: ActionValidationDetail = Field(
+        default_factory=ActionValidationDetail
+    )
+
+
+class ApprovalRequirement(BaseModel):
+    """A condition that must be met before the plan can be applied."""
+
+    requirement_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:8])
+    description: str
+    category: str = "user_confirmation"
+    satisfied: bool = False
+
+
+class PlanLatency(BaseModel):
+    """Timing metadata for plan generation."""
+
+    context_build_ms: float | None = None
+    plan_build_ms: float | None = None
+    validation_ms: float | None = None
+    total_ms: float | None = None
+
+
+class EditPlan(BaseModel):
+    """Canonical typed edit plan — the structured output of edit planning.
+
+    An EditPlan describes a bounded set of edit actions with explicit
+    confidence, validation, risk, and approval requirements. Plans
+    are plan_only: they do not apply changes. The preview/apply workflow
+    (EPIC-CAD-08) consumes EditPlan as its input.
+    """
+
+    schema_version: str = "1.0"
+    plan_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
+    request_id: str = Field(
+        default_factory=lambda: uuid.uuid4().hex[:16],
+        description="Correlates to the originating PlatformRequest",
+    )
+    task_family: str = "edit_plan"
+
+    # Drawing references
+    source_drawing: str | None = Field(
+        default=None, description="Path or ID of the source drawing"
+    )
+    target_drawing: str | None = Field(
+        default=None, description="Path or ID of the target drawing (if different)"
+    )
+
+    # Selection context
+    selected_region_ids: list[str] = Field(
+        default_factory=list, description="Region IDs used as input"
+    )
+    entity_handles: list[str] = Field(
+        default_factory=list, description="Known entity handles used as input"
+    )
+
+    # Actions
+    actions: list[EditAction] = Field(
+        default_factory=list, description="Ordered list of planned edit actions"
+    )
+
+    # Aggregate assessment
+    confidence: float = Field(
+        default=1.0, ge=0.0, le=1.0, description="Overall plan confidence"
+    )
+    ambiguity_flags: list[str] = Field(
+        default_factory=list, description="Plan-level ambiguity flags"
+    )
+    risk_level: RiskLevel = RiskLevel.LOW
+    validation_status: PlanValidationStatus = PlanValidationStatus.VALID
+    blocked_reasons: list[str] = Field(
+        default_factory=list, description="Why the plan is blocked (if status=blocked)"
+    )
+
+    # Evidence and rationale
+    evidence: list[EvidenceRef] = Field(
+        default_factory=list, description="Plan-level evidence references"
+    )
+    rationale: str = Field(
+        default="", description="Top-level explanation of the plan"
+    )
+
+    # Approval
+    approval_requirements: list[ApprovalRequirement] = Field(
+        default_factory=list,
+        description="Conditions that must be satisfied before apply",
+    )
+    requires_approval: bool = Field(
+        default=True, description="Whether user approval is needed before apply"
+    )
+
+    # Metadata
+    latency: PlanLatency = Field(default_factory=PlanLatency)
+    prompt: str = Field(default="", description="Original user request text")
+
+    @property
+    def action_count(self) -> int:
+        return len(self.actions)
+
+    @property
+    def is_blocked(self) -> bool:
+        return self.validation_status == PlanValidationStatus.BLOCKED
+
+    @property
+    def has_warnings(self) -> bool:
+        return self.validation_status == PlanValidationStatus.VALID_WITH_WARNINGS
+
+    @property
+    def needs_clarification(self) -> bool:
+        return self.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION

--- a/src/cad_dxf_agent/models/plan_schema.py
+++ b/src/cad_dxf_agent/models/plan_schema.py
@@ -55,14 +55,10 @@ class EditAction(BaseModel):
 
     action_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
     action_type: EditActionType
-    target_handle: str | None = Field(
-        default=None, description="Handle of the entity to act on"
-    )
+    target_handle: str | None = Field(default=None, description="Handle of the entity to act on")
     target_layer: str | None = None
     target_entity_type: str | None = None
-    region_id: str | None = Field(
-        default=None, description="Source region for this action"
-    )
+    region_id: str | None = Field(default=None, description="Source region for this action")
     params: dict = Field(
         default_factory=dict,
         description="Action-specific parameters (dx/dy, new_text, block_name, etc.)",
@@ -70,19 +66,13 @@ class EditAction(BaseModel):
     evidence: list[EvidenceRef] = Field(
         default_factory=list, description="Supporting evidence for this action"
     )
-    rationale: str = Field(
-        default="", description="Why this action was planned"
-    )
-    confidence: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="Confidence in this action"
-    )
+    rationale: str = Field(default="", description="Why this action was planned")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Confidence in this action")
     ambiguity: list[str] = Field(
         default_factory=list, description="Ambiguity flags for this action"
     )
     risk_level: RiskLevel = RiskLevel.LOW
-    validation: ActionValidationDetail = Field(
-        default_factory=ActionValidationDetail
-    )
+    validation: ActionValidationDetail = Field(default_factory=ActionValidationDetail)
 
 
 class ApprovalRequirement(BaseModel):
@@ -121,9 +111,7 @@ class EditPlan(BaseModel):
     task_family: str = "edit_plan"
 
     # Drawing references
-    source_drawing: str | None = Field(
-        default=None, description="Path or ID of the source drawing"
-    )
+    source_drawing: str | None = Field(default=None, description="Path or ID of the source drawing")
     target_drawing: str | None = Field(
         default=None, description="Path or ID of the target drawing (if different)"
     )
@@ -142,9 +130,7 @@ class EditPlan(BaseModel):
     )
 
     # Aggregate assessment
-    confidence: float = Field(
-        default=1.0, ge=0.0, le=1.0, description="Overall plan confidence"
-    )
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Overall plan confidence")
     ambiguity_flags: list[str] = Field(
         default_factory=list, description="Plan-level ambiguity flags"
     )
@@ -158,9 +144,7 @@ class EditPlan(BaseModel):
     evidence: list[EvidenceRef] = Field(
         default_factory=list, description="Plan-level evidence references"
     )
-    rationale: str = Field(
-        default="", description="Top-level explanation of the plan"
-    )
+    rationale: str = Field(default="", description="Top-level explanation of the plan")
 
     # Approval
     approval_requirements: list[ApprovalRequirement] = Field(

--- a/src/cad_dxf_agent/models/preview_schema.py
+++ b/src/cad_dxf_agent/models/preview_schema.py
@@ -1,0 +1,64 @@
+"""Preview schema for structured edit plan previews (EPIC-CAD-08).
+
+Defines typed models for previewing what an EditPlan will do before
+applying it. Each action gets a before/after state, confidence badge,
+risk indicator, and destructive flag.
+"""
+
+from __future__ import annotations
+
+import uuid
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .response_schema import RiskLevel
+
+
+class PreviewStatus(StrEnum):
+    """Overall status of an edit preview."""
+
+    READY = "ready"
+    BLOCKED = "blocked"
+    NEEDS_CLARIFICATION = "needs_clarification"
+
+
+class ActionPreview(BaseModel):
+    """Preview of a single edit action with before/after state."""
+
+    action_id: str
+    action_type: str
+    description: str = ""
+    target_handle: str | None = None
+    target_layer: str | None = None
+    target_entity_type: str | None = None
+    before_state: dict[str, Any] = Field(default_factory=dict)
+    after_state: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    risk_level: RiskLevel = RiskLevel.LOW
+    is_destructive: bool = False
+    warnings: list[str] = Field(default_factory=list)
+    ambiguity: list[str] = Field(default_factory=list)
+    validation_status: str = "valid"
+    blockers: list[str] = Field(default_factory=list)
+
+
+class EditPreview(BaseModel):
+    """Complete preview of an edit plan — what will happen if applied."""
+
+    preview_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
+    plan_id: str = ""
+    request_id: str = ""
+    status: PreviewStatus = PreviewStatus.READY
+    actions: list[ActionPreview] = Field(default_factory=list)
+    total_actions: int = 0
+    destructive_count: int = 0
+    blocked_count: int = 0
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    risk_level: RiskLevel = RiskLevel.LOW
+    summary: str = ""
+    warnings: list[str] = Field(default_factory=list)
+    approval_requirements: list[str] = Field(default_factory=list)
+    requires_approval: bool = True
+    preview_build_ms: float | None = None

--- a/tests/unit/test_apply_anti_regression.py
+++ b/tests/unit/test_apply_anti_regression.py
@@ -1,0 +1,262 @@
+"""Anti-regression tests for the preview + apply workflow (EPIC-CAD-08).
+
+These tests guard specific invariants that must never break:
+- Blocked plans never reach EditEngine
+- Apply does not mutate the plan object
+- REPLICATE_NOTE produces ADD_BLOCK, not an unknown op
+- Non-edit task families do not enter apply flow
+- Low-trust OCR text warnings preserved through apply
+- Preview does not mutate drawing context
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.plan_converter import plan_to_changeset
+from cad_dxf_agent.core.preview_builder import EditPreviewBuilder
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.ops_schema import OpType
+from cad_dxf_agent.models.plan_schema import (
+    ActionValidationDetail,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+
+
+def _make_context() -> DrawingContext:
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="E1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=20),
+                text_content="Sample",
+            ),
+            EntityRef(
+                handle="E2",
+                entity_type=EntityType.INSERT,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=50, y=60),
+                block_name="COLUMN_MARK",
+            ),
+        ],
+    )
+
+
+def test_blocked_plan_never_reaches_edit_engine(sample_dxf, sample_context, tmp_path):
+    """A blocked plan must never produce operations for the engine."""
+    plan = EditPlan(
+        validation_status=PlanValidationStatus.BLOCKED,
+        blocked_reasons=["Protected layer"],
+        actions=[
+            EditAction(
+                action_type=EditActionType.DELETE_ENTITY,
+                target_handle="DOES_NOT_MATTER",
+            )
+        ],
+    )
+
+    from cad_dxf_agent.core.apply_pipeline import ApplyPipeline
+    from cad_dxf_agent.models.apply_schema import ApplyStatus
+
+    pipeline = ApplyPipeline(sample_context)
+    result = pipeline.apply(plan, sample_dxf, tmp_path / "out.dxf")
+
+    assert result.status == ApplyStatus.REJECTED
+    assert not (tmp_path / "out.dxf").exists()
+
+
+def test_apply_does_not_mutate_plan(sample_dxf, sample_context, tmp_path):
+    """The apply pipeline must not modify the EditPlan object."""
+    text_entity = next(
+        e
+        for e in sample_context.entities
+        if e.entity_type in (EntityType.TEXT, EntityType.MTEXT) and e.layer != "TITLE"
+    )
+
+    plan = EditPlan(
+        requires_approval=False,
+        actions=[
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=text_entity.handle,
+                params={"new_text": "Changed"},
+            )
+        ],
+    )
+
+    plan_before = plan.model_dump()
+
+    from cad_dxf_agent.core.apply_pipeline import ApplyPipeline
+
+    pipeline = ApplyPipeline(sample_context)
+    pipeline.apply(plan, sample_dxf, tmp_path / "out.dxf")
+
+    plan_after = plan.model_dump()
+    # Compare everything except action_id which is UUID-generated
+    assert plan_before["actions"][0]["action_type"] == plan_after["actions"][0]["action_type"]
+    assert plan_before["actions"][0]["params"] == plan_after["actions"][0]["params"]
+    assert plan_before["requires_approval"] == plan_after["requires_approval"]
+    assert plan_before["validation_status"] == plan_after["validation_status"]
+
+
+def test_replicate_note_produces_add_block():
+    """REPLICATE_NOTE must convert to ADD_BLOCK, not an unknown op type."""
+    context = _make_context()
+    plan = EditPlan(
+        actions=[
+            EditAction(
+                action_type=EditActionType.REPLICATE_NOTE,
+                target_handle="E2",
+                params={
+                    "source_handles": ["E2"],
+                    "target_centroid": {"x": 100, "y": 200},
+                },
+            )
+        ],
+    )
+
+    changeset, _ = plan_to_changeset(plan, context)
+    assert len(changeset.operations) == 1
+    assert changeset.operations[0].op_type == OpType.ADD_BLOCK
+
+
+def test_non_edit_task_family_does_not_enter_apply():
+    """Plans with non-edit task families should still work through the converter.
+
+    The plan_to_changeset function doesn't filter by task_family — it only
+    cares about action types. This test documents that behavior.
+    """
+    plan = EditPlan(
+        task_family="qna",  # Not an edit family
+        actions=[],
+    )
+    changeset, index_map = plan_to_changeset(plan)
+    assert len(changeset.operations) == 0
+    assert len(index_map) == 0
+
+
+def test_low_trust_ocr_text_warning_preserved():
+    """Low-trust OCR text entities should surface warnings through preview."""
+    context = DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="OCR1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=20),
+                text_content="OCR Result",
+                text_geometry=TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT),
+            ),
+        ],
+    )
+
+    plan = EditPlan(
+        actions=[
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle="OCR1",
+                params={"new_text": "Fixed Text"},
+                confidence=0.6,
+                ambiguity=["low_text_trust"],
+                validation=ActionValidationDetail(
+                    warnings=["Low text confidence from OCR"],
+                ),
+            )
+        ],
+    )
+
+    builder = EditPreviewBuilder(context)
+    preview = builder.build(plan)
+
+    assert len(preview.actions) == 1
+    assert "Low text confidence from OCR" in preview.actions[0].warnings
+    assert "low_text_trust" in preview.actions[0].ambiguity
+
+
+def test_preview_does_not_mutate_drawing_context():
+    """Building a preview must not modify the DrawingContext."""
+    context = _make_context()
+    entities_before = [e.model_dump() for e in context.entities]
+
+    plan = EditPlan(
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle="E1",
+                params={"dx": 10, "dy": 20},
+            )
+        ],
+    )
+
+    builder = EditPreviewBuilder(context)
+    builder.build(plan)
+
+    entities_after = [e.model_dump() for e in context.entities]
+    assert entities_before == entities_after
+
+
+def test_blocked_action_skipped_in_converter():
+    """Blocked individual actions are skipped by the converter."""
+    plan = EditPlan(
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle="E1",
+                params={"dx": 10, "dy": 0},
+            ),
+            EditAction(
+                action_type=EditActionType.DELETE_ENTITY,
+                target_handle="E2",
+                validation=ActionValidationDetail(
+                    status=PlanValidationStatus.BLOCKED,
+                    blockers=["Protected layer"],
+                ),
+            ),
+        ],
+    )
+
+    changeset, index_map = plan_to_changeset(plan)
+    assert len(changeset.operations) == 1
+    assert changeset.operations[0].op_type == OpType.MOVE_ENTITY
+    assert index_map == {0: 0}
+
+
+def test_preview_build_with_mixed_valid_and_blocked_actions():
+    """Preview should include all actions, even blocked ones."""
+    context = _make_context()
+    plan = EditPlan(
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle="E1",
+                params={"dx": 5, "dy": 0},
+            ),
+            EditAction(
+                action_type=EditActionType.DELETE_ENTITY,
+                target_handle="E2",
+                validation=ActionValidationDetail(
+                    status=PlanValidationStatus.BLOCKED,
+                    blockers=["Protected"],
+                ),
+            ),
+        ],
+    )
+
+    builder = EditPreviewBuilder(context)
+    preview = builder.build(plan)
+
+    assert len(preview.actions) == 2
+    assert preview.actions[1].validation_status == "blocked"
+    assert preview.blocked_count == 1

--- a/tests/unit/test_apply_golden.py
+++ b/tests/unit/test_apply_golden.py
@@ -1,0 +1,186 @@
+"""Golden tests for the full preview + apply pipeline (EPIC-CAD-08).
+
+End-to-end: build plan → validate → preview → apply → verify file.
+Tests use real DXF files via the sample_dxf fixture.
+"""
+
+from __future__ import annotations
+
+import ezdxf
+
+from cad_dxf_agent.core.apply_pipeline import ApplyPipeline
+from cad_dxf_agent.core.preview_builder import EditPreviewBuilder
+from cad_dxf_agent.models.apply_schema import ApplyStatus, ApprovalDecision
+from cad_dxf_agent.models.cad_schema import EntityType
+from cad_dxf_agent.models.plan_schema import EditAction, EditActionType, EditPlan
+from cad_dxf_agent.models.preview_schema import PreviewStatus
+
+
+def _find_entity(context, entity_type, layer=None, exclude_layer=None):
+    """Find a specific entity in the context."""
+    for e in context.entities:
+        if e.entity_type == entity_type:
+            if layer and e.layer != layer:
+                continue
+            if exclude_layer and e.layer == exclude_layer:
+                continue
+            return e
+    return None
+
+
+def test_golden_move(sample_dxf, sample_context, tmp_path):
+    """Golden test: plan move → preview → approve → apply → verify position."""
+    entity = _find_entity(sample_context, EntityType.LINE, layer="STRUCTURAL")
+    assert entity is not None
+
+    plan = EditPlan(
+        requires_approval=True,
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                params={"dx": 10.0, "dy": 5.0},
+            )
+        ],
+    )
+
+    # Preview
+    builder = EditPreviewBuilder(sample_context)
+    preview = builder.build(plan)
+    assert preview.status == PreviewStatus.READY
+    assert len(preview.actions) == 1
+    assert preview.actions[0].after_state.get("delta") == {"dx": 10.0, "dy": 5.0}
+
+    # Apply with approval
+    output = tmp_path / "golden_move.dxf"
+    pipeline = ApplyPipeline(sample_context)
+    approval = ApprovalDecision(plan_id=plan.plan_id, approved=True)
+    result = pipeline.apply(plan, sample_dxf, output, approval=approval)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert result.success_count == 1
+    assert output.exists()
+
+    # Verify original unchanged
+    original_size = sample_dxf.stat().st_size
+    assert sample_dxf.stat().st_size == original_size
+
+
+def test_golden_edit_text(sample_dxf, sample_context, tmp_path):
+    """Golden test: plan text edit → preview → approve → apply → verify text."""
+    entity = _find_entity(
+        sample_context,
+        EntityType.TEXT,
+        exclude_layer="TITLE",
+    )
+    assert entity is not None
+
+    plan = EditPlan(
+        requires_approval=True,
+        actions=[
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                params={"new_text": "GOLDEN LABEL"},
+            )
+        ],
+    )
+
+    # Preview
+    builder = EditPreviewBuilder(sample_context)
+    preview = builder.build(plan)
+    assert preview.status == PreviewStatus.READY
+    assert preview.actions[0].before_state.get("text") == entity.text_content
+    assert preview.actions[0].after_state.get("text") == "GOLDEN LABEL"
+
+    # Apply
+    output = tmp_path / "golden_text.dxf"
+    pipeline = ApplyPipeline(sample_context)
+    approval = ApprovalDecision(plan_id=plan.plan_id, approved=True)
+    result = pipeline.apply(plan, sample_dxf, output, approval=approval)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert output.exists()
+
+    # Verify text was actually changed in the DXF
+    doc = ezdxf.readfile(str(output))
+    ent = doc.entitydb.get(entity.handle)
+    assert ent is not None
+    assert ent.dxf.text == "GOLDEN LABEL"
+
+
+def test_golden_delete(sample_dxf, sample_context, tmp_path):
+    """Golden test: plan delete → preview → approve → apply → verify entity gone."""
+    entity = _find_entity(
+        sample_context,
+        EntityType.TEXT,
+        exclude_layer="TITLE",
+    )
+    assert entity is not None
+
+    plan = EditPlan(
+        requires_approval=True,
+        actions=[
+            EditAction(
+                action_type=EditActionType.DELETE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+            )
+        ],
+    )
+
+    # Preview
+    builder = EditPreviewBuilder(sample_context)
+    preview = builder.build(plan)
+    assert preview.status == PreviewStatus.READY
+    assert preview.actions[0].is_destructive is True
+    assert preview.destructive_count == 1
+
+    # Apply
+    output = tmp_path / "golden_delete.dxf"
+    pipeline = ApplyPipeline(sample_context)
+    approval = ApprovalDecision(plan_id=plan.plan_id, approved=True)
+    result = pipeline.apply(plan, sample_dxf, output, approval=approval)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert output.exists()
+
+    # Verify entity was removed
+    doc = ezdxf.readfile(str(output))
+    assert doc.entitydb.get(entity.handle) is None
+
+
+def test_golden_full_pipeline_with_revision_notes(sample_dxf, sample_context, tmp_path):
+    """Golden test: full pipeline with revision notes enabled."""
+    entity = _find_entity(
+        sample_context,
+        EntityType.TEXT,
+        exclude_layer="TITLE",
+    )
+    assert entity is not None
+
+    plan = EditPlan(
+        requires_approval=False,
+        actions=[
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=entity.handle,
+                params={"new_text": "REVISED LABEL"},
+            )
+        ],
+    )
+
+    # Apply with revision notes
+    from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+
+    output = tmp_path / "golden_notes.dxf"
+    pipeline = ApplyPipeline(sample_context)
+    rev_config = RevisionNoteConfig(enabled=True)
+    result = pipeline.apply(plan, sample_dxf, output, revision_config=rev_config)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert result.revision_note is not None
+    assert "REV 1" in result.revision_note
+    assert output.exists()

--- a/tests/unit/test_apply_pipeline.py
+++ b/tests/unit/test_apply_pipeline.py
@@ -1,0 +1,393 @@
+"""Tests for ApplyPipeline — applies EditPlans to DXF files (EPIC-CAD-08).
+
+Covers SUCCESS/PARTIAL/FAILED/REJECTED status paths, approval gating,
+timing metadata, save-as safety, revision notes, and multi-action plans.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.apply_pipeline import ApplyPipeline
+from cad_dxf_agent.models.apply_schema import ApplyStatus, ApprovalDecision
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+from cad_dxf_agent.models.plan_schema import (
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_handle(context, *, entity_type: str | None = None, layer: str | None = None) -> str:
+    """Return the handle of the first matching entity."""
+    for entity in context.entities:
+        if entity_type and entity.entity_type.value != entity_type:
+            continue
+        if layer and entity.layer != layer:
+            continue
+        return entity.handle
+    raise ValueError(f"No entity found: type={entity_type!r}, layer={layer!r}")
+
+
+def _find_text_handle(context, text: str) -> str:
+    """Return the handle of the first TEXT/MTEXT entity with matching content."""
+    for entity in context.entities:
+        if entity.text_content and text in entity.text_content:
+            return entity.handle
+    raise ValueError(f"No text entity found containing: {text!r}")
+
+
+def _move_plan(handle: str, *, requires_approval: bool = False) -> EditPlan:
+    """Build a minimal move plan targeting the given handle."""
+    return EditPlan(
+        prompt="move entity",
+        requires_approval=requires_approval,
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=handle,
+                params={"dx": 5.0, "dy": 0.0},
+            )
+        ],
+    )
+
+
+def _edit_text_plan(handle: str, new_text: str, *, requires_approval: bool = False) -> EditPlan:
+    """Build a minimal edit_text plan targeting the given handle."""
+    return EditPlan(
+        prompt="edit text",
+        requires_approval=requires_approval,
+        actions=[
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=handle,
+                params={"new_text": new_text},
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: valid move plan → SUCCESS, output file created
+# ---------------------------------------------------------------------------
+
+
+def test_move_plan_succeeds_and_creates_output(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert output.exists()
+    assert result.output_path == str(output)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: valid edit_text plan → SUCCESS
+# ---------------------------------------------------------------------------
+
+
+def test_edit_text_plan_succeeds(sample_dxf, sample_context, tmp_path):
+    handle = _find_text_handle(sample_context, "Column C-4")
+    plan = _edit_text_plan(handle, "Column C-5")
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert result.success_count == 1
+    assert result.failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3: blocked plan → REJECTED, no output file created
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_plan_is_rejected(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = EditPlan(
+        prompt="blocked",
+        requires_approval=False,
+        validation_status=PlanValidationStatus.BLOCKED,
+        blocked_reasons=["Protected layer constraint violation"],
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=handle,
+                params={"dx": 1.0, "dy": 0.0},
+            )
+        ],
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.REJECTED
+    assert not output.exists()
+    assert "blocked" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: needs_clarification plan → REJECTED
+# ---------------------------------------------------------------------------
+
+
+def test_needs_clarification_plan_is_rejected(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = EditPlan(
+        prompt="unclear request",
+        requires_approval=False,
+        validation_status=PlanValidationStatus.NEEDS_CLARIFICATION,
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=handle,
+                params={"dx": 1.0, "dy": 0.0},
+            )
+        ],
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.REJECTED
+    assert not output.exists()
+    assert "clarification" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: requires_approval=True with no ApprovalDecision → REJECTED
+# ---------------------------------------------------------------------------
+
+
+def test_requires_approval_without_decision_is_rejected(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle, requires_approval=True)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output, approval=None)
+
+    assert result.status == ApplyStatus.REJECTED
+    assert not output.exists()
+    assert "approval" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: approval granted → SUCCESS
+# ---------------------------------------------------------------------------
+
+
+def test_approval_granted_allows_apply(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle, requires_approval=True)
+    approval = ApprovalDecision(
+        plan_id=plan.plan_id,
+        approved=True,
+        approved_by="engineer@example.com",
+        notes="Reviewed and approved",
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output, approval=approval)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert output.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: ApprovalDecision with approved=False → REJECTED
+# ---------------------------------------------------------------------------
+
+
+def test_approval_rejected_blocks_apply(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle, requires_approval=True)
+    approval = ApprovalDecision(
+        plan_id=plan.plan_id,
+        approved=False,
+        approved_by="reviewer@example.com",
+        notes="Too broad — needs scoping",
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output, approval=approval)
+
+    assert result.status == ApplyStatus.REJECTED
+    assert not output.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: timing metadata is populated on SUCCESS
+# ---------------------------------------------------------------------------
+
+
+def test_timing_metadata_populated_on_success(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.total_ms is not None
+    assert result.total_ms > 0
+    assert result.apply_ms is not None
+    assert result.apply_ms > 0
+    assert result.save_ms is not None
+    assert result.save_ms > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 9: original file is unchanged after save-as (apply never mutates source)
+# ---------------------------------------------------------------------------
+
+
+def test_original_file_unchanged_after_apply(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    output = tmp_path / "out.dxf"
+
+    original_bytes = sample_dxf.read_bytes()
+    ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert sample_dxf.read_bytes() == original_bytes, (
+        "Source DXF was modified — ApplyPipeline must use save-as, never overwrite the original"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 10: success_count and failure_count are correct on SUCCESS
+# ---------------------------------------------------------------------------
+
+
+def test_success_and_failure_counts_on_success(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.success_count == 1
+    assert result.failure_count == 0
+    assert len(result.action_results) == 1
+    assert result.action_results[0].success is True
+
+
+# ---------------------------------------------------------------------------
+# Test 11: apply result carries the plan_id from the plan
+# ---------------------------------------------------------------------------
+
+
+def test_apply_result_carries_plan_id(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.plan_id == plan.plan_id
+
+
+# ---------------------------------------------------------------------------
+# Test 12: empty plan (no actions) → FAILED
+# ---------------------------------------------------------------------------
+
+
+def test_empty_plan_fails(sample_dxf, sample_context, tmp_path):
+    plan = EditPlan(
+        prompt="nothing to do",
+        requires_approval=False,
+        actions=[],
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.FAILED
+    assert not output.exists()
+    assert "no operations" in result.summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 13: requires_approval=False needs no approval object
+# ---------------------------------------------------------------------------
+
+
+def test_no_approval_needed_when_flag_is_false(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle, requires_approval=False)
+    output = tmp_path / "out.dxf"
+
+    # Explicitly pass no approval object — should not be rejected
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output, approval=None)
+
+    assert result.status == ApplyStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Test 14: revision notes are generated when RevisionNoteConfig is provided
+# ---------------------------------------------------------------------------
+
+
+def test_revision_notes_generated_when_config_provided(sample_dxf, sample_context, tmp_path):
+    handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    plan = _move_plan(handle)
+    revision_config = RevisionNoteConfig(enabled=True)
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(
+        plan, sample_dxf, output, revision_config=revision_config
+    )
+
+    assert result.status == ApplyStatus.SUCCESS
+    # Revision note text should be set (may be empty string if no text was generated,
+    # but the field should not be None on a successful apply with config enabled)
+    assert result.revision_note is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 15: multiple actions in one plan → all applied, counts match
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_actions_all_applied(sample_dxf, sample_context, tmp_path):
+    line_handle = _find_handle(sample_context, entity_type="LINE", layer="STRUCTURAL")
+    text_handle = _find_text_handle(sample_context, "Column C-4")
+    mtext_handle = _find_text_handle(sample_context, "Footing detail note")
+
+    plan = EditPlan(
+        prompt="batch edit",
+        requires_approval=False,
+        actions=[
+            EditAction(
+                action_type=EditActionType.MOVE_ENTITY,
+                target_handle=line_handle,
+                params={"dx": 10.0, "dy": 5.0},
+            ),
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=text_handle,
+                params={"new_text": "Column C-99"},
+            ),
+            EditAction(
+                action_type=EditActionType.EDIT_TEXT,
+                target_handle=mtext_handle,
+                params={"new_text": "Updated footing note"},
+            ),
+        ],
+    )
+    output = tmp_path / "out.dxf"
+
+    result = ApplyPipeline(sample_context).apply(plan, sample_dxf, output)
+
+    assert result.status == ApplyStatus.SUCCESS
+    assert result.success_count == 3
+    assert result.failure_count == 0
+    assert len(result.action_results) == 3
+    assert all(ar.success for ar in result.action_results)
+    assert output.exists()

--- a/tests/unit/test_apply_schema.py
+++ b/tests/unit/test_apply_schema.py
@@ -1,0 +1,202 @@
+"""Tests for apply schema models (EPIC-CAD-08)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cad_dxf_agent.models.apply_schema import (
+    ActionResult,
+    ApplyResult,
+    ApplyStatus,
+    ApprovalDecision,
+    AuditEvent,
+)
+
+# ---------------------------------------------------------------------------
+# ApplyStatus
+# ---------------------------------------------------------------------------
+
+
+def test_apply_status_values():
+    assert ApplyStatus.SUCCESS == "success"
+    assert ApplyStatus.PARTIAL == "partial"
+    assert ApplyStatus.FAILED == "failed"
+    assert ApplyStatus.REJECTED == "rejected"
+
+
+def test_apply_status_invalid_raises():
+    with pytest.raises(ValueError):
+        ApplyStatus("unknown")
+
+
+# ---------------------------------------------------------------------------
+# ActionResult
+# ---------------------------------------------------------------------------
+
+
+def test_action_result_defaults():
+    result = ActionResult(action_id="a1", action_type="move_entity")
+    assert result.action_id == "a1"
+    assert result.action_type == "move_entity"
+    assert result.success is True
+    assert result.entity_handle is None
+    assert result.description == ""
+    assert result.error is None
+
+
+def test_action_result_with_error():
+    result = ActionResult(
+        action_id="a2",
+        action_type="delete_entity",
+        success=False,
+        entity_handle="3F",
+        description="Entity not found",
+        error="Handle 3F does not exist in drawing",
+    )
+    assert result.success is False
+    assert result.entity_handle == "3F"
+    assert result.error == "Handle 3F does not exist in drawing"
+    assert result.description == "Entity not found"
+
+
+# ---------------------------------------------------------------------------
+# ApplyResult
+# ---------------------------------------------------------------------------
+
+
+def test_apply_result_defaults():
+    result = ApplyResult()
+    assert result.apply_id  # auto-generated, non-empty
+    assert result.plan_id == ""
+    assert result.preview_id == ""
+    assert result.request_id == ""
+    assert result.status == ApplyStatus.SUCCESS
+    assert result.action_results == []
+    assert result.success_count == 0
+    assert result.failure_count == 0
+    assert result.output_path is None
+    assert result.revision_note is None
+    assert result.summary == ""
+    assert result.warnings == []
+    assert result.apply_ms is None
+    assert result.save_ms is None
+    assert result.total_ms is None
+
+
+def test_apply_result_apply_id_is_unique():
+    r1 = ApplyResult()
+    r2 = ApplyResult()
+    assert r1.apply_id != r2.apply_id
+
+
+def test_apply_result_with_action_results():
+    actions = [
+        ActionResult(action_id="a1", action_type="move_entity", success=True),
+        ActionResult(
+            action_id="a2",
+            action_type="edit_text",
+            success=False,
+            error="Protected layer",
+        ),
+    ]
+    result = ApplyResult(
+        plan_id="plan-001",
+        preview_id="prev-001",
+        request_id="req-001",
+        status=ApplyStatus.PARTIAL,
+        action_results=actions,
+        success_count=1,
+        failure_count=1,
+        output_path="/tmp/out.dxf",
+        revision_note="1 of 2 actions applied",
+        summary="Partial apply: one action blocked",
+        warnings=["edit_text blocked on protected layer"],
+        apply_ms=12.5,
+        save_ms=3.1,
+        total_ms=15.6,
+    )
+    assert result.status == ApplyStatus.PARTIAL
+    assert len(result.action_results) == 2
+    assert result.success_count == 1
+    assert result.failure_count == 1
+    assert result.output_path == "/tmp/out.dxf"
+    assert result.revision_note == "1 of 2 actions applied"
+    assert result.warnings == ["edit_text blocked on protected layer"]
+    assert result.apply_ms == pytest.approx(12.5)
+    assert result.total_ms == pytest.approx(15.6)
+
+
+# ---------------------------------------------------------------------------
+# AuditEvent
+# ---------------------------------------------------------------------------
+
+
+def test_audit_event_required_fields_and_defaults():
+    event = AuditEvent(event_type="plan_created")
+    assert event.event_id  # auto-generated
+    assert event.event_type == "plan_created"
+    assert event.timestamp  # auto-generated ISO string
+    assert event.plan_id is None
+    assert event.preview_id is None
+    assert event.apply_id is None
+    assert event.actor == ""
+    assert event.details == {}
+
+
+def test_audit_event_event_id_is_unique():
+    e1 = AuditEvent(event_type="apply_started")
+    e2 = AuditEvent(event_type="apply_started")
+    assert e1.event_id != e2.event_id
+
+
+def test_audit_event_with_all_fields():
+    event = AuditEvent(
+        event_type="apply_completed",
+        plan_id="plan-001",
+        preview_id="prev-001",
+        apply_id="apply-001",
+        actor="user@example.com",
+        details={"success_count": 3, "failure_count": 0},
+    )
+    assert event.plan_id == "plan-001"
+    assert event.preview_id == "prev-001"
+    assert event.apply_id == "apply-001"
+    assert event.actor == "user@example.com"
+    assert event.details["success_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# ApprovalDecision
+# ---------------------------------------------------------------------------
+
+
+def test_approval_decision_approved():
+    decision = ApprovalDecision(plan_id="plan-42", approved=True)
+    assert decision.plan_id == "plan-42"
+    assert decision.approved is True
+    assert decision.approved_by == ""
+    assert decision.approved_at  # auto-generated ISO string
+    assert decision.notes == ""
+
+
+def test_approval_decision_rejected():
+    decision = ApprovalDecision(
+        plan_id="plan-43",
+        approved=False,
+        approved_by="reviewer@example.com",
+        notes="Scope too broad — split into smaller operations",
+    )
+    assert decision.approved is False
+    assert decision.approved_by == "reviewer@example.com"
+    assert decision.notes == "Scope too broad — split into smaller operations"
+
+
+def test_approval_decision_requires_plan_id():
+    with pytest.raises(ValidationError):
+        ApprovalDecision(approved=True)  # type: ignore[call-arg]
+
+
+def test_approval_decision_requires_approved():
+    with pytest.raises(ValidationError):
+        ApprovalDecision(plan_id="plan-44")  # type: ignore[call-arg]

--- a/tests/unit/test_plan_anti_regression.py
+++ b/tests/unit/test_plan_anti_regression.py
@@ -1,0 +1,257 @@
+"""Anti-regression tests for edit planning (EPIC-CAD-07.4).
+
+These tests enforce hard boundaries:
+1. Edit planning does not apply edits
+2. Non-edit task families do not enter edit planning
+3. Planner does not emit unsupported freeform action blobs
+4. Blocked plans remain blocked
+5. Q&A and summary never route to edit planning
+6. Low-trust OCR text does not masquerade as exact targeting
+7. Repeated-condition batch plans require prior approval
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.intent_router import IntentRouter
+from cad_dxf_agent.llm.plan_builder import EditPlanBuilder, PlanRequest
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.plan_schema import (
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.repeated_condition_schema import (
+    ApprovalState,
+    ConditionMatch,
+    RepeatedConditionResult,
+)
+from cad_dxf_agent.models.response_schema import TaskFamily
+
+
+@pytest.fixture
+def builder():
+    return EditPlanBuilder()
+
+
+@pytest.fixture
+def drawing_context():
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="T1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=20),
+                text_content="Note A",
+            ),
+        ],
+        layers=[],
+        blocks=[],
+    )
+
+
+class TestEditPlanDoesNotApplyEdits:
+    """Edit planning must never apply edits — plan_only output."""
+
+    def test_plan_has_no_apply_method(self):
+        plan = EditPlan()
+        assert not hasattr(plan, "apply")
+        assert not hasattr(plan, "execute")
+
+    def test_plan_builder_returns_plan_not_changeset(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move right 10",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        result = builder.build(req)
+        assert isinstance(result, EditPlan)
+        # Must NOT be a ChangeSet or have apply semantics
+        assert not hasattr(result, "apply")
+
+
+class TestNonEditFamiliesExcluded:
+    """Non-edit task families must not enter edit planning."""
+
+    @pytest.mark.parametrize(
+        "prompt,expected_family",
+        [
+            ("what is on layer WALLS?", TaskFamily.QNA),
+            ("summarize this drawing", TaskFamily.SUMMARY),
+            ("compare these two drawings", TaskFamily.COMPARE),
+            ("find all instances of this", TaskFamily.REPEATED_CONDITION),
+        ],
+    )
+    def test_non_edit_prompts_do_not_route_to_edit(self, prompt, expected_family):
+        router = IntentRouter()
+        result = router.classify(prompt)
+        assert result.family == expected_family
+        assert result.family != TaskFamily.EDIT_PLAN
+
+    def test_qna_does_not_enter_edit_planning(self):
+        router = IntentRouter()
+        result = router.classify("what is this text?")
+        assert result.family == TaskFamily.QNA
+
+    def test_summary_does_not_enter_edit_planning(self):
+        router = IntentRouter()
+        result = router.classify("give me an overview of this drawing")
+        assert result.family == TaskFamily.SUMMARY
+
+
+class TestNoUnsupportedFreeformActions:
+    """Planner must not emit unsupported action types."""
+
+    def test_all_action_types_are_valid_enum(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move right 10",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        for action in plan.actions:
+            # This would raise ValueError if action_type isn't a valid enum
+            assert action.action_type in EditActionType
+
+    def test_unsupported_request_produces_no_actions(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="analyze the structural integrity of this beam",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 0
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+
+
+class TestBlockedPlansRemainBlocked:
+    """Blocked plans must not be silently downgraded."""
+
+    def test_blocked_status_persists_after_creation(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt='change text to "X"',
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        # Manually block it
+        plan.validation_status = PlanValidationStatus.BLOCKED
+        plan.blocked_reasons.append("test block")
+        # Status must persist
+        assert plan.is_blocked
+        assert "test block" in plan.blocked_reasons
+
+    def test_batch_plan_pending_stays_blocked(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["T1"],
+            exemplar_centroid=Point2D(x=10, y=20),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["T1"],
+                    confidence=0.9,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.PENDING,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="replicate",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.BLOCKED
+
+
+class TestOcrTextDoesNotMasqueradeAsExact:
+    """Low-trust OCR text must not pass as strong targeting evidence."""
+
+    def test_ocr_text_reduces_confidence(self, builder):
+        ctx = DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="OCR1",
+                    entity_type=EntityType.TEXT,
+                    layer="NOTES",
+                    insert_point=Point2D(x=10, y=20),
+                    text_content="Fuzzy text",
+                    text_geometry=TextGeometry(
+                        provenance=TextProvenance.RASTER_OCR_TEXT,
+                        confidence_position=0.2,
+                        confidence_rotation=0.2,
+                        confidence_content=0.2,
+                    ),
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+        req = PlanRequest(
+            prompt='change text to "Fixed"',
+            drawing_context=ctx,
+            target_handles=["OCR1"],
+        )
+        plan = builder.build(req)
+        assert plan.actions[0].confidence < 1.0
+        assert "low_text_trust" in plan.actions[0].ambiguity
+
+
+class TestRepeatedConditionApprovalRequired:
+    """Batch plans from repeated-condition must require prior approval."""
+
+    def test_unapproved_candidates_blocked(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["T1"],
+            exemplar_centroid=Point2D(x=10, y=20),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["T1"],
+                    confidence=0.9,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.PENDING,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="batch replicate",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.BLOCKED
+        assert any(
+            req.category == "repeated_condition_approval"
+            for req in plan.approval_requirements
+        )
+
+    def test_approved_candidates_proceed(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["T1"],
+            exemplar_centroid=Point2D(x=10, y=20),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["T1"],
+                    confidence=0.9,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.APPROVED,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="batch replicate",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 1
+        assert plan.validation_status != PlanValidationStatus.BLOCKED

--- a/tests/unit/test_plan_anti_regression.py
+++ b/tests/unit/test_plan_anti_regression.py
@@ -230,8 +230,7 @@ class TestRepeatedConditionApprovalRequired:
         plan = builder.build(req)
         assert plan.validation_status == PlanValidationStatus.BLOCKED
         assert any(
-            req.category == "repeated_condition_approval"
-            for req in plan.approval_requirements
+            req.category == "repeated_condition_approval" for req in plan.approval_requirements
         )
 
     def test_approved_candidates_proceed(self, builder, drawing_context):

--- a/tests/unit/test_plan_builder.py
+++ b/tests/unit/test_plan_builder.py
@@ -1,0 +1,432 @@
+"""Tests for edit plan builder (EPIC-CAD-07.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.plan_builder import EditPlanBuilder, PlanRequest
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.plan_schema import (
+    EditActionType,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.region_schema import BoundingBox, NormalizedRegion, RegionType
+from cad_dxf_agent.models.repeated_condition_schema import (
+    ApprovalState,
+    ConditionMatch,
+    RepeatedConditionResult,
+)
+from cad_dxf_agent.models.response_schema import RiskLevel
+
+
+@pytest.fixture
+def builder():
+    return EditPlanBuilder()
+
+
+@pytest.fixture
+def drawing_context():
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="T1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=20),
+                text_content="Note A",
+            ),
+            EntityRef(
+                handle="T2",
+                entity_type=EntityType.MTEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=50, y=60),
+                text_content="Note B",
+            ),
+            EntityRef(
+                handle="L1",
+                entity_type=EntityType.LINE,
+                layer="WALLS",
+                insert_point=Point2D(x=100, y=200),
+            ),
+            EntityRef(
+                handle="I1",
+                entity_type=EntityType.INSERT,
+                layer="SYMBOLS",
+                insert_point=Point2D(x=30, y=40),
+                block_name="DETAIL_A",
+            ),
+        ],
+        layers=[],
+        blocks=[],
+    )
+
+
+@pytest.fixture
+def region_containing_t1():
+    return NormalizedRegion(
+        region_id="region-1",
+        source_type=RegionType.BOX_SELECT,
+        bounds=BoundingBox(min_x=0, min_y=0, max_x=25, max_y=35),
+        center=Point2D(x=12.5, y=17.5),
+    )
+
+
+class TestMoveRequests:
+    """Plan builder generates move plans."""
+
+    def test_move_with_handles(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move this right 10",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.MOVE_ENTITY
+        assert plan.actions[0].target_handle == "T1"
+        assert plan.actions[0].params["dx"] == 10.0
+        assert plan.actions[0].params["dy"] == 0.0
+
+    def test_move_with_coordinates(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move by (5, -3)",
+            drawing_context=drawing_context,
+            target_handles=["L1"],
+        )
+        plan = builder.build(req)
+        assert plan.actions[0].params["dx"] == 5.0
+        assert plan.actions[0].params["dy"] == -3.0
+
+    def test_move_no_target_returns_clarification(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move this somewhere",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+        assert "no_move_target" in plan.ambiguity_flags
+
+    def test_move_no_displacement_flags_ambiguity(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move this note",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert "displacement_not_specified" in plan.ambiguity_flags
+        assert plan.actions[0].confidence == 0.5
+
+    def test_move_in_region(self, builder, drawing_context, region_containing_t1):
+        req = PlanRequest(
+            prompt="move up 5",
+            drawing_context=drawing_context,
+            selected_regions=[region_containing_t1],
+        )
+        plan = builder.build(req)
+        assert plan.action_count >= 1
+        assert plan.actions[0].params["dy"] == 5.0
+        assert plan.selected_region_ids == ["region-1"]
+
+
+class TestDeleteRequests:
+    """Plan builder generates delete plans."""
+
+    def test_delete_with_handle(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="delete this entity",
+            drawing_context=drawing_context,
+            target_handles=["L1"],
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.DELETE_ENTITY
+        assert plan.actions[0].target_handle == "L1"
+
+    def test_delete_multiple(self, builder, drawing_context, region_containing_t1):
+        req = PlanRequest(
+            prompt="remove everything in this area",
+            drawing_context=drawing_context,
+            selected_regions=[region_containing_t1],
+        )
+        plan = builder.build(req)
+        assert plan.action_count >= 1
+        assert plan.risk_level in (RiskLevel.MEDIUM, RiskLevel.HIGH)
+        assert any(
+            req.category == "destructive_confirmation"
+            for req in plan.approval_requirements
+        )
+
+    def test_delete_no_target_returns_clarification(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="delete something",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+
+
+class TestTextEditRequests:
+    """Plan builder generates text edit plans."""
+
+    def test_edit_text_with_new_value(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt='change text to "Updated Note"',
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.EDIT_TEXT
+        assert plan.actions[0].params["new_text"] == "Updated Note"
+
+    def test_edit_text_no_new_value_flags_ambiguity(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="change text on this note",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert "new_text_not_specified" in plan.ambiguity_flags
+
+    def test_edit_text_on_non_text_entity_blocked(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt='change text to "X"',
+            drawing_context=drawing_context,
+            target_handles=["L1"],  # LINE entity
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.BLOCKED
+
+    def test_edit_text_low_trust_reduces_confidence(self, builder):
+        ctx = DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="OCR1",
+                    entity_type=EntityType.TEXT,
+                    layer="NOTES",
+                    insert_point=Point2D(x=10, y=20),
+                    text_content="OCR text",
+                    text_geometry=TextGeometry(
+                        provenance=TextProvenance.RASTER_OCR_TEXT,
+                        confidence_position=0.3,
+                        confidence_rotation=0.3,
+                        confidence_content=0.3,
+                    ),
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+        req = PlanRequest(
+            prompt='change text to "fixed"',
+            drawing_context=ctx,
+            target_handles=["OCR1"],
+        )
+        plan = builder.build(req)
+        assert plan.actions[0].confidence < 1.0
+        assert "low_text_trust" in plan.actions[0].ambiguity
+
+
+class TestAddRequests:
+    """Plan builder generates add/insert plans."""
+
+    def test_add_with_region(self, builder, drawing_context, region_containing_t1):
+        req = PlanRequest(
+            prompt="add a note here",
+            drawing_context=drawing_context,
+            selected_regions=[region_containing_t1],
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.ADD_BLOCK
+
+    def test_add_without_region_needs_clarification(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="insert a block",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+
+
+class TestBatchPlans:
+    """Plan builder handles repeated-condition batch plans."""
+
+    def test_batch_from_approved_matches(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["I1"],
+            exemplar_centroid=Point2D(x=30, y=40),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["T1"],
+                    confidence=0.85,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.APPROVED,
+                ),
+                ConditionMatch(
+                    entity_handles=["T2"],
+                    confidence=0.75,
+                    centroid=Point2D(x=200, y=300),
+                    approval_state=ApprovalState.APPROVED,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="replicate to all approved locations",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.action_count == 2
+        assert all(
+            a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions
+        )
+
+    def test_batch_with_pending_matches_blocked(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["I1"],
+            exemplar_centroid=Point2D(x=30, y=40),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["T1"],
+                    confidence=0.85,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.PENDING,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="replicate",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.BLOCKED
+        assert any("pending approval" in r for r in plan.blocked_reasons)
+
+    def test_batch_no_candidates_needs_clarification(self, builder, drawing_context):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["I1"],
+            exemplar_centroid=Point2D(x=30, y=40),
+            candidates=[],
+        )
+        req = PlanRequest(
+            prompt="replicate",
+            drawing_context=drawing_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+
+
+class TestUnsupportedRequests:
+    """Unsupported requests return clarification, not fake plans."""
+
+    def test_unsupported_prompt(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="please optimize the layout for energy efficiency",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+        assert plan.action_count == 0
+        assert "unsupported_edit_request" in plan.ambiguity_flags
+
+    def test_empty_prompt(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="",
+            drawing_context=drawing_context,
+        )
+        plan = builder.build(req)
+        assert plan.validation_status == PlanValidationStatus.NEEDS_CLARIFICATION
+
+
+class TestPlanEvidencePreservation:
+    """Plans preserve evidence and rationale."""
+
+    def test_move_preserves_evidence(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="move right 10",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert len(plan.actions[0].evidence) > 0
+        assert plan.actions[0].evidence[0].entity_handle == "T1"
+
+    def test_delete_preserves_evidence(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="delete",
+            drawing_context=drawing_context,
+            target_handles=["L1"],
+        )
+        plan = builder.build(req)
+        assert len(plan.actions[0].evidence) > 0
+
+    def test_plan_has_latency(self, builder, drawing_context):
+        req = PlanRequest(
+            prompt="delete",
+            drawing_context=drawing_context,
+            target_handles=["T1"],
+        )
+        plan = builder.build(req)
+        assert plan.latency.plan_build_ms is not None
+        assert plan.latency.plan_build_ms >= 0
+
+
+class TestDisplacementParsing:
+    """Displacement parsing from prompt text."""
+
+    def test_parse_tuple(self):
+        dx, dy = EditPlanBuilder._parse_displacement("move by (10, -5)")
+        assert dx == 10.0
+        assert dy == -5.0
+
+    def test_parse_direction_right(self):
+        dx, dy = EditPlanBuilder._parse_displacement("move 15 units right")
+        assert dx == 15.0
+        assert dy == 0.0
+
+    def test_parse_direction_up(self):
+        dx, dy = EditPlanBuilder._parse_displacement("shift up 7")
+        assert dx == 0.0
+        assert dy == 7.0
+
+    def test_parse_direction_left(self):
+        dx, dy = EditPlanBuilder._parse_displacement("move left 3")
+        assert dx == -3.0
+        assert dy == 0.0
+
+    def test_parse_no_displacement(self):
+        dx, dy = EditPlanBuilder._parse_displacement("move it somewhere")
+        assert dx == 0.0
+        assert dy == 0.0
+
+
+class TestNewTextParsing:
+    """New text extraction from prompt."""
+
+    def test_quoted_text(self):
+        text = EditPlanBuilder._parse_new_text('change to "Hello World"')
+        assert text == "Hello World"
+
+    def test_single_quoted_text(self):
+        text = EditPlanBuilder._parse_new_text("rename to 'Fixed'")
+        assert text == "Fixed"
+
+    def test_unquoted_trailing(self):
+        text = EditPlanBuilder._parse_new_text("change to REVISED")
+        assert text == "REVISED"
+
+    def test_no_text(self):
+        text = EditPlanBuilder._parse_new_text("change the text")
+        assert text is None

--- a/tests/unit/test_plan_builder.py
+++ b/tests/unit/test_plan_builder.py
@@ -159,10 +159,7 @@ class TestDeleteRequests:
         plan = builder.build(req)
         assert plan.action_count >= 1
         assert plan.risk_level in (RiskLevel.MEDIUM, RiskLevel.HIGH)
-        assert any(
-            req.category == "destructive_confirmation"
-            for req in plan.approval_requirements
-        )
+        assert any(req.category == "destructive_confirmation" for req in plan.approval_requirements)
 
     def test_delete_no_target_returns_clarification(self, builder, drawing_context):
         req = PlanRequest(
@@ -287,9 +284,7 @@ class TestBatchPlans:
         )
         plan = builder.build(req)
         assert plan.action_count == 2
-        assert all(
-            a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions
-        )
+        assert all(a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions)
 
     def test_batch_with_pending_matches_blocked(self, builder, drawing_context):
         rc_result = RepeatedConditionResult(

--- a/tests/unit/test_plan_converter.py
+++ b/tests/unit/test_plan_converter.py
@@ -1,0 +1,344 @@
+"""Tests for plan_to_changeset converter (EPIC-CAD-07)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.plan_converter import plan_to_changeset
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityRef, EntityType, Point2D
+from cad_dxf_agent.models.ops_schema import OpType
+from cad_dxf_agent.models.plan_schema import (
+    ActionValidationDetail,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_plan(*actions: EditAction, prompt: str = "test prompt") -> EditPlan:
+    """Build a minimal EditPlan wrapping the given actions."""
+    return EditPlan(actions=list(actions), prompt=prompt)
+
+
+def _make_action(
+    action_type: EditActionType,
+    handle: str = "H1",
+    layer: str | None = None,
+    params: dict | None = None,
+    *,
+    blocked: bool = False,
+) -> EditAction:
+    """Build an EditAction with optional BLOCKED validation status."""
+    validation = ActionValidationDetail(
+        status=PlanValidationStatus.BLOCKED if blocked else PlanValidationStatus.VALID
+    )
+    return EditAction(
+        action_type=action_type,
+        target_handle=handle,
+        target_layer=layer,
+        params=params or {},
+        validation=validation,
+    )
+
+
+def _context_with_insert(handle: str, block_name: str, layer: str = "NOTES") -> DrawingContext:
+    """Return a DrawingContext containing one INSERT entity."""
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle=handle,
+                entity_type=EntityType.INSERT,
+                layer=layer,
+                block_name=block_name,
+                insert_point=Point2D(x=10, y=20),
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty plan → empty changeset
+# ---------------------------------------------------------------------------
+
+
+def test_empty_plan_returns_empty_changeset():
+    plan = _make_plan()
+    changeset, index_map = plan_to_changeset(plan)
+
+    assert changeset.op_count == 0
+    assert index_map == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. MOVE_ENTITY → move_entity with dx, dy
+# ---------------------------------------------------------------------------
+
+
+def test_move_action_converts_op_type_and_params():
+    action = _make_action(EditActionType.MOVE_ENTITY, handle="A1", params={"dx": 5.0, "dy": -3.0})
+    changeset, _ = plan_to_changeset(_make_plan(action))
+
+    assert changeset.op_count == 1
+    op = changeset.operations[0]
+    assert op.op_type == OpType.MOVE_ENTITY
+    assert op.target_handle == "A1"
+    assert op.params["dx"] == 5.0
+    assert op.params["dy"] == -3.0
+
+
+# ---------------------------------------------------------------------------
+# 3. EDIT_TEXT → edit_text with new_text
+# ---------------------------------------------------------------------------
+
+
+def test_edit_text_action_converts_op_type_and_params():
+    action = _make_action(
+        EditActionType.EDIT_TEXT, handle="T1", params={"new_text": "Revised Note"}
+    )
+    changeset, _ = plan_to_changeset(_make_plan(action))
+
+    assert changeset.op_count == 1
+    op = changeset.operations[0]
+    assert op.op_type == OpType.EDIT_TEXT
+    assert op.target_handle == "T1"
+    assert op.params["new_text"] == "Revised Note"
+
+
+# ---------------------------------------------------------------------------
+# 4. DELETE_ENTITY → delete_entity with no required params
+# ---------------------------------------------------------------------------
+
+
+def test_delete_action_converts_correctly():
+    action = _make_action(EditActionType.DELETE_ENTITY, handle="D1")
+    changeset, _ = plan_to_changeset(_make_plan(action))
+
+    assert changeset.op_count == 1
+    op = changeset.operations[0]
+    assert op.op_type == OpType.DELETE_ENTITY
+    assert op.target_handle == "D1"
+
+
+# ---------------------------------------------------------------------------
+# 5. ADD_BLOCK → add_block with block_name and insert_point
+# ---------------------------------------------------------------------------
+
+
+def test_add_block_action_converts_correctly():
+    action = _make_action(
+        EditActionType.ADD_BLOCK,
+        handle="I1",
+        params={"block_name": "DETAIL_A", "insert_point": {"x": 10.0, "y": 20.0}},
+    )
+    changeset, _ = plan_to_changeset(_make_plan(action))
+
+    assert changeset.op_count == 1
+    op = changeset.operations[0]
+    assert op.op_type == OpType.ADD_BLOCK
+    assert op.params["block_name"] == "DETAIL_A"
+    assert op.params["insert_point"] == {"x": 10.0, "y": 20.0}
+
+
+# ---------------------------------------------------------------------------
+# 6. REPLICATE_NOTE → add_block, block_name resolved from context
+# ---------------------------------------------------------------------------
+
+
+def test_replicate_note_resolves_block_name_from_context():
+    context = _context_with_insert(handle="SRC1", block_name="MARK_X")
+    action = _make_action(
+        EditActionType.REPLICATE_NOTE,
+        handle="SRC1",
+        params={
+            "source_handles": ["SRC1"],
+            "target_centroid": {"x": 50.0, "y": 60.0},
+        },
+    )
+    changeset, _ = plan_to_changeset(_make_plan(action), context=context)
+
+    assert changeset.op_count == 1
+    op = changeset.operations[0]
+    assert op.op_type == OpType.ADD_BLOCK
+    assert op.params["block_name"] == "MARK_X"
+    assert op.params["insert_point"] == {"x": 50.0, "y": 60.0}
+
+
+# ---------------------------------------------------------------------------
+# 7. REPLICATE_NOTE without context → empty block_name
+# ---------------------------------------------------------------------------
+
+
+def test_replicate_note_without_context_yields_empty_block_name():
+    action = _make_action(
+        EditActionType.REPLICATE_NOTE,
+        params={
+            "source_handles": ["SRC1"],
+            "target_centroid": {"x": 1.0, "y": 2.0},
+        },
+    )
+    changeset, _ = plan_to_changeset(_make_plan(action), context=None)
+
+    assert changeset.op_count == 1
+    assert changeset.operations[0].params["block_name"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 8. Order preserved across multiple actions
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_actions_preserve_order():
+    actions = [
+        _make_action(EditActionType.MOVE_ENTITY, handle="M1", params={"dx": 1.0, "dy": 0.0}),
+        _make_action(EditActionType.EDIT_TEXT, handle="T1", params={"new_text": "A"}),
+        _make_action(EditActionType.DELETE_ENTITY, handle="D1"),
+    ]
+    changeset, _ = plan_to_changeset(_make_plan(*actions))
+
+    assert changeset.op_count == 3
+    assert changeset.operations[0].target_handle == "M1"
+    assert changeset.operations[1].target_handle == "T1"
+    assert changeset.operations[2].target_handle == "D1"
+
+
+# ---------------------------------------------------------------------------
+# 9. Blocked action is skipped
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_action_is_skipped():
+    action = _make_action(EditActionType.MOVE_ENTITY, handle="BLK", blocked=True)
+    changeset, index_map = plan_to_changeset(_make_plan(action))
+
+    assert changeset.op_count == 0
+    assert index_map == {}
+
+
+# ---------------------------------------------------------------------------
+# 10. Mixed blocked and valid actions → only valid ones in changeset
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_blocked_and_valid_only_includes_valid():
+    valid_action = _make_action(EditActionType.DELETE_ENTITY, handle="KEEP")
+    blocked_action = _make_action(EditActionType.EDIT_TEXT, handle="SKIP", blocked=True)
+    changeset, _ = plan_to_changeset(_make_plan(valid_action, blocked_action))
+
+    assert changeset.op_count == 1
+    assert changeset.operations[0].target_handle == "KEEP"
+
+
+# ---------------------------------------------------------------------------
+# 11. action_index_map is correct when actions are skipped
+# ---------------------------------------------------------------------------
+
+
+def test_action_index_map_accounts_for_skipped_actions():
+    # action indices: 0=blocked, 1=valid, 2=valid
+    blocked = _make_action(EditActionType.MOVE_ENTITY, handle="BLK", blocked=True)
+    first_valid = _make_action(EditActionType.DELETE_ENTITY, handle="V1")
+    second_valid = _make_action(EditActionType.DELETE_ENTITY, handle="V2")
+
+    _, index_map = plan_to_changeset(_make_plan(blocked, first_valid, second_valid))
+
+    # op index 0 → action index 1, op index 1 → action index 2
+    assert index_map == {0: 1, 1: 2}
+
+
+# ---------------------------------------------------------------------------
+# 12. Prompt is forwarded from plan to changeset
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_forwarded_to_changeset():
+    plan = _make_plan(prompt="move the wall left 5")
+    changeset, _ = plan_to_changeset(plan)
+
+    assert changeset.prompt == "move the wall left 5"
+
+
+# ---------------------------------------------------------------------------
+# 13. Multiple actions of the same type
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_actions_same_type():
+    actions = [
+        _make_action(EditActionType.EDIT_TEXT, handle=f"T{i}", params={"new_text": f"Note {i}"})
+        for i in range(4)
+    ]
+    changeset, index_map = plan_to_changeset(_make_plan(*actions))
+
+    assert changeset.op_count == 4
+    for op_idx, action_idx in index_map.items():
+        assert op_idx == action_idx  # no skips, indices are identical
+    handles = [op.target_handle for op in changeset.operations]
+    assert handles == ["T0", "T1", "T2", "T3"]
+
+
+# ---------------------------------------------------------------------------
+# 14. Plan with all five action types
+# ---------------------------------------------------------------------------
+
+
+def test_plan_with_all_action_types():
+    context = _context_with_insert(handle="SRC", block_name="BLK_Y")
+    actions = [
+        _make_action(EditActionType.MOVE_ENTITY, handle="M1", params={"dx": 1.0, "dy": 0.0}),
+        _make_action(EditActionType.EDIT_TEXT, handle="T1", params={"new_text": "X"}),
+        _make_action(EditActionType.DELETE_ENTITY, handle="D1"),
+        _make_action(
+            EditActionType.ADD_BLOCK,
+            handle="I1",
+            params={"block_name": "BLK_A", "insert_point": {"x": 0.0, "y": 0.0}},
+        ),
+        _make_action(
+            EditActionType.REPLICATE_NOTE,
+            handle="SRC",
+            params={"source_handles": ["SRC"], "target_centroid": {"x": 5.0, "y": 5.0}},
+        ),
+    ]
+    changeset, index_map = plan_to_changeset(_make_plan(*actions), context=context)
+
+    assert changeset.op_count == 5
+    assert index_map == {0: 0, 1: 1, 2: 2, 3: 3, 4: 4}
+
+    op_types = [op.op_type for op in changeset.operations]
+    assert op_types == [
+        OpType.MOVE_ENTITY,
+        OpType.EDIT_TEXT,
+        OpType.DELETE_ENTITY,
+        OpType.ADD_BLOCK,
+        OpType.ADD_BLOCK,  # REPLICATE_NOTE maps to ADD_BLOCK
+    ]
+
+    # REPLICATE_NOTE resolved the block name from context
+    assert changeset.operations[4].params["block_name"] == "BLK_Y"
+
+
+# ---------------------------------------------------------------------------
+# 15. REPLICATE_NOTE with block_name already in params skips context lookup
+# ---------------------------------------------------------------------------
+
+
+def test_replicate_note_with_explicit_block_name_skips_context_lookup():
+    # Context has a different block_name for the same handle — should be ignored
+    context = _context_with_insert(handle="SRC", block_name="CONTEXT_BLOCK")
+    action = _make_action(
+        EditActionType.REPLICATE_NOTE,
+        handle="SRC",
+        params={
+            "source_handles": ["SRC"],
+            "block_name": "EXPLICIT_BLOCK",  # already provided
+            "target_centroid": {"x": 7.0, "y": 8.0},
+        },
+    )
+    changeset, _ = plan_to_changeset(_make_plan(action), context=context)
+
+    op = changeset.operations[0]
+    assert op.params["block_name"] == "EXPLICIT_BLOCK"
+    assert op.params["insert_point"] == {"x": 7.0, "y": 8.0}

--- a/tests/unit/test_plan_golden.py
+++ b/tests/unit/test_plan_golden.py
@@ -90,9 +90,7 @@ class TestGoldenConstructionEdit:
             blocks=[],
         )
 
-    def test_move_callout_produces_valid_plan(
-        self, builder, construction_context, rules
-    ):
+    def test_move_callout_produces_valid_plan(self, builder, construction_context, rules):
         req = PlanRequest(
             prompt="move this callout right 25",
             drawing_context=construction_context,
@@ -183,9 +181,7 @@ class TestGoldenAnnotationReview:
             center=Point2D(x=15, y=15),
         )
 
-    def test_delete_annotations_in_region(
-        self, builder, review_context, annotation_region, rules
-    ):
+    def test_delete_annotations_in_region(self, builder, review_context, annotation_region, rules):
         req = PlanRequest(
             prompt="remove all items in this area",
             drawing_context=review_context,
@@ -201,10 +197,7 @@ class TestGoldenAnnotationReview:
         assert "KEEP" not in handles
 
         assert plan.risk_level in (RiskLevel.MEDIUM, RiskLevel.HIGH)
-        assert any(
-            r.category == "destructive_confirmation"
-            for r in plan.approval_requirements
-        )
+        assert any(r.category == "destructive_confirmation" for r in plan.approval_requirements)
 
         # Validate
         validator = PlanValidator(review_context, rules)
@@ -304,9 +297,7 @@ class TestGoldenBatchReplication:
             blocks=[],
         )
 
-    def test_approved_batch_generates_replication_plan(
-        self, builder, batch_context, rules
-    ):
+    def test_approved_batch_generates_replication_plan(self, builder, batch_context, rules):
         rc_result = RepeatedConditionResult(
             exemplar_handles=["EX1"],
             exemplar_centroid=Point2D(x=10, y=20),
@@ -333,9 +324,7 @@ class TestGoldenBatchReplication:
         plan = builder.build(req)
 
         assert plan.action_count == 2
-        assert all(
-            a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions
-        )
+        assert all(a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions)
         # Confidences from match scores
         assert plan.actions[0].confidence == 0.88
         assert plan.actions[1].confidence == 0.82

--- a/tests/unit/test_plan_golden.py
+++ b/tests/unit/test_plan_golden.py
@@ -1,0 +1,345 @@
+"""Golden tests for edit planning (EPIC-CAD-07.4).
+
+Representative edit planning fixtures covering:
+1. Construction-oriented edit planning
+2. General drawing review / annotation edit
+3. Text-sensitive case with SQ67 provenance influence
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.plan_validator import PlanValidator
+from cad_dxf_agent.llm.plan_builder import EditPlanBuilder, PlanRequest
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.config_schema import RuleConfig
+from cad_dxf_agent.models.plan_schema import (
+    EditActionType,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.region_schema import (
+    BoundingBox,
+    NormalizedRegion,
+    RegionType,
+)
+from cad_dxf_agent.models.repeated_condition_schema import (
+    ApprovalState,
+    ConditionMatch,
+    RepeatedConditionResult,
+)
+from cad_dxf_agent.models.response_schema import RiskLevel
+
+
+@pytest.fixture
+def builder():
+    return EditPlanBuilder()
+
+
+@pytest.fixture
+def rules():
+    return RuleConfig(
+        protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"],
+        max_move_distance=500.0,
+    )
+
+
+class TestGoldenConstructionEdit:
+    """Construction drawing: relocate a callout and update its text."""
+
+    @pytest.fixture
+    def construction_context(self):
+        return DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="C1",
+                    entity_type=EntityType.TEXT,
+                    layer="CALLOUTS",
+                    insert_point=Point2D(x=150, y=300),
+                    text_content="SEE DETAIL A",
+                    text_geometry=TextGeometry(
+                        provenance=TextProvenance.NATIVE_CAD_TEXT,
+                        confidence_position=0.95,
+                        confidence_rotation=0.95,
+                        confidence_content=0.99,
+                    ),
+                ),
+                EntityRef(
+                    handle="W1",
+                    entity_type=EntityType.LINE,
+                    layer="WALLS",
+                    insert_point=Point2D(x=200, y=350),
+                ),
+                EntityRef(
+                    handle="TITLE1",
+                    entity_type=EntityType.TEXT,
+                    layer="TITLE",
+                    insert_point=Point2D(x=0, y=0),
+                    text_content="FLOOR PLAN",
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+
+    def test_move_callout_produces_valid_plan(
+        self, builder, construction_context, rules
+    ):
+        req = PlanRequest(
+            prompt="move this callout right 25",
+            drawing_context=construction_context,
+            target_handles=["C1"],
+        )
+        plan = builder.build(req)
+
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.MOVE_ENTITY
+        assert plan.actions[0].params["dx"] == 25.0
+        assert plan.actions[0].confidence == 1.0
+
+        # Validate against constraints
+        validator = PlanValidator(construction_context, rules)
+        validated = validator.validate(plan)
+        assert validated.validation_status in (
+            PlanValidationStatus.VALID,
+            PlanValidationStatus.VALID_WITH_WARNINGS,
+        )
+
+    def test_edit_callout_text(self, builder, construction_context, rules):
+        req = PlanRequest(
+            prompt='change text to "SEE DETAIL B"',
+            drawing_context=construction_context,
+            target_handles=["C1"],
+        )
+        plan = builder.build(req)
+
+        assert plan.action_count == 1
+        assert plan.actions[0].action_type == EditActionType.EDIT_TEXT
+        assert plan.actions[0].params["new_text"] == "SEE DETAIL B"
+
+        validator = PlanValidator(construction_context, rules)
+        validated = validator.validate(plan)
+        assert not validated.is_blocked
+
+    def test_edit_title_blocked(self, builder, construction_context, rules):
+        req = PlanRequest(
+            prompt='change text to "MODIFIED"',
+            drawing_context=construction_context,
+            target_handles=["TITLE1"],
+        )
+        plan = builder.build(req)
+        validator = PlanValidator(construction_context, rules)
+        validated = validator.validate(plan)
+        assert validated.is_blocked
+
+
+class TestGoldenAnnotationReview:
+    """General drawing review: delete annotation entities in a selected region."""
+
+    @pytest.fixture
+    def review_context(self):
+        return DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="N1",
+                    entity_type=EntityType.TEXT,
+                    layer="ANNOTATIONS",
+                    insert_point=Point2D(x=10, y=10),
+                    text_content="Old note",
+                ),
+                EntityRef(
+                    handle="N2",
+                    entity_type=EntityType.TEXT,
+                    layer="ANNOTATIONS",
+                    insert_point=Point2D(x=15, y=12),
+                    text_content="Another note",
+                ),
+                EntityRef(
+                    handle="KEEP",
+                    entity_type=EntityType.LINE,
+                    layer="STRUCTURAL",
+                    insert_point=Point2D(x=500, y=500),
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+
+    @pytest.fixture
+    def annotation_region(self):
+        return NormalizedRegion(
+            region_id="annot-region",
+            source_type=RegionType.BOX_SELECT,
+            bounds=BoundingBox(min_x=0, min_y=0, max_x=30, max_y=30),
+            center=Point2D(x=15, y=15),
+        )
+
+    def test_delete_annotations_in_region(
+        self, builder, review_context, annotation_region, rules
+    ):
+        req = PlanRequest(
+            prompt="remove all items in this area",
+            drawing_context=review_context,
+            selected_regions=[annotation_region],
+        )
+        plan = builder.build(req)
+
+        # Should find N1 and N2 in region, not KEEP
+        assert plan.action_count == 2
+        handles = {a.target_handle for a in plan.actions}
+        assert "N1" in handles
+        assert "N2" in handles
+        assert "KEEP" not in handles
+
+        assert plan.risk_level in (RiskLevel.MEDIUM, RiskLevel.HIGH)
+        assert any(
+            r.category == "destructive_confirmation"
+            for r in plan.approval_requirements
+        )
+
+        # Validate
+        validator = PlanValidator(review_context, rules)
+        validated = validator.validate(plan)
+        assert not validated.is_blocked
+
+
+class TestGoldenTextProvenance:
+    """Text-sensitive edit influenced by SQ67 provenance trust hierarchy."""
+
+    @pytest.fixture
+    def provenance_context(self):
+        return DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="NATIVE",
+                    entity_type=EntityType.TEXT,
+                    layer="NOTES",
+                    insert_point=Point2D(x=10, y=20),
+                    text_content="Native text",
+                    text_geometry=TextGeometry(
+                        provenance=TextProvenance.NATIVE_CAD_TEXT,
+                        confidence_position=0.95,
+                        confidence_rotation=0.95,
+                        confidence_content=0.99,
+                    ),
+                ),
+                EntityRef(
+                    handle="OCR",
+                    entity_type=EntityType.TEXT,
+                    layer="NOTES",
+                    insert_point=Point2D(x=50, y=60),
+                    text_content="Fuzzy OCR",
+                    text_geometry=TextGeometry(
+                        provenance=TextProvenance.RASTER_OCR_TEXT,
+                        confidence_position=0.2,
+                        confidence_rotation=0.2,
+                        confidence_content=0.3,
+                    ),
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+
+    def test_native_text_high_confidence(self, builder, provenance_context):
+        req = PlanRequest(
+            prompt='change text to "Updated"',
+            drawing_context=provenance_context,
+            target_handles=["NATIVE"],
+        )
+        plan = builder.build(req)
+        assert plan.actions[0].confidence == 1.0
+        assert "low_text_trust" not in plan.actions[0].ambiguity
+
+    def test_ocr_text_reduced_confidence(self, builder, provenance_context):
+        req = PlanRequest(
+            prompt='change text to "Fixed"',
+            drawing_context=provenance_context,
+            target_handles=["OCR"],
+        )
+        plan = builder.build(req)
+        assert plan.actions[0].confidence < 1.0
+        assert "low_text_trust" in plan.actions[0].ambiguity
+
+    def test_ocr_text_validator_warns(self, builder, provenance_context, rules):
+        req = PlanRequest(
+            prompt='change text to "Fixed"',
+            drawing_context=provenance_context,
+            target_handles=["OCR"],
+        )
+        plan = builder.build(req)
+        validator = PlanValidator(provenance_context, rules)
+        validated = validator.validate(plan)
+        action_warnings = validated.actions[0].validation.warnings
+        assert any("text trust" in w.lower() for w in action_warnings)
+
+
+class TestGoldenBatchReplication:
+    """Batch plan from approved repeated-condition matches."""
+
+    @pytest.fixture
+    def batch_context(self):
+        return DrawingContext(
+            file_path="test.dxf",
+            entities=[
+                EntityRef(
+                    handle="EX1",
+                    entity_type=EntityType.INSERT,
+                    layer="SYMBOLS",
+                    insert_point=Point2D(x=10, y=20),
+                    block_name="DETAIL_A",
+                ),
+            ],
+            layers=[],
+            blocks=[],
+        )
+
+    def test_approved_batch_generates_replication_plan(
+        self, builder, batch_context, rules
+    ):
+        rc_result = RepeatedConditionResult(
+            exemplar_handles=["EX1"],
+            exemplar_centroid=Point2D(x=10, y=20),
+            candidates=[
+                ConditionMatch(
+                    entity_handles=["M1"],
+                    confidence=0.88,
+                    centroid=Point2D(x=100, y=200),
+                    approval_state=ApprovalState.APPROVED,
+                ),
+                ConditionMatch(
+                    entity_handles=["M2"],
+                    confidence=0.82,
+                    centroid=Point2D(x=300, y=400),
+                    approval_state=ApprovalState.APPROVED,
+                ),
+            ],
+        )
+        req = PlanRequest(
+            prompt="replicate to approved locations",
+            drawing_context=batch_context,
+            repeated_condition_result=rc_result,
+        )
+        plan = builder.build(req)
+
+        assert plan.action_count == 2
+        assert all(
+            a.action_type == EditActionType.REPLICATE_NOTE for a in plan.actions
+        )
+        # Confidences from match scores
+        assert plan.actions[0].confidence == 0.88
+        assert plan.actions[1].confidence == 0.82
+
+        validator = PlanValidator(batch_context, rules)
+        validated = validator.validate(plan)
+        assert not validated.is_blocked

--- a/tests/unit/test_plan_schema.py
+++ b/tests/unit/test_plan_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from cad_dxf_agent.models.plan_schema import (
     ActionValidationDetail,
@@ -77,9 +78,9 @@ class TestEditAction:
         assert action.confidence == 0.9
 
     def test_confidence_bounds(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             EditAction(action_type=EditActionType.MOVE_ENTITY, confidence=1.5)
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             EditAction(action_type=EditActionType.MOVE_ENTITY, confidence=-0.1)
 
     def test_action_serialization(self):

--- a/tests/unit/test_plan_schema.py
+++ b/tests/unit/test_plan_schema.py
@@ -1,0 +1,222 @@
+"""Tests for edit plan schema (EPIC-CAD-07.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.models.plan_schema import (
+    ActionValidationDetail,
+    ApprovalRequirement,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanLatency,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.response_schema import EvidenceRef, RiskLevel
+
+
+class TestEditActionType:
+    """Action type enum validates correctly."""
+
+    def test_all_types_defined(self):
+        assert len(EditActionType) == 5
+
+    def test_supported_types(self):
+        assert EditActionType.MOVE_ENTITY == "move_entity"
+        assert EditActionType.EDIT_TEXT == "edit_text"
+        assert EditActionType.DELETE_ENTITY == "delete_entity"
+        assert EditActionType.ADD_BLOCK == "add_block"
+        assert EditActionType.REPLICATE_NOTE == "replicate_note"
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            EditActionType("fly_entity")
+
+
+class TestPlanValidationStatus:
+    """Validation status enum validates correctly."""
+
+    def test_all_statuses(self):
+        assert PlanValidationStatus.VALID == "valid"
+        assert PlanValidationStatus.VALID_WITH_WARNINGS == "valid_with_warnings"
+        assert PlanValidationStatus.BLOCKED == "blocked"
+        assert PlanValidationStatus.NEEDS_CLARIFICATION == "needs_clarification"
+
+
+class TestEditAction:
+    """Edit action model validates and serializes."""
+
+    def test_minimal_action(self):
+        action = EditAction(action_type=EditActionType.MOVE_ENTITY)
+        assert action.action_type == EditActionType.MOVE_ENTITY
+        assert action.action_id  # auto-generated
+        assert action.confidence == 1.0
+        assert action.risk_level == RiskLevel.LOW
+        assert action.ambiguity == []
+        assert action.evidence == []
+        assert action.validation.status == PlanValidationStatus.VALID
+
+    def test_full_action(self):
+        action = EditAction(
+            action_type=EditActionType.EDIT_TEXT,
+            target_handle="ABC",
+            target_layer="NOTES",
+            target_entity_type="TEXT",
+            region_id="region1",
+            params={"new_text": "Updated"},
+            evidence=[EvidenceRef(entity_handle="ABC", description="test")],
+            rationale="User requested text change",
+            confidence=0.9,
+            ambiguity=["partial_match"],
+            risk_level=RiskLevel.MEDIUM,
+        )
+        assert action.target_handle == "ABC"
+        assert action.params["new_text"] == "Updated"
+        assert len(action.evidence) == 1
+        assert action.confidence == 0.9
+
+    def test_confidence_bounds(self):
+        with pytest.raises(Exception):
+            EditAction(action_type=EditActionType.MOVE_ENTITY, confidence=1.5)
+        with pytest.raises(Exception):
+            EditAction(action_type=EditActionType.MOVE_ENTITY, confidence=-0.1)
+
+    def test_action_serialization(self):
+        action = EditAction(
+            action_type=EditActionType.DELETE_ENTITY,
+            target_handle="DEF",
+        )
+        data = action.model_dump()
+        assert data["action_type"] == "delete_entity"
+        assert data["target_handle"] == "DEF"
+        assert "action_id" in data
+
+
+class TestActionValidationDetail:
+    """Per-action validation detail."""
+
+    def test_defaults_to_valid(self):
+        detail = ActionValidationDetail()
+        assert detail.status == PlanValidationStatus.VALID
+        assert detail.blockers == []
+        assert detail.warnings == []
+
+    def test_blocked(self):
+        detail = ActionValidationDetail(
+            status=PlanValidationStatus.BLOCKED,
+            blockers=["protected layer"],
+        )
+        assert detail.status == PlanValidationStatus.BLOCKED
+
+
+class TestEditPlan:
+    """Edit plan model validates correctly."""
+
+    def test_empty_plan(self):
+        plan = EditPlan()
+        assert plan.schema_version == "1.0"
+        assert plan.task_family == "edit_plan"
+        assert plan.action_count == 0
+        assert not plan.is_blocked
+        assert plan.requires_approval
+
+    def test_plan_with_actions(self):
+        plan = EditPlan(
+            actions=[
+                EditAction(action_type=EditActionType.MOVE_ENTITY),
+                EditAction(action_type=EditActionType.DELETE_ENTITY),
+            ],
+            source_drawing="test.dxf",
+        )
+        assert plan.action_count == 2
+        assert plan.source_drawing == "test.dxf"
+
+    def test_plan_confidence_ambiguity_risk(self):
+        plan = EditPlan(
+            confidence=0.7,
+            ambiguity_flags=["displacement_not_specified"],
+            risk_level=RiskLevel.HIGH,
+        )
+        assert plan.confidence == 0.7
+        assert "displacement_not_specified" in plan.ambiguity_flags
+        assert plan.risk_level == RiskLevel.HIGH
+
+    def test_plan_blocked_status(self):
+        plan = EditPlan(
+            validation_status=PlanValidationStatus.BLOCKED,
+            blocked_reasons=["protected layer"],
+        )
+        assert plan.is_blocked
+        assert plan.blocked_reasons == ["protected layer"]
+
+    def test_plan_needs_clarification(self):
+        plan = EditPlan(
+            validation_status=PlanValidationStatus.NEEDS_CLARIFICATION,
+        )
+        assert plan.needs_clarification
+
+    def test_plan_with_warnings(self):
+        plan = EditPlan(
+            validation_status=PlanValidationStatus.VALID_WITH_WARNINGS,
+        )
+        assert plan.has_warnings
+
+    def test_plan_approval_requirements(self):
+        plan = EditPlan(
+            approval_requirements=[
+                ApprovalRequirement(
+                    description="Confirm deletion",
+                    category="destructive_confirmation",
+                ),
+            ],
+        )
+        assert len(plan.approval_requirements) == 1
+        assert not plan.approval_requirements[0].satisfied
+
+    def test_plan_latency(self):
+        plan = EditPlan(
+            latency=PlanLatency(
+                plan_build_ms=5.2,
+                validation_ms=1.1,
+                total_ms=6.3,
+            ),
+        )
+        assert plan.latency.plan_build_ms == 5.2
+        assert plan.latency.total_ms == 6.3
+
+    def test_plan_evidence(self):
+        plan = EditPlan(
+            evidence=[
+                EvidenceRef(entity_handle="A1", description="source entity"),
+            ],
+        )
+        assert len(plan.evidence) == 1
+
+    def test_plan_serialization_roundtrip(self):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="X",
+                    params={"new_text": "hello"},
+                ),
+            ],
+            confidence=0.85,
+            risk_level=RiskLevel.MEDIUM,
+            validation_status=PlanValidationStatus.VALID_WITH_WARNINGS,
+            rationale="Test plan",
+        )
+        data = plan.model_dump()
+        restored = EditPlan.model_validate(data)
+        assert restored.action_count == 1
+        assert restored.confidence == 0.85
+        assert restored.risk_level == RiskLevel.MEDIUM
+
+    def test_plan_entity_handles(self):
+        plan = EditPlan(entity_handles=["A", "B", "C"])
+        assert plan.entity_handles == ["A", "B", "C"]
+
+    def test_plan_selected_regions(self):
+        plan = EditPlan(selected_region_ids=["r1", "r2"])
+        assert len(plan.selected_region_ids) == 2

--- a/tests/unit/test_plan_validator.py
+++ b/tests/unit/test_plan_validator.py
@@ -20,7 +20,7 @@ from cad_dxf_agent.models.plan_schema import (
     EditPlan,
     PlanValidationStatus,
 )
-from cad_dxf_agent.models.response_schema import EvidenceRef, RiskLevel
+from cad_dxf_agent.models.response_schema import EvidenceRef
 
 
 @pytest.fixture

--- a/tests/unit/test_plan_validator.py
+++ b/tests/unit/test_plan_validator.py
@@ -1,0 +1,351 @@
+"""Tests for plan validator (EPIC-CAD-07.3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.plan_validator import PlanValidator
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.config_schema import RuleConfig
+from cad_dxf_agent.models.plan_schema import (
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.response_schema import EvidenceRef, RiskLevel
+
+
+@pytest.fixture
+def drawing_context():
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="T1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=20),
+                text_content="Note A",
+            ),
+            EntityRef(
+                handle="P1",
+                entity_type=EntityType.TEXT,
+                layer="TITLE",
+                insert_point=Point2D(x=50, y=60),
+                text_content="Drawing Title",
+            ),
+            EntityRef(
+                handle="L1",
+                entity_type=EntityType.LINE,
+                layer="WALLS",
+                insert_point=Point2D(x=100, y=200),
+            ),
+            EntityRef(
+                handle="OCR1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=70, y=80),
+                text_content="OCR derived",
+                text_geometry=TextGeometry(
+                    provenance=TextProvenance.RASTER_OCR_TEXT,
+                    confidence_position=0.3,
+                    confidence_rotation=0.3,
+                    confidence_content=0.3,
+                ),
+            ),
+        ],
+        layers=[],
+        blocks=[],
+    )
+
+
+@pytest.fixture
+def rules():
+    return RuleConfig(
+        protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"],
+        max_move_distance=500.0,
+    )
+
+
+@pytest.fixture
+def validator(drawing_context, rules):
+    return PlanValidator(drawing_context, rules)
+
+
+class TestProtectedLayerBlocking:
+    """Protected layers block edit actions."""
+
+    def test_edit_on_protected_layer_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="P1",
+                    params={"new_text": "New Title"},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+        assert any("protected layer" in b.lower() for b in result.blocked_reasons)
+
+    def test_move_on_protected_layer_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="P1",
+                    params={"dx": 10, "dy": 0},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+    def test_delete_on_protected_layer_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.DELETE_ENTITY,
+                    target_handle="P1",
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+    def test_add_block_on_protected_layer_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.ADD_BLOCK,
+                    target_layer="TITLE",
+                    params={"block_name": "X", "insert_point": {"x": 0, "y": 0}},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+
+class TestUnsupportedEntityActionCombinations:
+    """Unsupported entity/action combos are blocked."""
+
+    def test_edit_text_on_line_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="L1",
+                    params={"new_text": "hello"},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+        assert any("not supported" in b for b in result.blocked_reasons)
+
+
+class TestMissingTargets:
+    """Missing targets generate blockers."""
+
+    def test_move_missing_handle_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    params={"dx": 10, "dy": 0},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+    def test_nonexistent_handle_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.DELETE_ENTITY,
+                    target_handle="NONEXISTENT",
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+        assert any("not found" in b for b in result.blocked_reasons)
+
+
+class TestLowConfidenceTargeting:
+    """Low confidence targeting surfaces warnings."""
+
+    def test_low_confidence_action_warns(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="T1",
+                    params={"dx": 10, "dy": 0},
+                    confidence=0.3,
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.VALID_WITH_WARNINGS
+        action_warnings = result.actions[0].validation.warnings
+        assert any("low confidence" in w.lower() for w in action_warnings)
+
+    def test_missing_evidence_warns(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.DELETE_ENTITY,
+                    target_handle="T1",
+                    evidence=[],
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        action_warnings = result.actions[0].validation.warnings
+        assert any("no evidence" in w.lower() for w in action_warnings)
+
+
+class TestTextTrustIssues:
+    """Low-trust OCR text targeting surfaces warnings."""
+
+    def test_ocr_text_edit_warns(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="OCR1",
+                    params={"new_text": "fixed"},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        action_warnings = result.actions[0].validation.warnings
+        assert any("text trust" in w.lower() for w in action_warnings)
+
+
+class TestMoveValidation:
+    """Move-specific validation."""
+
+    def test_zero_displacement_warns(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="T1",
+                    params={"dx": 0, "dy": 0},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        action_warnings = result.actions[0].validation.warnings
+        assert any("zero displacement" in w.lower() for w in action_warnings)
+
+    def test_large_distance_warns(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="T1",
+                    params={"dx": 1000, "dy": 0},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        action_warnings = result.actions[0].validation.warnings
+        assert any("exceeds max" in w for w in action_warnings)
+
+
+class TestEditTextValidation:
+    """Edit text param validation."""
+
+    def test_missing_new_text_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="T1",
+                    params={},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+
+class TestReplicateValidation:
+    """Replicate action validation."""
+
+    def test_missing_source_handles_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.REPLICATE_NOTE,
+                    params={"target_centroid": {"x": 0, "y": 0}},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+    def test_missing_target_centroid_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.REPLICATE_NOTE,
+                    params={"source_handles": ["I1"]},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED
+
+
+class TestPlanLevelValidation:
+    """Plan-level constraints."""
+
+    def test_valid_plan_stays_valid(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="T1",
+                    params={"dx": 10, "dy": 5},
+                    evidence=[EvidenceRef(entity_handle="T1", description="target")],
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status in (
+            PlanValidationStatus.VALID,
+            PlanValidationStatus.VALID_WITH_WARNINGS,
+        )
+
+    def test_mixed_valid_and_blocked(self, validator):
+        plan = EditPlan(
+            actions=[
+                EditAction(
+                    action_type=EditActionType.MOVE_ENTITY,
+                    target_handle="T1",
+                    params={"dx": 10, "dy": 0},
+                ),
+                EditAction(
+                    action_type=EditActionType.EDIT_TEXT,
+                    target_handle="P1",  # protected
+                    params={"new_text": "X"},
+                ),
+            ],
+        )
+        result = validator.validate(plan)
+        assert result.validation_status == PlanValidationStatus.BLOCKED

--- a/tests/unit/test_preview_builder.py
+++ b/tests/unit/test_preview_builder.py
@@ -1,0 +1,516 @@
+"""Tests for EditPreviewBuilder (EPIC-CAD-08).
+
+Covers before/after state generation for every action type, aggregate
+confidence/risk, warning forwarding, blocked/clarification short-circuits,
+and build-timing metadata.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.preview_builder import EditPreviewBuilder
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityRef, EntityType, Point2D
+from cad_dxf_agent.models.plan_schema import (
+    ActionValidationDetail,
+    ApprovalRequirement,
+    EditAction,
+    EditActionType,
+    EditPlan,
+    PlanValidationStatus,
+)
+from cad_dxf_agent.models.preview_schema import PreviewStatus
+from cad_dxf_agent.models.response_schema import RiskLevel
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def make_context() -> DrawingContext:
+    """DrawingContext with three entities covering the main entity types."""
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="A1",
+                entity_type=EntityType.LINE,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=10.0, y=20.0),
+            ),
+            EntityRef(
+                handle="B1",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=30.0, y=40.0),
+                text_content="Old Label",
+            ),
+            EntityRef(
+                handle="C1",
+                entity_type=EntityType.INSERT,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=50.0, y=60.0),
+                block_name="COLUMN_MARK",
+            ),
+        ],
+    )
+
+
+def make_plan(**kwargs) -> EditPlan:
+    """EditPlan factory with sane defaults."""
+    return EditPlan(
+        actions=kwargs.pop("actions", []),
+        **kwargs,
+    )
+
+
+def move_action(
+    handle: str = "A1",
+    dx: float = 5.0,
+    dy: float = 3.0,
+    confidence: float = 1.0,
+    risk_level: RiskLevel = RiskLevel.LOW,
+    validation: ActionValidationDetail | None = None,
+    ambiguity: list[str] | None = None,
+) -> EditAction:
+    return EditAction(
+        action_type=EditActionType.MOVE_ENTITY,
+        target_handle=handle,
+        params={"dx": dx, "dy": dy},
+        confidence=confidence,
+        risk_level=risk_level,
+        validation=validation or ActionValidationDetail(),
+        ambiguity=ambiguity or [],
+    )
+
+
+def edit_text_action(
+    handle: str = "B1",
+    new_text: str = "New Label",
+    confidence: float = 1.0,
+    risk_level: RiskLevel = RiskLevel.LOW,
+    validation: ActionValidationDetail | None = None,
+) -> EditAction:
+    return EditAction(
+        action_type=EditActionType.EDIT_TEXT,
+        target_handle=handle,
+        params={"new_text": new_text},
+        confidence=confidence,
+        risk_level=risk_level,
+        validation=validation or ActionValidationDetail(),
+    )
+
+
+def delete_action(
+    handle: str = "A1",
+    risk_level: RiskLevel = RiskLevel.HIGH,
+    validation: ActionValidationDetail | None = None,
+) -> EditAction:
+    return EditAction(
+        action_type=EditActionType.DELETE_ENTITY,
+        target_handle=handle,
+        risk_level=risk_level,
+        validation=validation or ActionValidationDetail(),
+    )
+
+
+def add_block_action(
+    block_name: str = "BEAM_MARK",
+    insert_point: dict | None = None,
+    confidence: float = 1.0,
+    risk_level: RiskLevel = RiskLevel.LOW,
+) -> EditAction:
+    return EditAction(
+        action_type=EditActionType.ADD_BLOCK,
+        params={
+            "block_name": block_name,
+            "insert_point": insert_point or {"x": 100.0, "y": 200.0},
+        },
+        confidence=confidence,
+        risk_level=risk_level,
+        validation=ActionValidationDetail(),
+    )
+
+
+def replicate_action(
+    source_handles: list[str] | None = None,
+    target_centroid: dict | None = None,
+    confidence: float = 0.9,
+) -> EditAction:
+    return EditAction(
+        action_type=EditActionType.REPLICATE_NOTE,
+        params={
+            "source_handles": source_handles or ["B1", "C1"],
+            "target_centroid": target_centroid or {"x": 150.0, "y": 250.0},
+        },
+        confidence=confidence,
+        validation=ActionValidationDetail(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Move: correct before/after positions
+# ---------------------------------------------------------------------------
+
+
+def test_move_before_after_positions() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[move_action(handle="A1", dx=5.0, dy=3.0)])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state == {"position": {"x": 10.0, "y": 20.0}}
+    assert ap.after_state == {
+        "position": {"x": 15.0, "y": 23.0},
+        "delta": {"dx": 5.0, "dy": 3.0},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Edit text: before has old text, after has new text
+# ---------------------------------------------------------------------------
+
+
+def test_edit_text_before_after() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[edit_text_action(handle="B1", new_text="Updated Label")])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state == {"text": "Old Label"}
+    assert ap.after_state == {"text": "Updated Label"}
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Delete: is_destructive=True and empty after_state
+# ---------------------------------------------------------------------------
+
+
+def test_delete_is_destructive_with_empty_after() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[delete_action(handle="A1")])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.is_destructive is True
+    assert ap.after_state == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Add block: after_state has block_name and insert_point
+# ---------------------------------------------------------------------------
+
+
+def test_add_block_after_state() -> None:
+    ctx = make_context()
+    action = add_block_action(block_name="BEAM_MARK", insert_point={"x": 100.0, "y": 200.0})
+    plan = make_plan(actions=[action])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state == {}
+    assert ap.after_state["block_name"] == "BEAM_MARK"
+    assert ap.after_state["insert_point"] == {"x": 100.0, "y": 200.0}
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Replicate note: before has source_handles, after has target_centroid
+# ---------------------------------------------------------------------------
+
+
+def test_replicate_note_before_after() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        actions=[
+            replicate_action(
+                source_handles=["B1", "C1"],
+                target_centroid={"x": 150.0, "y": 250.0},
+            )
+        ]
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state == {"source_handles": ["B1", "C1"]}
+    assert ap.after_state == {"target_centroid": {"x": 150.0, "y": 250.0}}
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — Blocked plan yields BLOCKED status
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_plan_returns_blocked_status() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        validation_status=PlanValidationStatus.BLOCKED,
+        blocked_reasons=["Protected layer: SEAL", "Entity not found"],
+        actions=[],
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.status == PreviewStatus.BLOCKED
+    assert "Protected layer: SEAL" in preview.summary
+    assert "Entity not found" in preview.warnings
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — Needs-clarification plan yields NEEDS_CLARIFICATION status
+# ---------------------------------------------------------------------------
+
+
+def test_needs_clarification_plan_returns_correct_status() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        validation_status=PlanValidationStatus.NEEDS_CLARIFICATION,
+        rationale="Which entity should be moved?",
+        actions=[],
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.status == PreviewStatus.NEEDS_CLARIFICATION
+    assert "Which entity should be moved?" in preview.summary
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — Empty plan yields no actions and correct summary
+# ---------------------------------------------------------------------------
+
+
+def test_empty_plan_summary() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.actions == []
+    assert preview.total_actions == 0
+    assert preview.summary == "No actions to preview."
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — Missing entity surfaces a warning
+# ---------------------------------------------------------------------------
+
+
+def test_missing_entity_surfaces_warning() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[move_action(handle="GHOST")])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    combined_warnings = preview.warnings
+    assert any("GHOST" in w and "not found" in w for w in combined_warnings)
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — Confidence is minimum across all actions
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_is_minimum_across_actions() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        actions=[
+            move_action(handle="A1", confidence=0.9),
+            edit_text_action(handle="B1", confidence=0.6),
+            delete_action(handle="C1"),  # default confidence=1.0
+        ]
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.confidence == pytest.approx(0.6)
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — Risk level is maximum across all actions
+# ---------------------------------------------------------------------------
+
+
+def test_risk_level_is_maximum_across_actions() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        actions=[
+            move_action(handle="A1", risk_level=RiskLevel.LOW),
+            edit_text_action(handle="B1", risk_level=RiskLevel.MEDIUM),
+        ]
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.risk_level == RiskLevel.MEDIUM
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — Warnings forwarded from action validation
+# ---------------------------------------------------------------------------
+
+
+def test_action_validation_warnings_forwarded() -> None:
+    ctx = make_context()
+    validation = ActionValidationDetail(
+        status=PlanValidationStatus.VALID_WITH_WARNINGS,
+        warnings=["Move distance exceeds 500 units"],
+    )
+    plan = make_plan(actions=[move_action(handle="A1", validation=validation)])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert "Move distance exceeds 500 units" in preview.warnings
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — Approval requirements forwarded from plan
+# ---------------------------------------------------------------------------
+
+
+def test_approval_requirements_forwarded() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        actions=[delete_action(handle="A1")],
+        requires_approval=True,
+        approval_requirements=[
+            ApprovalRequirement(description="Confirm destructive delete"),
+            ApprovalRequirement(description="Supervisor sign-off required"),
+        ],
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.requires_approval is True
+    assert "Confirm destructive delete" in preview.approval_requirements
+    assert "Supervisor sign-off required" in preview.approval_requirements
+
+
+# ---------------------------------------------------------------------------
+# Test 14 — Build timing is set and non-negative
+# ---------------------------------------------------------------------------
+
+
+def test_build_timing_is_set() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[move_action()])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.preview_build_ms is not None
+    assert preview.preview_build_ms >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test 15 — Multiple actions in one plan
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_actions_all_previewed() -> None:
+    ctx = make_context()
+    plan = make_plan(
+        actions=[
+            move_action(handle="A1"),
+            edit_text_action(handle="B1"),
+            delete_action(handle="C1"),
+        ]
+    )
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    assert preview.total_actions == 3
+    assert preview.destructive_count == 1
+    action_types = {ap.action_type for ap in preview.actions}
+    assert action_types == {"move_entity", "edit_text", "delete_entity"}
+
+
+# ---------------------------------------------------------------------------
+# Test 16 — Move with missing insert_point still builds (delta-only after_state)
+# ---------------------------------------------------------------------------
+
+
+def test_move_missing_insert_point_still_builds() -> None:
+    ctx = DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="NO_PT",
+                entity_type=EntityType.LINE,
+                layer="STRUCTURAL",
+                insert_point=None,  # no position
+            )
+        ],
+    )
+    plan = make_plan(actions=[move_action(handle="NO_PT", dx=10.0, dy=0.0)])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state == {"position": None}
+    assert ap.after_state == {"delta": {"dx": 10.0, "dy": 0.0}}
+    # No crash — build completes
+    assert preview.status == PreviewStatus.READY
+
+
+# ---------------------------------------------------------------------------
+# Test 17 — Delete entity with text content included in before_state
+# ---------------------------------------------------------------------------
+
+
+def test_delete_text_entity_includes_text_in_before() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[delete_action(handle="B1")])  # B1 has text_content
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state.get("text") == "Old Label"
+    assert ap.before_state.get("entity_type") == EntityType.TEXT.value
+    assert ap.before_state.get("layer") == "NOTES"
+
+
+# ---------------------------------------------------------------------------
+# Test 18 — Delete entity with position included in before_state
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_includes_position_in_before() -> None:
+    ctx = make_context()
+    plan = make_plan(actions=[delete_action(handle="A1")])  # A1 has insert_point
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.before_state.get("position") == {"x": 10.0, "y": 20.0}
+    assert ap.before_state.get("entity_type") == EntityType.LINE.value
+
+
+# ---------------------------------------------------------------------------
+# Test 19 — Action ambiguity forwarded to action preview
+# ---------------------------------------------------------------------------
+
+
+def test_action_ambiguity_forwarded() -> None:
+    ctx = make_context()
+    action = move_action(
+        handle="A1",
+        ambiguity=["displacement_not_specified", "multiple_candidates"],
+    )
+    plan = make_plan(actions=[action])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert "displacement_not_specified" in ap.ambiguity
+    assert "multiple_candidates" in ap.ambiguity
+
+
+# ---------------------------------------------------------------------------
+# Test 20 — Blocked action validation status forwarded
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_action_validation_status_forwarded() -> None:
+    ctx = make_context()
+    validation = ActionValidationDetail(
+        status=PlanValidationStatus.BLOCKED,
+        blockers=["Entity is on a protected layer"],
+    )
+    action = EditAction(
+        action_type=EditActionType.EDIT_TEXT,
+        target_handle="B1",
+        params={"new_text": "X"},
+        validation=validation,
+    )
+    plan = make_plan(actions=[action])
+    preview = EditPreviewBuilder(ctx).build(plan)
+
+    ap = preview.actions[0]
+    assert ap.validation_status == "blocked"
+    assert "Entity is on a protected layer" in ap.blockers
+    assert preview.blocked_count == 1

--- a/tests/unit/test_preview_schema.py
+++ b/tests/unit/test_preview_schema.py
@@ -1,0 +1,347 @@
+"""Tests for preview_schema: PreviewStatus, ActionPreview, EditPreview (EPIC-CAD-08)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from cad_dxf_agent.models.preview_schema import ActionPreview, EditPreview, PreviewStatus
+from cad_dxf_agent.models.response_schema import RiskLevel
+
+# ---------------------------------------------------------------------------
+# PreviewStatus enum
+# ---------------------------------------------------------------------------
+
+
+def test_preview_status_values():
+    assert PreviewStatus.READY == "ready"
+    assert PreviewStatus.BLOCKED == "blocked"
+    assert PreviewStatus.NEEDS_CLARIFICATION == "needs_clarification"
+
+
+def test_preview_status_has_three_members():
+    assert len(PreviewStatus) == 3
+
+
+def test_preview_status_is_str():
+    # StrEnum members are plain strings — usable wherever str is expected.
+    assert isinstance(PreviewStatus.READY, str)
+    assert f"status={PreviewStatus.BLOCKED}" == "status=blocked"
+
+
+# ---------------------------------------------------------------------------
+# ActionPreview defaults
+# ---------------------------------------------------------------------------
+
+
+def test_action_preview_defaults():
+    action = ActionPreview(action_id="a1", action_type="move_entity")
+    assert action.action_id == "a1"
+    assert action.action_type == "move_entity"
+    assert action.description == ""
+    assert action.target_handle is None
+    assert action.target_layer is None
+    assert action.target_entity_type is None
+    assert action.before_state == {}
+    assert action.after_state == {}
+    assert action.confidence == 1.0
+    assert action.risk_level == RiskLevel.LOW
+    assert action.is_destructive is False
+    assert action.warnings == []
+    assert action.ambiguity == []
+    assert action.validation_status == "valid"
+    assert action.blockers == []
+
+
+# ---------------------------------------------------------------------------
+# ActionPreview with all fields populated
+# ---------------------------------------------------------------------------
+
+
+def test_action_preview_all_fields():
+    action = ActionPreview(
+        action_id="a2",
+        action_type="edit_text",
+        description="Change callout from A to B",
+        target_handle="1F3",
+        target_layer="NOTES",
+        target_entity_type="TEXT",
+        before_state={"text": "A"},
+        after_state={"text": "B"},
+        confidence=0.85,
+        risk_level=RiskLevel.MEDIUM,
+        is_destructive=False,
+        warnings=["text differs by more than threshold"],
+        ambiguity=["multiple_matches"],
+        validation_status="valid_with_warnings",
+        blockers=[],
+    )
+    assert action.target_handle == "1F3"
+    assert action.target_layer == "NOTES"
+    assert action.target_entity_type == "TEXT"
+    assert action.before_state == {"text": "A"}
+    assert action.after_state == {"text": "B"}
+    assert action.confidence == 0.85
+    assert action.risk_level == RiskLevel.MEDIUM
+    assert action.warnings == ["text differs by more than threshold"]
+    assert action.ambiguity == ["multiple_matches"]
+    assert action.validation_status == "valid_with_warnings"
+
+
+# ---------------------------------------------------------------------------
+# ActionPreview confidence validation
+# ---------------------------------------------------------------------------
+
+
+def test_action_preview_confidence_boundary_valid():
+    low = ActionPreview(action_id="x", action_type="move_entity", confidence=0.0)
+    high = ActionPreview(action_id="y", action_type="move_entity", confidence=1.0)
+    mid = ActionPreview(action_id="z", action_type="move_entity", confidence=0.5)
+    assert low.confidence == 0.0
+    assert high.confidence == 1.0
+    assert mid.confidence == 0.5
+
+
+def test_action_preview_confidence_above_one_raises():
+    with pytest.raises(ValidationError):
+        ActionPreview(action_id="bad", action_type="move_entity", confidence=1.1)
+
+
+def test_action_preview_confidence_below_zero_raises():
+    with pytest.raises(ValidationError):
+        ActionPreview(action_id="bad", action_type="move_entity", confidence=-0.01)
+
+
+# ---------------------------------------------------------------------------
+# ActionPreview serialization roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_action_preview_serialization_roundtrip():
+    action = ActionPreview(
+        action_id="rt1",
+        action_type="delete_entity",
+        target_handle="9A4",
+        target_layer="WALLS",
+        before_state={"layer": "WALLS", "type": "LINE"},
+        after_state={},
+        confidence=0.75,
+        risk_level=RiskLevel.HIGH,
+        is_destructive=True,
+        warnings=["irreversible"],
+        blockers=[],
+    )
+    data = action.model_dump()
+    restored = ActionPreview.model_validate(data)
+
+    assert restored.action_id == action.action_id
+    assert restored.action_type == action.action_type
+    assert restored.target_handle == action.target_handle
+    assert restored.before_state == {"layer": "WALLS", "type": "LINE"}
+    assert restored.after_state == {}
+    assert restored.confidence == 0.75
+    assert restored.risk_level == RiskLevel.HIGH
+    assert restored.is_destructive is True
+    assert restored.warnings == ["irreversible"]
+
+
+# ---------------------------------------------------------------------------
+# EditPreview defaults
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_defaults():
+    preview = EditPreview()
+    assert preview.plan_id == ""
+    assert preview.request_id == ""
+    assert preview.status == PreviewStatus.READY
+    assert preview.actions == []
+    assert preview.total_actions == 0
+    assert preview.destructive_count == 0
+    assert preview.blocked_count == 0
+    assert preview.confidence == 1.0
+    assert preview.risk_level == RiskLevel.LOW
+    assert preview.summary == ""
+    assert preview.warnings == []
+    assert preview.approval_requirements == []
+    assert preview.requires_approval is True
+    assert preview.preview_build_ms is None
+
+
+def test_edit_preview_auto_generated_preview_id():
+    p1 = EditPreview()
+    p2 = EditPreview()
+    assert p1.preview_id  # non-empty
+    assert len(p1.preview_id) == 16
+    assert p1.preview_id != p2.preview_id
+
+
+# ---------------------------------------------------------------------------
+# EditPreview with actions
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_with_actions():
+    actions = [
+        ActionPreview(action_id="a1", action_type="move_entity", target_handle="H1"),
+        ActionPreview(action_id="a2", action_type="edit_text", target_handle="H2"),
+    ]
+    preview = EditPreview(
+        plan_id="plan-001",
+        request_id="req-abc",
+        actions=actions,
+        total_actions=2,
+        summary="Move entity H1 and update text on H2",
+    )
+    assert len(preview.actions) == 2
+    assert preview.actions[0].action_id == "a1"
+    assert preview.actions[1].action_type == "edit_text"
+    assert preview.total_actions == 2
+    assert preview.plan_id == "plan-001"
+    assert preview.request_id == "req-abc"
+    assert "H2" in preview.summary
+
+
+# ---------------------------------------------------------------------------
+# EditPreview status values
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_status_ready():
+    preview = EditPreview(status=PreviewStatus.READY)
+    assert preview.status == PreviewStatus.READY
+    assert preview.status == "ready"
+
+
+def test_edit_preview_status_blocked():
+    preview = EditPreview(
+        status=PreviewStatus.BLOCKED,
+        blocked_count=1,
+        warnings=["operation targets protected layer TITLE"],
+    )
+    assert preview.status == PreviewStatus.BLOCKED
+    assert preview.blocked_count == 1
+    assert len(preview.warnings) == 1
+
+
+def test_edit_preview_status_needs_clarification():
+    preview = EditPreview(status=PreviewStatus.NEEDS_CLARIFICATION)
+    assert preview.status == PreviewStatus.NEEDS_CLARIFICATION
+    assert preview.status == "needs_clarification"
+
+
+# ---------------------------------------------------------------------------
+# EditPreview serialization roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_serialization_roundtrip():
+    preview = EditPreview(
+        plan_id="plan-rt",
+        request_id="req-rt",
+        status=PreviewStatus.READY,
+        actions=[
+            ActionPreview(
+                action_id="ra1",
+                action_type="move_entity",
+                target_handle="C9",
+                confidence=0.9,
+                risk_level=RiskLevel.LOW,
+            ),
+        ],
+        total_actions=1,
+        destructive_count=0,
+        confidence=0.9,
+        risk_level=RiskLevel.LOW,
+        summary="Move C9 by (5, 0)",
+        preview_build_ms=12.4,
+    )
+    data = json.loads(preview.model_dump_json())
+    restored = EditPreview.model_validate(data)
+
+    assert restored.plan_id == "plan-rt"
+    assert restored.request_id == "req-rt"
+    assert restored.status == PreviewStatus.READY
+    assert len(restored.actions) == 1
+    assert restored.actions[0].target_handle == "C9"
+    assert restored.total_actions == 1
+    assert restored.confidence == 0.9
+    assert restored.risk_level == RiskLevel.LOW
+    assert restored.preview_build_ms == 12.4
+
+
+# ---------------------------------------------------------------------------
+# EditPreview with approval requirements
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_approval_requirements():
+    preview = EditPreview(
+        requires_approval=True,
+        approval_requirements=["Confirm deletion of 3 entities", "Acknowledge high-risk operation"],
+    )
+    assert preview.requires_approval is True
+    assert len(preview.approval_requirements) == 2
+    assert "Confirm deletion of 3 entities" in preview.approval_requirements
+
+
+def test_edit_preview_no_approval_required():
+    preview = EditPreview(requires_approval=False, approval_requirements=[])
+    assert preview.requires_approval is False
+    assert preview.approval_requirements == []
+
+
+# ---------------------------------------------------------------------------
+# EditPreview destructive count
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_destructive_count():
+    actions = [
+        ActionPreview(action_id="d1", action_type="delete_entity", is_destructive=True),
+        ActionPreview(action_id="d2", action_type="delete_entity", is_destructive=True),
+        ActionPreview(action_id="d3", action_type="move_entity", is_destructive=False),
+    ]
+    preview = EditPreview(
+        actions=actions,
+        total_actions=3,
+        destructive_count=2,
+        risk_level=RiskLevel.HIGH,
+    )
+    assert preview.destructive_count == 2
+    assert preview.total_actions == 3
+    assert preview.risk_level == RiskLevel.HIGH
+    destructive = [a for a in preview.actions if a.is_destructive]
+    assert len(destructive) == 2
+
+
+# ---------------------------------------------------------------------------
+# EditPreview blocked status
+# ---------------------------------------------------------------------------
+
+
+def test_edit_preview_blocked_status_with_blockers():
+    actions = [
+        ActionPreview(
+            action_id="b1",
+            action_type="edit_text",
+            target_layer="TITLE",
+            validation_status="blocked",
+            blockers=["layer TITLE is protected"],
+        ),
+    ]
+    preview = EditPreview(
+        status=PreviewStatus.BLOCKED,
+        actions=actions,
+        total_actions=1,
+        blocked_count=1,
+        warnings=["1 action blocked due to protected layer"],
+    )
+    assert preview.status == PreviewStatus.BLOCKED
+    assert preview.blocked_count == 1
+    assert preview.actions[0].blockers == ["layer TITLE is protected"]
+    assert preview.actions[0].validation_status == "blocked"
+    blocked_actions = [a for a in preview.actions if a.validation_status == "blocked"]
+    assert len(blocked_actions) == 1

--- a/tests/unit/test_text_utils.py
+++ b/tests/unit/test_text_utils.py
@@ -1,0 +1,136 @@
+"""Tests for shared text utilities (ARCH-REVIEW-CAD-01 prerequisite P1)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.text_utils import (
+    describe_entity,
+    entity_to_evidence,
+    levenshtein_distance,
+    levenshtein_similarity,
+)
+from cad_dxf_agent.models.cad_schema import (
+    EntityRef,
+    EntityType,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+
+
+class TestLevenshteinDistance:
+    def test_identical(self):
+        assert levenshtein_distance("hello", "hello") == 0
+
+    def test_single_edit(self):
+        assert levenshtein_distance("cat", "bat") == 1
+
+    def test_empty(self):
+        assert levenshtein_distance("", "abc") == 3
+        assert levenshtein_distance("abc", "") == 3
+
+    def test_both_empty(self):
+        assert levenshtein_distance("", "") == 0
+
+    def test_insertion(self):
+        assert levenshtein_distance("abc", "abcd") == 1
+
+    def test_deletion(self):
+        assert levenshtein_distance("abcd", "abc") == 1
+
+
+class TestLevenshteinSimilarity:
+    def test_identical(self):
+        assert levenshtein_similarity("hello", "hello") == 1.0
+
+    def test_completely_different(self):
+        sim = levenshtein_similarity("abc", "xyz")
+        assert sim == 0.0
+
+    def test_empty_strings(self):
+        assert levenshtein_similarity("", "") == 1.0
+        assert levenshtein_similarity("abc", "") == 0.0
+        assert levenshtein_similarity("", "abc") == 0.0
+
+    def test_partial_match(self):
+        sim = levenshtein_similarity("hello", "hallo")
+        assert 0.5 < sim < 1.0
+
+
+class TestDescribeEntity:
+    def test_text_entity(self):
+        entity = EntityRef(
+            handle="T1",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            insert_point=Point2D(x=10, y=20),
+            text_content="Hello World",
+        )
+        desc = describe_entity(entity)
+        assert "TEXT" in desc
+        assert "NOTES" in desc
+        assert "Hello World" in desc
+
+    def test_insert_entity(self):
+        entity = EntityRef(
+            handle="I1",
+            entity_type=EntityType.INSERT,
+            layer="SYMBOLS",
+            insert_point=Point2D(x=30, y=40),
+            block_name="DETAIL_A",
+        )
+        desc = describe_entity(entity)
+        assert "INSERT" in desc
+        assert "DETAIL_A" in desc
+
+    def test_entity_with_provenance(self):
+        entity = EntityRef(
+            handle="T2",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            insert_point=Point2D(x=0, y=0),
+            text_content="OCR text",
+            text_geometry=TextGeometry(
+                provenance=TextProvenance.RASTER_OCR_TEXT,
+                confidence_position=0.3,
+                confidence_rotation=0.3,
+                confidence_content=0.3,
+            ),
+        )
+        desc = describe_entity(entity)
+        assert "raster_ocr_text" in desc
+
+    def test_long_text_truncated(self):
+        entity = EntityRef(
+            handle="T3",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            text_content="A" * 100,
+        )
+        desc = describe_entity(entity)
+        assert "..." in desc
+
+
+class TestEntityToEvidence:
+    def test_basic_conversion(self):
+        entity = EntityRef(
+            handle="T1",
+            entity_type=EntityType.TEXT,
+            layer="NOTES",
+            insert_point=Point2D(x=10, y=20),
+            text_content="Hello",
+        )
+        evidence = entity_to_evidence(entity)
+        assert evidence.entity_handle == "T1"
+        assert evidence.layer == "NOTES"
+        assert evidence.entity_type == "TEXT"
+        assert evidence.location == (10, 20)
+        assert evidence.text_excerpt == "Hello"
+
+    def test_no_position(self):
+        entity = EntityRef(
+            handle="T2",
+            entity_type=EntityType.LINE,
+            layer="WALLS",
+        )
+        evidence = entity_to_evidence(entity)
+        assert evidence.location is None

--- a/tests/web/test_preview_apply_endpoints.py
+++ b/tests/web/test_preview_apply_endpoints.py
@@ -1,0 +1,229 @@
+"""Tests for v2 preview/approve/apply endpoints (EPIC-CAD-08).
+
+Uses shared fixtures from conftest.py (client, upload_dxf, etc.)
+"""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+
+
+@pytest.fixture
+def uploaded_session(client, tmp_path):
+    """Upload a DXF with known entities and return session_id."""
+    doc = ezdxf.new(dxfversion="R2018")
+    msp = doc.modelspace()
+    doc.layers.add("STRUCTURAL", color=1)
+    doc.layers.add("NOTES", color=3)
+    msp.add_line((0, 0), (100, 0), dxfattribs={"layer": "STRUCTURAL"})
+    msp.add_text(
+        "Test Label",
+        dxfattribs={"layer": "NOTES", "height": 2.5, "insert": (10, 10)},
+    )
+    block = doc.blocks.new("COLUMN_MARK")
+    block.add_circle((0, 0), radius=2)
+    msp.add_blockref("COLUMN_MARK", insert=(50, 50), dxfattribs={"layer": "STRUCTURAL"})
+
+    dxf_path = tmp_path / "test.dxf"
+    doc.saveas(str(dxf_path))
+
+    with open(dxf_path, "rb") as f:
+        files = {"file": ("test.dxf", f, "application/octet-stream")}
+        resp = client.post("/api/upload", files=files)
+    assert resp.status_code == 200
+    return resp.json()["session_id"]
+
+
+@pytest.fixture
+def session_with_plan(client, uploaded_session):
+    """Send a prompt to create an edit plan in the session."""
+    resp = client.post(
+        "/api/v2/prompt",
+        json={"session_id": uploaded_session, "prompt": "move the line 10 units right"},
+    )
+    assert resp.status_code == 200
+    return uploaded_session
+
+
+# --- Preview endpoint tests ---
+
+
+def test_preview_invalid_session(client):
+    resp = client.post("/api/v2/preview", json={"session_id": "nonexistent"})
+    assert resp.status_code == 404
+
+
+def test_preview_no_plan(client, uploaded_session):
+    resp = client.post("/api/v2/preview", json={"session_id": uploaded_session})
+    assert resp.status_code == 400
+    assert "No edit plan" in resp.json()["detail"]
+
+
+def test_preview_returns_structured_preview(client, session_with_plan):
+    resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["response_type"] == "preview_edit"
+    assert data["task_family"] == "edit_plan"
+    assert "data" in data
+    assert "preview_id" in data["data"]
+    assert "total_actions" in data["data"]
+
+
+# --- Approve endpoint tests ---
+
+
+def test_approve_invalid_session(client):
+    resp = client.post(
+        "/api/v2/approve",
+        json={"session_id": "nonexistent", "plan_id": "abc", "approved": True},
+    )
+    assert resp.status_code == 404
+
+
+def test_approve_no_plan(client, uploaded_session):
+    resp = client.post(
+        "/api/v2/approve",
+        json={"session_id": uploaded_session, "plan_id": "abc", "approved": True},
+    )
+    assert resp.status_code == 400
+
+
+def test_approve_plan_id_mismatch(client, session_with_plan):
+    resp = client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": "wrong_id", "approved": True},
+    )
+    assert resp.status_code == 400
+    assert "mismatch" in resp.json()["detail"].lower()
+
+
+def test_approve_records_decision(client, session_with_plan):
+    # Get plan_id from preview
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    plan_id = preview_resp.json()["data"]["plan_id"]
+
+    resp = client.post(
+        "/api/v2/approve",
+        json={
+            "session_id": session_with_plan,
+            "plan_id": plan_id,
+            "approved": True,
+            "notes": "Looks good",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["approved"] is True
+    assert data["plan_id"] == plan_id
+    assert data["event_type"] == "approval_granted"
+
+
+def test_approve_rejection(client, session_with_plan):
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    plan_id = preview_resp.json()["data"]["plan_id"]
+
+    resp = client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": plan_id, "approved": False},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["event_type"] == "approval_rejected"
+
+
+# --- Apply endpoint tests ---
+
+
+def test_apply_invalid_session(client):
+    resp = client.post("/api/v2/apply", json={"session_id": "nonexistent"})
+    assert resp.status_code == 404
+
+
+def test_apply_no_plan(client, uploaded_session):
+    resp = client.post("/api/v2/apply", json={"session_id": uploaded_session})
+    assert resp.status_code == 400
+
+
+def test_apply_without_approval_rejected(client, session_with_plan):
+    """Apply without prior approval → rejected (plan requires approval by default)."""
+    resp = client.post("/api/v2/apply", json={"session_id": session_with_plan})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["data"]["status"] == "rejected"
+
+
+def test_apply_with_approval_succeeds(client, session_with_plan):
+    """Full flow: preview → approve → apply."""
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    plan_id = preview_resp.json()["data"]["plan_id"]
+
+    client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": plan_id, "approved": True},
+    )
+
+    resp = client.post("/api/v2/apply", json={"session_id": session_with_plan})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["response_type"] == "applied_edit"
+    assert data["task_family"] == "apply_edit"
+    assert data["data"]["status"] in ("success", "partial", "failed", "rejected")
+
+
+def test_apply_response_format(client, session_with_plan):
+    """Verify response includes expected fields."""
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    plan_id = preview_resp.json()["data"]["plan_id"]
+
+    client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": plan_id, "approved": True},
+    )
+
+    resp = client.post("/api/v2/apply", json={"session_id": session_with_plan})
+    data = resp.json()
+
+    assert "message" in data
+    assert "operations" in data
+    assert "data" in data
+    assert "apply_id" in data["data"]
+    assert "success_count" in data["data"]
+    assert "failure_count" in data["data"]
+
+
+# --- Integration flow tests ---
+
+
+def test_preview_then_apply_full_flow(client, session_with_plan):
+    """Integration: preview → approve → apply → correct response types."""
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    assert preview_resp.status_code == 200
+    assert preview_resp.json()["response_type"] == "preview_edit"
+
+    plan_id = preview_resp.json()["data"]["plan_id"]
+    assert plan_id is not None
+
+    approve_resp = client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": plan_id, "approved": True},
+    )
+    assert approve_resp.status_code == 200
+
+    apply_resp = client.post("/api/v2/apply", json={"session_id": session_with_plan})
+    assert apply_resp.status_code == 200
+    assert apply_resp.json()["response_type"] == "applied_edit"
+
+
+def test_preview_after_rejection_still_works(client, session_with_plan):
+    """Can re-preview after rejecting."""
+    preview_resp = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    plan_id = preview_resp.json()["data"]["plan_id"]
+
+    client.post(
+        "/api/v2/approve",
+        json={"session_id": session_with_plan, "plan_id": plan_id, "approved": False},
+    )
+
+    preview_resp2 = client.post("/api/v2/preview", json={"session_id": session_with_plan})
+    assert preview_resp2.status_code == 200

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -163,6 +163,21 @@ class RevisionApplyRequest(BaseModel):
     session_id: str
 
 
+class V2PreviewRequest(BaseModel):
+    session_id: str
+
+
+class V2ApproveRequest(BaseModel):
+    session_id: str
+    plan_id: str
+    approved: bool
+    notes: str = ""
+
+
+class V2ApplyRequest(BaseModel):
+    session_id: str
+
+
 # ---------------------------------------------------------------------------
 # Dependency: get authenticated user
 # ---------------------------------------------------------------------------
@@ -551,6 +566,25 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 session.changeset = changeset
                 audit.llm_time_ms = (_time.monotonic() - llm_start) * 1000
 
+                # Build structured EditPlan for preview/apply workflow (EPIC-CAD-08)
+                try:
+                    from cad_dxf_agent.llm.plan_builder import EditPlanBuilder, PlanRequest as PlanReq
+
+                    plan_req = PlanReq(
+                        prompt=body.prompt,
+                        drawing_context=session.context,
+                        request_id=getattr(body, "request_id", ""),
+                        target_handles=[
+                            op.target_handle
+                            for op in changeset.operations
+                            if op.target_handle
+                        ] or None,
+                    )
+                    edit_plan = EditPlanBuilder().build(plan_req)
+                    session.edit_plan = edit_plan
+                except Exception as plan_err:
+                    logger.warning("EditPlan build failed (non-fatal): %s", plan_err)
+
                 val_start = _time.monotonic()
                 validation = validate_changeset(changeset, session.context, rule_config)
                 audit.validation_time_ms = (_time.monotonic() - val_start) * 1000
@@ -604,6 +638,158 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
         return ResponseBuilder.unsupported_operation(
             family=intent.family, audit=audit,
         ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# v2 Preview / Approve / Apply (EPIC-CAD-08)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/api/v2/preview")
+async def v2_preview(body: V2PreviewRequest, user: dict = Depends(get_user)):
+    """Build a structured preview from the session's edit plan."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_plan is None:
+        raise HTTPException(status_code=400, detail="No edit plan in session. Send a prompt first.")
+
+    from cad_dxf_agent.core.preview_builder import EditPreviewBuilder
+    from cad_dxf_agent.llm.response_builder import ResponseBuilder
+    from cad_dxf_agent.models.apply_schema import AuditEvent
+    from cad_dxf_agent.models.response_schema import AuditMetadata
+
+    builder = EditPreviewBuilder(session.context)
+    preview = builder.build(session.edit_plan)
+    session.edit_preview = preview
+
+    # Record audit event
+    session.audit_events.append(
+        AuditEvent(
+            event_type="preview_generated",
+            plan_id=session.edit_plan.plan_id,
+            preview_id=preview.preview_id,
+            actor=user["uid"],
+            details={"total_actions": preview.total_actions, "status": preview.status.value},
+        ).model_dump()
+    )
+
+    audit = AuditMetadata()
+    return ResponseBuilder.structured_preview(
+        preview=preview,
+        audit=audit,
+    ).model_dump()
+
+
+@app.post("/api/v2/approve")
+async def v2_approve(body: V2ApproveRequest, user: dict = Depends(get_user)):
+    """Record an approval or rejection decision for an edit plan."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_plan is None:
+        raise HTTPException(status_code=400, detail="No edit plan in session.")
+
+    if session.edit_plan.plan_id != body.plan_id:
+        raise HTTPException(status_code=400, detail="Plan ID mismatch.")
+
+    from cad_dxf_agent.models.apply_schema import ApprovalDecision, AuditEvent
+
+    decision = ApprovalDecision(
+        plan_id=body.plan_id,
+        approved=body.approved,
+        approved_by=user["uid"],
+        notes=body.notes,
+    )
+    session.edit_approval = decision
+
+    event_type = "approval_granted" if body.approved else "approval_rejected"
+    session.audit_events.append(
+        AuditEvent(
+            event_type=event_type,
+            plan_id=body.plan_id,
+            actor=user["uid"],
+            details={"approved": body.approved, "notes": body.notes},
+        ).model_dump()
+    )
+
+    return {
+        "plan_id": body.plan_id,
+        "approved": body.approved,
+        "event_type": event_type,
+    }
+
+
+@app.post("/api/v2/apply")
+async def v2_apply(body: V2ApplyRequest, user: dict = Depends(get_user)):
+    """Apply the approved edit plan to the DXF file."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_plan is None:
+        raise HTTPException(status_code=400, detail="No edit plan in session.")
+
+    if session.context is None:
+        raise HTTPException(status_code=400, detail="No drawing context in session.")
+
+    from cad_dxf_agent.core.apply_pipeline import ApplyPipeline
+    from cad_dxf_agent.llm.response_builder import ResponseBuilder
+    from cad_dxf_agent.models.apply_schema import AuditEvent
+    from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+    from cad_dxf_agent.models.response_schema import AuditMetadata
+
+    session_dir = Path("/tmp/cad-sessions") / session.session_id
+    output_path = session_dir / "edited.dxf"
+
+    pipeline = ApplyPipeline(session.context)
+    result = pipeline.apply(
+        plan=session.edit_plan,
+        dxf_path=session.working_path or session.original_path,
+        output_path=output_path,
+        approval=session.edit_approval,
+        revision_config=RevisionNoteConfig(enabled=True),
+    )
+
+    session.edit_apply_result = result
+    if result.output_path:
+        session.edited_path = Path(result.output_path)
+
+    # Render edited preview
+    try:
+        from cad_dxf_agent.core.renderer import render_dxf_to_png
+
+        render_result = render_dxf_to_png(output_path, session_dir / "edited.png")
+        if render_result.success:
+            session.edited_render = render_result.output_path
+    except Exception as render_err:
+        logger.warning("Edited render failed (non-fatal): %s", render_err)
+
+    # Record audit event
+    session.audit_events.append(
+        AuditEvent(
+            event_type="apply_executed",
+            plan_id=session.edit_plan.plan_id,
+            apply_id=result.apply_id,
+            actor=user["uid"],
+            details={
+                "status": result.status.value,
+                "success_count": result.success_count,
+                "failure_count": result.failure_count,
+            },
+        ).model_dump()
+    )
+
+    audit = AuditMetadata()
+    return ResponseBuilder.structured_apply_result(
+        result=result,
+        audit=audit,
+    ).model_dump()
 
 
 @app.post("/api/apply")

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -237,9 +237,15 @@ async def upload(
     session = session_mgr.create(user_id=user["uid"])
     session_dir = Path("/tmp/cad-sessions") / session.session_id
 
-    # Save uploaded file
+    # Save uploaded file — enforce size limit (ARCH-REVIEW-CAD-01 P0)
+    MAX_UPLOAD_SIZE = 25 * 1024 * 1024  # 25 MB
     upload_path = session_dir / f"upload{ext}"
     content = await file.read()
+    if len(content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large ({len(content) / 1024 / 1024:.1f} MB). Maximum is 25 MB.",
+        )
     upload_path.write_bytes(content)
 
     # Convert if needed

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -46,6 +46,12 @@ class Session:
     approval_set: object | None = None  # ApprovalSet
     apply_result: object | None = None  # ApplyResult
     bundle_dir: Path | None = None
+    # EPIC-CAD-08: Structured edit plan preview + apply state
+    edit_plan: object | None = None
+    edit_preview: object | None = None
+    edit_approval: object | None = None
+    edit_apply_result: object | None = None
+    audit_events: list = field(default_factory=list)
 
 
 class SessionManager:

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -48,6 +48,7 @@ export default function PreviewPanel({
   editApplyResult: structuredApplyResult,
   onPreviewPlan,
   onApprovePlan,
+  onApproveAndApplyPlan,
   onApplyPlan,
 }) {
   const [activeTab, setActiveTab] = useState('original');
@@ -646,7 +647,7 @@ export default function PreviewPanel({
             <div className="flex gap-2" style={{ marginTop: 'var(--space-2)' }}>
               <button
                 className="btn btn--primary btn--full"
-                onClick={() => { onApprovePlan?.(true); setTimeout(() => onApplyPlan?.(), 100); }}
+                onClick={() => onApproveAndApplyPlan?.()}
                 disabled={loading}
               >
                 {loading ? <span className="spinner" aria-hidden="true" /> : 'Approve & Apply'}

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -44,6 +44,11 @@ export default function PreviewPanel({
   onRevisionApply,
   onBundleDownload,
   onRealign,
+  editPreview,
+  editApplyResult: structuredApplyResult,
+  onPreviewPlan,
+  onApprovePlan,
+  onApplyPlan,
 }) {
   const [activeTab, setActiveTab] = useState('original');
   const hasEdited = !!previewUrls.edited;
@@ -598,8 +603,89 @@ export default function PreviewPanel({
         </>
       )}
 
+      {/* ===== STRUCTURED PREVIEW (EPIC-CAD-08) ===== */}
+      {editPreview && activeTab !== 'comparison' && (
+        <div className="preview__controls">
+          <div className="op-list">
+            <h4 className="op-list__title">
+              Edit Preview
+              {editPreview.data?.status === 'blocked' && (
+                <span className="comparison-badge comparison-badge--removed" style={{ marginLeft: 'var(--space-2)' }}>Blocked</span>
+              )}
+            </h4>
+            {editPreview.operations?.map((op, i) => (
+              <div key={op.action_id || i} className="revision-op-item">
+                <div className="revision-op-item__header">
+                  <span className={`op-item__type op-item__type--${opTypeClass(op.action_type)}`}>
+                    {op.action_type}
+                  </span>
+                  <span className="revision-op-item__confidence" title="Confidence">
+                    {((op.confidence || 1) * 100).toFixed(0)}%
+                  </span>
+                  {op.is_destructive && (
+                    <span className="comparison-badge comparison-badge--removed">destructive</span>
+                  )}
+                </div>
+                <p className="revision-op-item__desc">{op.description}</p>
+                {op.before_state && Object.keys(op.before_state).length > 0 && (
+                  <div className="text-xs text-secondary">Before: {JSON.stringify(op.before_state)}</div>
+                )}
+                {op.after_state && Object.keys(op.after_state).length > 0 && (
+                  <div className="text-xs text-secondary">After: {JSON.stringify(op.after_state)}</div>
+                )}
+                {op.warnings?.length > 0 && (
+                  <div className="text-xs" style={{ color: 'var(--color-warning)' }}>
+                    {op.warnings.join('; ')}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {editPreview.data?.status !== 'blocked' && !structuredApplyResult && (
+            <div className="flex gap-2" style={{ marginTop: 'var(--space-2)' }}>
+              <button
+                className="btn btn--primary btn--full"
+                onClick={() => { onApprovePlan?.(true); setTimeout(() => onApplyPlan?.(), 100); }}
+                disabled={loading}
+              >
+                {loading ? <span className="spinner" aria-hidden="true" /> : 'Approve & Apply'}
+              </button>
+              <button
+                className="btn btn--ghost"
+                onClick={() => onApprovePlan?.(false)}
+                disabled={loading}
+              >
+                Reject
+              </button>
+            </div>
+          )}
+
+          {structuredApplyResult && (
+            <div className="bundle-download" style={{ marginTop: 'var(--space-2)' }}>
+              <p className="bundle-download__status">
+                {structuredApplyResult.data?.status === 'success' ? 'Applied successfully' : `Status: ${structuredApplyResult.data?.status || 'unknown'}`}
+                {' '}{structuredApplyResult.data?.success_count || 0} succeeded
+                {structuredApplyResult.data?.failure_count > 0 && (
+                  <span className="comparison-badge comparison-badge--removed" style={{ marginLeft: 'var(--space-2)' }}>
+                    {structuredApplyResult.data.failure_count} failed
+                  </span>
+                )}
+              </p>
+              <button
+                className="btn btn--secondary btn--full"
+                onClick={onDownload}
+                disabled={loading}
+              >
+                Download Edited DXF
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* ===== EDIT TAB CONTENT ===== */}
-      {(hasOperations || hasEdited) && activeTab !== 'comparison' && (
+      {!editPreview && (hasOperations || hasEdited) && activeTab !== 'comparison' && (
         <div className="preview__controls">
           {hasOperations && (
             <div className="op-list">

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -168,6 +168,12 @@ export default function Workspace({ user, onSignOut }) {
               onRevisionApply={session.handleRevisionApply}
               onBundleDownload={session.handleBundleDownload}
               onRealign={session.handleRealign}
+              editPreview={session.editPreview}
+              editApplyResult={session.editApplyResult}
+              onPreviewPlan={session.previewPlan}
+              onApprovePlan={session.approvePlan}
+              onApproveAndApplyPlan={session.approveAndApplyPlan}
+              onApplyPlan={session.applyPlan}
             />
           </section>
 

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -3,6 +3,7 @@ import {
   uploadFile, planEdit, v2Prompt, applyChanges, downloadFile, getRenderBlob, getDxfBlob,
   clearHistory, compareFiles, revisionUpload, revisionAlign, revisionDiff,
   revisionApprove, revisionApply, revisionDownloadUrl,
+  v2Preview, v2Approve, v2Apply,
 } from '../lib/api';
 
 const NO_CHANGES_MESSAGE = "I couldn't plan any changes. Try being more specific about which element to edit.";
@@ -28,6 +29,12 @@ export function useSession() {
   const [loading, setLoading] = useState(false);
   const [loadingStartTime, setLoadingStartTime] = useState(null);
   const [error, setError] = useState(null);
+
+  // Structured edit plan preview/apply state (EPIC-CAD-08)
+  const [editPreview, setEditPreview] = useState(null);
+  const [editApproval, setEditApproval] = useState(null);
+  const [editApplyResult, setEditApplyResult] = useState(null);
+  const [currentPlanId, setCurrentPlanId] = useState(null);
 
   // Revision pipeline state
   const [revisionFile, setRevisionFile] = useState(null);
@@ -465,6 +472,66 @@ export function useSession() {
     a.remove();
   }, [sessionId]);
 
+  // --- Structured edit plan preview/approve/apply (EPIC-CAD-08) ---
+
+  const previewPlan = useCallback(async () => {
+    if (!sessionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await v2Preview(sessionId);
+      setEditPreview(data);
+      if (data.data?.plan_id) setCurrentPlanId(data.data.plan_id);
+      setMessages((prev) => [...prev, msg('system', `Preview ready: ${data.data?.total_actions || 0} action(s)`)]);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  const approvePlan = useCallback(async (approved, notes = '') => {
+    if (!sessionId || !currentPlanId) return;
+    setError(null);
+    try {
+      const data = await v2Approve(sessionId, currentPlanId, approved, notes);
+      setEditApproval(data);
+      setMessages((prev) => [...prev, msg('system', approved ? 'Plan approved.' : 'Plan rejected.')]);
+    } catch (err) {
+      setError(err.message);
+    }
+  }, [sessionId, currentPlanId]);
+
+  const applyPlan = useCallback(async () => {
+    if (!sessionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await v2Apply(sessionId);
+      setEditApplyResult(data);
+      const status = data.data?.status || 'unknown';
+      const successCount = data.data?.success_count || 0;
+      const failCount = data.data?.failure_count || 0;
+      setMessages((prev) => [...prev, msg('system', `Apply ${status}: ${successCount} succeeded, ${failCount} failed`)]);
+
+      // Fetch edited render and DXF
+      const [renderRes, dxfRes] = await Promise.allSettled([
+        getRenderBlob(sessionId, 'edited'),
+        getDxfBlob(sessionId, 'edited'),
+      ]);
+      if (renderRes.status === 'fulfilled') {
+        setPreviewUrls((prev) => ({ ...prev, edited: URL.createObjectURL(renderRes.value) }));
+      }
+      if (dxfRes.status === 'fulfilled') {
+        setDxfUrls((prev) => ({ ...prev, edited: URL.createObjectURL(dxfRes.value) }));
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
   const reset = useCallback(() => {
     // Revoke blob URLs to free memory
     Object.values(previewUrls).forEach((url) => {
@@ -491,6 +558,10 @@ export function useSession() {
     setAlignmentResult(null);
     setDiffSummary(null);
     setWizardStep(1);
+    setEditPreview(null);
+    setEditApproval(null);
+    setEditApplyResult(null);
+    setCurrentPlanId(null);
     lastPromptRef.current = null;
   }, [previewUrls, dxfUrls]);
 
@@ -529,6 +600,13 @@ export function useSession() {
     handleRevisionApply,
     handleBundleDownload,
     handleRealign,
+    editPreview,
+    editApproval,
+    editApplyResult,
+    currentPlanId,
+    previewPlan,
+    approvePlan,
+    applyPlan,
     reset,
   };
 }

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -502,6 +502,39 @@ export function useSession() {
     }
   }, [sessionId, currentPlanId]);
 
+  const approveAndApplyPlan = useCallback(async (notes = '') => {
+    if (!sessionId || !currentPlanId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await v2Approve(sessionId, currentPlanId, true, notes);
+      setEditApproval({ approved: true, plan_id: currentPlanId });
+      setMessages((prev) => [...prev, msg('system', 'Plan approved.')]);
+
+      const data = await v2Apply(sessionId);
+      setEditApplyResult(data);
+      const status = data.data?.status || 'unknown';
+      const successCount = data.data?.success_count || 0;
+      const failCount = data.data?.failure_count || 0;
+      setMessages((prev) => [...prev, msg('system', `Apply ${status}: ${successCount} succeeded, ${failCount} failed`)]);
+
+      const [renderRes, dxfRes] = await Promise.allSettled([
+        getRenderBlob(sessionId, 'edited'),
+        getDxfBlob(sessionId, 'edited'),
+      ]);
+      if (renderRes.status === 'fulfilled') {
+        setPreviewUrls((prev) => ({ ...prev, edited: URL.createObjectURL(renderRes.value) }));
+      }
+      if (dxfRes.status === 'fulfilled') {
+        setDxfUrls((prev) => ({ ...prev, edited: URL.createObjectURL(dxfRes.value) }));
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, currentPlanId]);
+
   const applyPlan = useCallback(async () => {
     if (!sessionId) return;
     setLoading(true);
@@ -606,6 +639,7 @@ export function useSession() {
     currentPlanId,
     previewPlan,
     approvePlan,
+    approveAndApplyPlan,
     applyPlan,
     reset,
   };

--- a/web/frontend/src/lib/api.js
+++ b/web/frontend/src/lib/api.js
@@ -232,3 +232,32 @@ export async function revisionApply(sessionId) {
 export function revisionDownloadUrl(sessionId) {
   return `${API_BASE}/api/revision/download?session_id=${sessionId}`;
 }
+
+// --- v2 Preview / Approve / Apply (EPIC-CAD-08) ---
+
+export async function v2Preview(sessionId) {
+  const res = await request('/api/v2/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+  return res.json();
+}
+
+export async function v2Approve(sessionId, planId, approved, notes = '') {
+  const res = await request('/api/v2/approve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, plan_id: planId, approved, notes }),
+  });
+  return res.json();
+}
+
+export async function v2Apply(sessionId) {
+  const res = await request('/api/v2/apply', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+  return res.json();
+}


### PR DESCRIPTION
## Epic
EPIC-CAD-08: Preview + Apply Workflow

## Bead(s)
cad-6zz

## Summary
- **Preview pipeline**: `EditPreviewBuilder` generates typed `EditPreview` with per-action before/after state, confidence badges, risk levels, and destructive flags from `EditPlan` + `DrawingContext`
- **Apply pipeline**: `ApplyPipeline` orchestrates approval → convert → apply → save → revision notes, bridging EPIC-07's `EditPlan` into the existing `EditEngine` via `plan_to_changeset()` converter
- **Web endpoints**: `POST /api/v2/preview`, `/api/v2/approve`, `/api/v2/apply` with session-scoped audit trail
- **Frontend**: Structured preview cards with approve/reject controls in `PreviewPanel.jsx`

## New files
| File | Purpose |
|------|---------|
| `models/preview_schema.py` | PreviewStatus, ActionPreview, EditPreview |
| `models/apply_schema.py` | ApplyStatus, ActionResult, ApplyResult, AuditEvent, ApprovalDecision |
| `core/plan_converter.py` | `plan_to_changeset()` bridge from EditPlan → ChangeSet |
| `core/preview_builder.py` | `EditPreviewBuilder` with per-action before/after state |
| `core/apply_pipeline.py` | `ApplyPipeline` orchestrator |

## Test plan
- [x] 12 preview schema tests
- [x] 16 apply schema tests
- [x] 15 plan converter tests
- [x] 20 preview builder tests
- [x] 15 apply pipeline tests
- [x] 8 anti-regression tests
- [x] 4 golden end-to-end tests
- [x] 15 web endpoint tests
- [x] Full regression: 2021 passed, 0 failed
- [x] `make lint` — all checks passed
- [x] `make format` — clean
- [x] `make typecheck` — no issues

## Docs
- Session.py updated with EPIC-CAD-08 fields (documented inline)
- Audit trail is in-memory, session-scoped (2h TTL), not durable across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)