### PR TITLE
feat: EPIC-CAD-09 design operations workflow pack

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -44,6 +44,7 @@
 | 043 | AAR | [043-PM-AAR-epic-cad-03-aar.md](043-PM-AAR-epic-cad-03-aar.md) |
 | 048 | AAR | [048-PM-AAR-epic-cad-07-aar.md](048-PM-AAR-epic-cad-07-aar.md) |
 | 049 | AAR | [049-PM-AAR-epic-cad-08-aar.md](049-PM-AAR-epic-cad-08-aar.md) |
+| 050 | AAR | [050-PM-AAR-epic-cad-09-aar.md](050-PM-AAR-epic-cad-09-aar.md) |
 
 ### DR — Documentation & Reference
 | # | Type | File |
@@ -136,6 +137,7 @@
 | 047 | RL | REPT | Release v0.6.0 report (Phase 2 complete) |
 | 048 | PM | AAR | EPIC-CAD-07 end-of-phase report (Structured Edit Planning) |
 | 049 | PM | AAR | EPIC-CAD-08 end-of-phase report (Preview + Apply Workflow) |
+| 050 | PM | AAR | EPIC-CAD-09 end-of-phase report (Design Operations Workflow Pack) |
 
 ## Quick Reference
 

--- a/000-docs/041-PM-STAT-implementation-status.md
+++ b/000-docs/041-PM-STAT-implementation-status.md
@@ -20,7 +20,7 @@
 | — | ARCH-REVIEW-01 | cad-sfw | DONE | `feature/arch-review-cad-01` | — | [046-AT-AUDT](046-AT-AUDT-arch-review-cad-01.md): 10-dimension review, CONDITIONAL GO for EPIC-07, 3 prerequisites, 2 constraints | N/A (review output is ADR document) |
 | 07 | Structured Edit Planning | cad-9ug | DONE | `feature/epic-cad-07-edit-planning` | #85 | `plan_schema.py` (EditPlan, EditAction, 5 action types), `plan_builder.py` (deterministic, no LLM), `plan_validator.py` (protected layers, text trust, move limits), `text_utils.py` (shared utilities) | 109 tests — unit (25 schema + 30 builder + 20 validator + 16 text_utils), anti-regression (15), golden (10) |
 | 08 | Preview + Apply Workflow | cad-6zz | DONE | `feature/epic-cad-08-preview-apply` | #86 | `preview_schema.py`, `apply_schema.py`, `plan_converter.py`, `preview_builder.py`, `apply_pipeline.py`, web endpoints (`/api/v2/preview`, `/approve`, `/apply`), `PreviewPanel.jsx`, session-scoped audit trail | 105 tests — unit (12 preview schema + 20 preview builder + 16 apply schema + 15 apply pipeline + 15 plan converter), anti-regression (8), golden (4), web (15) |
-| 09 | Design Operations Workflow Pack | cad-ady | NOT STARTED | — | — | `workflows/design_ops.py`, prompt templates for layout/revision/takeoff | TBD — golden trajectories (design_ops families), scorecard entries, live API tests |
+| 09 | Design Operations Workflow Pack | cad-ady | DONE | `feature/epic-cad-09-design-operations` | #88 | `design_ops_schema.py`, `design_ops.py` (LayoutRecommender, RevisionSummarizer, TakeoffGenerator, ScopeBuilder), `DesignOpsPanel.jsx`, web dispatch for 3 task families, intent router patterns | 176 tests — unit (34 schema + 30 layout + 22 revision + 27 takeoff + 20 scope + 23 anti-regression), web (20 endpoint), 4 golden trajectories |
 | 10 | Construction Drawing Workflow Pack | cad-8p2 | NOT STARTED | — | — | `workflows/construction.py`, prompt templates for grid/bay/markup/batch | TBD — golden trajectories (construction families), scorecard entries, live API tests |
 | 11 | Session Durability + Scale Readiness | cad-36p | NOT STARTED | — | — | `core/session_store.py` (ABC + GCS impl), durable metadata model, tracing/metrics | TBD — unit (session store, metadata model), integration (persistence round-trip), migration tests |
 | 12 | Evaluation Harness + Quality Governance | cad-m7d | NOT STARTED | — | — | `tests/eval/` fixture packs, `scripts/run_eval.py`, scorecard JSON schema, CI regression | TBD — meta-tests (scorecard schema validation), CI smoke (eval harness runs clean) |
@@ -35,7 +35,7 @@
 | **Phase 2: Core Intelligence** | 04, 05, 06 | 3/3 COMPLETE (+ SQ67 done) | Golden trajectories pass per family |
 | **Architecture Review** | ARCH-REVIEW-01 | COMPLETE | CONDITIONAL GO — doc 046 published, 3 prerequisites for EPIC-07 |
 | **Phase 3: Structured Editing** | 07, 08 | 2/2 COMPLETE | EPIC-07 DONE (edit plan schema + builder + validator). EPIC-08 DONE (preview + apply workflow, PR #86). Phase gate: structured edit plans validated, previewed, and applied end-to-end. |
-| **Phase 4: Workflow Packs** | 09, 10 | 0/2 complete | Domain scorecard entries pass. Key files: `src/cad_dxf_agent/workflows/design_ops.py`, `src/cad_dxf_agent/workflows/construction.py`, domain-specific prompt templates |
+| **Phase 4: Workflow Packs** | 09, 10 | 1/2 complete | EPIC-09 DONE (design-ops: layout, revision, takeoff, scope). Key files: `src/cad_dxf_agent/core/design_ops.py`, `src/cad_dxf_agent/models/design_ops_schema.py`, `src/cad_dxf_agent/workflows/construction.py` |
 | **Phase 5: Production Readiness** | 11, 12 | 0/2 complete | Durable sessions + full scorecard green. Key files: `src/cad_dxf_agent/core/session_store.py` (GCS integration), `tests/eval/`, `scripts/run_eval.py`, scorecard schema |
 
 ---
@@ -55,7 +55,7 @@ EPIC-01 (DONE) → EPIC-02 (DONE)
 ```
 
 **Critical path:** Phase 1 COMPLETE. Phase 2 COMPLETE. ARCH-REVIEW-01 COMPLETE (CONDITIONAL GO).
-Phase 3 COMPLETE (EPIC-07 + EPIC-08). Next: Phase 4 (EPIC-09 Design Operations + EPIC-10 Construction Workflows).
+Phase 3 COMPLETE (EPIC-07 + EPIC-08). Phase 4: EPIC-09 DONE. Next: EPIC-10 (Construction Workflows).
 
 ---
 
@@ -78,11 +78,11 @@ Phase 3 COMPLETE (EPIC-07 + EPIC-08). Next: Phase 4 (EPIC-09 Design Operations +
 
 | Metric | Current (post-SQ67) | Target (all epics) |
 |--------|-------------------|-------------------|
-| Total tests | 2,144 (collected) | 2000+ |
+| Total tests | 2,249+ (collected) | 2000+ |
 | Coverage | ~95% | 70%+ |
-| Golden trajectories | 19 (edit_plan 5 + qna 6 + repeated_condition 4 + preview_apply 4) | 25+ (all 9 families) |
+| Golden trajectories | 23 (edit_plan 5 + qna 6 + repeated_condition 4 + preview_apply 4 + design_ops 4) | 25+ (all 9 families) |
 | Scorecard entries | 0 | 32+ |
-| Task families tested | 5 (edit_plan + compare + qna + repeated_condition + preview_apply) | 9 |
+| Task families tested | 8 (edit_plan + compare + qna + repeated_condition + preview_apply + design_assist + summary + takeoff_estimate) | 9 |
 | Scorecard pass rate (mock) | N/A | 100% |
 | Scorecard pass rate (live) | N/A | >= 95% |
 
@@ -119,7 +119,7 @@ Phase 3 COMPLETE (EPIC-07 + EPIC-08). Next: Phase 4 (EPIC-09 Design Operations +
 | — | ARCH-REVIEW-01 | DONE — doc 046 published. CONDITIONAL GO for EPIC-07 with 3 prerequisites (upload size, text_utils extraction, truncation confidence) |
 | 07 | Structured Edit Planning | DONE — PR #85. EditPlan schema (5 action types), deterministic plan builder (no LLM), plan validator (protected layers, text trust, move limits), shared text_utils. 109 new tests. All 3 ARCH-REVIEW prerequisites satisfied. |
 | 08 | Preview + Apply Workflow | DONE — PR #86. AAR: [049-PM-AAR](049-PM-AAR-epic-cad-08-aar.md) |
-| 09 | Design Operations Workflow Pack | Draft prompt templates for layout recommendations; implement `design_ops.py` workflow module |
+| 09 | Design Operations Workflow Pack | DONE — PR #88. AAR: [050-PM-AAR](050-PM-AAR-epic-cad-09-aar.md) |
 | 10 | Construction Drawing Workflow Pack | Gather sample construction drawings for regional convention analysis; draft grid/bay extraction logic |
 | 11 | Session Durability + Scale Readiness | Audit current in-memory session lifecycle; define `SessionStore` ABC with GCS-backed implementation |
 | 12 | Evaluation Harness + Quality Governance | Define scorecard JSON schema; scaffold `tests/eval/` directory with first fixture pack |
@@ -129,8 +129,8 @@ Phase 3 COMPLETE (EPIC-07 + EPIC-08). Next: Phase 4 (EPIC-09 Design Operations +
 ## 8. Global Next Actions
 
 1. **Phase 3 COMPLETE** — EPIC-07 (Structured Edit Planning, PR #85) + EPIC-08 (Preview + Apply Workflow, PR #86)
-2. **All ARCH-REVIEW-01 prerequisites satisfied** — upload size (P0), text_utils (P1), truncation confidence (P1)
-3. **Begin Phase 4** — EPIC-09 (Design Operations) + EPIC-10 (Construction Workflows)
+2. **EPIC-09 DONE** — Design Operations Workflow Pack (layout, revision, takeoff, scope). 176 new tests, 4 golden trajectories, 3 new task families wired.
+3. **Begin EPIC-10** — Construction Drawing Workflow Pack (grid/bay/markup/batch)
 
 ---
 
@@ -159,3 +159,4 @@ Phase 3 COMPLETE (EPIC-07 + EPIC-08). Next: Phase 4 (EPIC-09 Design Operations +
 | 2026-03-07 | ARCH-REVIEW-01 DONE: 10-dimension architecture review. CONDITIONAL GO for EPIC-07. Doc 046 published. Test count: 1,924. Coverage: 95.24%. Prerequisites: upload size validation (P0), extract text_utils (P1), truncation confidence (P1). |
 | 2026-03-07 | EPIC-07 DONE: PR #85. 4 new source files (plan_schema.py, plan_builder.py, plan_validator.py, text_utils.py). 109 new tests (25 schema + 30 builder + 20 validator + 15 anti-regression + 10 golden + 16 text_utils). All 3 ARCH-REVIEW prerequisites satisfied. Test count: 1,760 collected, all pass. Phase 3: 1/2 complete. Doc 048 added. |
 | 2026-03-07 | EPIC-08 DONE: PR #86. 5 new source files (preview_schema, apply_schema, plan_converter, preview_builder, apply_pipeline). 105 new tests. 3 web endpoints. Phase 3: 2/2 COMPLETE. Total tests: 2,144. Golden trajectories: 19. Task families: 5. Doc 049 added. |
+| 2026-03-07 | EPIC-09 DONE: PR #88. 2 new source files (design_ops_schema.py, design_ops.py — 4 classes). 176 new tests (156 unit + 20 web). 4 golden trajectories. 3 task families wired (design_assist, summary, takeoff_estimate). DesignOpsPanel.jsx frontend. Phase 4: 1/2 complete. Total tests: 2,249+. Golden trajectories: 23. Task families: 8. Doc 050 added. |

--- a/000-docs/050-PM-AAR-epic-cad-09-aar.md
+++ b/000-docs/050-PM-AAR-epic-cad-09-aar.md
@@ -1,0 +1,120 @@
+# 050 — EPIC-CAD-09 After Action Report
+
+**Epic:** EPIC-CAD-09 Design Operations Workflow Pack
+**Bead:** cad-ady (parent) + cad-ady.2 through cad-ady.5 (children)
+**Status:** DONE
+**Date:** 2026-03-07
+**Branch:** `feature/epic-cad-09-design-operations`
+**PR:** #88
+
+---
+
+## 1. Objective
+
+Add bounded, typed, evidence-grounded outputs for four design operations workflows:
+layout recommendations, revision summaries, takeoff candidates, and scope-style summaries.
+All deterministic (no LLM). All outputs surface confidence, caveats, and evidence.
+
+---
+
+## 2. Deliverables
+
+### New Source Files (2)
+
+| File | Purpose |
+|------|---------|
+| `src/cad_dxf_agent/models/design_ops_schema.py` | All Pydantic schemas: RecommendationType, LayoutRecommendation, LayoutRecommendationResult, ChangeSummaryEntry, CustomerRevisionSummary, TakeoffConfidence, TakeoffItem, TakeoffCandidateResult, ScopeSectionType, ScopeSection, ScopeSummary |
+| `src/cad_dxf_agent/core/design_ops.py` | Four classes: LayoutRecommender, RevisionSummarizer, TakeoffGenerator, ScopeBuilder |
+
+### Modified Source Files (5)
+
+| File | Change |
+|------|--------|
+| `src/cad_dxf_agent/llm/capability_registry.py` | Added DESIGN_ASSIST, SUMMARY, TAKEOFF_ESTIMATE to `_DEFAULT_ENABLED` |
+| `src/cad_dxf_agent/llm/intent_router.py` | Extended patterns for design-ops prompts (layout, placement, scope, revision summary, etc.) |
+| `src/cad_dxf_agent/llm/response_builder.py` | Added `design_assist()`, `summary_result()`, `takeoff_result()` static methods |
+| `web/backend/main.py` | Added dispatch for 3 task families in `/api/v2/prompt` handler |
+| `web/frontend/src/components/ChatPanel.jsx` | Renders DesignOpsPanel for design-ops responses |
+
+### Frontend (1)
+
+| File | Purpose |
+|------|---------|
+| `web/frontend/src/components/DesignOpsPanel.jsx` | Scope sections, recommendations, takeoff tables, revision summaries with confidence badges and caveats |
+
+### Test Files (8)
+
+| File | Tests |
+|------|-------|
+| `tests/unit/test_design_ops_schema.py` | 34 schema validation tests |
+| `tests/unit/test_layout_recommender.py` | 30 layout recommendation tests |
+| `tests/unit/test_revision_summarizer.py` | 22 revision summary tests |
+| `tests/unit/test_takeoff_generator.py` | 27 takeoff generation tests |
+| `tests/unit/test_scope_builder.py` | 20 scope assembly tests |
+| `tests/unit/test_design_ops_anti_regression.py` | 23 anti-regression guards |
+| `tests/web/test_design_ops_endpoints.py` | 20 web endpoint tests |
+| **Total** | **176 new tests** |
+
+### Golden Trajectories (4)
+
+- `design_ops_layout_recommendation.json`
+- `design_ops_revision_summary.json`
+- `design_ops_takeoff_candidate.json`
+- `design_ops_scope_summary.json`
+
+---
+
+## 3. Architecture Decisions
+
+1. **Single module, four classes** — All design-ops logic in `core/design_ops.py` rather than a separate `workflows/` package. Keeps imports simple and matches existing `core/` convention.
+
+2. **Deterministic-only** — No LLM calls. Layout recommendations analyze entity distribution; revision summaries translate structured diffs; takeoff counts blocks/layers/text labels; scope assembles all three. Confidence and caveats are first-class.
+
+3. **OCR provenance enforcement (SQ67)** — TakeoffGenerator checks `TextGeometry.is_high_trust`. OCR-derived quantities are capped at `ESTIMATE_ONLY` confidence with mandatory provenance warnings. Anti-regression tests prevent this from silently weakening.
+
+4. **Reuse existing routing infrastructure** — TaskFamily enums (DESIGN_ASSIST, SUMMARY, TAKEOFF_ESTIMATE) and PlatformResponse envelope from EPIC-02 used as-is. Only added dispatch blocks and response builder methods.
+
+---
+
+## 4. Metrics
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Total tests | 2,144 | 2,249+ |
+| Golden trajectories | 19 | 23 |
+| Task families tested | 5 | 8 |
+| Source files | — | +2 new, 5 modified |
+| Test files | — | +8 new, 3 modified |
+| Frontend components | — | +1 (DesignOpsPanel) |
+
+---
+
+## 5. What Went Well
+
+- **Schema-first design** — Writing `design_ops_schema.py` first made the generator classes straightforward to implement and test.
+- **Anti-regression coverage** — 23 dedicated anti-regression tests catch silent confidence inflation, missing caveats, and accidental edit operation leakage.
+- **Existing infrastructure reuse** — TaskFamily enum, PlatformResponse, intent router patterns, and web dispatch all extended cleanly without breaking existing tests.
+- **Text provenance integration** — SQ67 enforcement from SIDEQUEST-CAD-67 carried through naturally to takeoff confidence scoring.
+
+---
+
+## 6. What Could Improve
+
+- **Trajectory filter fragility** — Integration test trajectory loader broke when new JSON files (without `expected_turns`) were added. Fixed by checking key existence instead of task_family values. Consider a schema version field in trajectory files.
+- **Large module size** — `design_ops.py` has four classes (~400 lines). If EPIC-10 adds more, consider splitting into `core/design_ops/` package.
+
+---
+
+## 7. Phase 4 Status
+
+- EPIC-09: DONE
+- EPIC-10 (Construction Drawing Workflow Pack): NOT STARTED
+- Phase 4 gate: 1/2 complete
+
+---
+
+## Related Documents
+
+- [041-PM-STAT](041-PM-STAT-implementation-status.md) — Implementation status tracker
+- [036-AT-SPEC](036-AT-SPEC-response-contracts-taxonomy.md) — Response contracts (TaskFamily, PlatformResponse)
+- [044-AT-SPEC](044-AT-SPEC-sidequest-cad-67-text-accuracy.md) — Text provenance (SQ67, TextGeometry)

--- a/src/cad_dxf_agent/core/design_ops.py
+++ b/src/cad_dxf_agent/core/design_ops.py
@@ -1,0 +1,736 @@
+"""Design operations — deterministic analysis pipelines for design workflows.
+
+LayoutRecommender:   Analyze entity layout, density, placement patterns.
+RevisionSummarizer:  Translate comparison/changeset into plain-language summaries.
+TakeoffGenerator:    Count block inserts, layer entities, and text-derived quantities.
+ScopeBuilder:        Assemble all of the above into a scope-style report.
+
+All outputs are evidence-grounded. No LLM calls. No edit operations produced.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import TYPE_CHECKING
+
+from ..models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+)
+from ..models.design_ops_schema import (
+    ChangeSummaryEntry,
+    CustomerRevisionSummary,
+    LayoutRecommendation,
+    LayoutRecommendationResult,
+    RecommendationType,
+    ScopeSection,
+    ScopeSectionType,
+    ScopeSummary,
+    TakeoffCandidateResult,
+    TakeoffConfidence,
+    TakeoffItem,
+)
+from ..models.response_schema import EvidenceRef
+from .text_utils import describe_entity, entity_to_evidence
+
+if TYPE_CHECKING:
+    from ..models.comparison_schema import ComparisonResult
+    from ..models.ops_schema import ChangeSet
+    from ..models.qna_schema import RegionContext
+
+
+_TEXT_TYPES = frozenset({EntityType.TEXT, EntityType.MTEXT})
+
+
+# ---------------------------------------------------------------------------
+# 09.1 — Layout Recommender
+# ---------------------------------------------------------------------------
+
+
+class LayoutRecommender:
+    """Analyze drawing layout and produce bounded recommendations."""
+
+    def recommend(
+        self,
+        context: DrawingContext,
+        prompt: str,
+        region: RegionContext | None = None,
+    ) -> LayoutRecommendationResult:
+        entities = list(region.entities) if region else list(context.entities)
+        if not entities:
+            return LayoutRecommendationResult(
+                drawing_summary="Empty drawing — no entities to analyze.",
+                ambiguity_flags=["empty_drawing"],
+                limitations=["No entities available for analysis."],
+            )
+
+        recommendations: list[LayoutRecommendation] = []
+        ambiguity_flags: list[str] = []
+        limitations: list[str] = []
+
+        # Layer distribution analysis
+        layer_counts = Counter(e.layer for e in entities)
+        layer_recs = self._analyze_layer_distribution(entities, layer_counts)
+        recommendations.extend(layer_recs)
+
+        # Entity density analysis
+        density_recs = self._analyze_density(entities)
+        recommendations.extend(density_recs)
+
+        # Block placement patterns
+        block_recs = self._analyze_block_placement(entities)
+        recommendations.extend(block_recs)
+
+        # Text label analysis
+        text_recs = self._analyze_text_labels(entities)
+        recommendations.extend(text_recs)
+
+        # Region-specific caveats
+        if region and not region.is_whole_drawing:
+            ambiguity_flags.append("partial_region")
+            limitations.append("Analysis is limited to the selected region, not the whole drawing.")
+            for rec in recommendations:
+                rec.confidence = max(0.0, rec.confidence - 0.1)
+
+        if region and "context_truncated" in region.ambiguity_flags:
+            ambiguity_flags.append("context_truncated")
+            limitations.append("Entity count was capped; some entities may be excluded.")
+
+        # Sparse evidence check
+        text_count = sum(1 for e in entities if e.entity_type in _TEXT_TYPES)
+        if text_count < 3:
+            ambiguity_flags.append("sparse_text_evidence")
+            limitations.append("Few text labels available — recommendations may lack context.")
+            for rec in recommendations:
+                rec.confidence = max(0.0, rec.confidence - 0.15)
+
+        # Aggregate confidence = min of all recommendations
+        agg_conf = min((r.confidence for r in recommendations), default=0.0)
+
+        total = len(recommendations)
+        return LayoutRecommendationResult(
+            recommendations=recommendations,
+            drawing_summary=self._build_summary(entities, layer_counts),
+            total_recommendations=total,
+            aggregate_confidence=round(agg_conf, 2),
+            ambiguity_flags=ambiguity_flags,
+            limitations=limitations,
+        )
+
+    # -- Internal analyzers --
+
+    def _analyze_layer_distribution(
+        self,
+        entities: list[EntityRef],
+        layer_counts: Counter[str],
+    ) -> list[LayoutRecommendation]:
+        recs: list[LayoutRecommendation] = []
+        total = len(entities)
+        if total == 0:
+            return recs
+
+        for layer, count in layer_counts.most_common():
+            ratio = count / total
+            if ratio > 0.6 and total > 10:
+                evidence = [entity_to_evidence(e) for e in entities if e.layer == layer][:5]
+                recs.append(
+                    LayoutRecommendation(
+                        type=RecommendationType.GENERAL_OBSERVATION,
+                        title=f"High entity concentration on layer '{layer}'",
+                        description=(
+                            f"Layer '{layer}' contains {count} of {total} entities "
+                            f"({ratio:.0%}). Consider splitting into sub-layers."
+                        ),
+                        rationale="Concentrated layers can be harder to manage and filter.",
+                        evidence=evidence,
+                        confidence=0.85,
+                        affected_layers=[layer],
+                    )
+                )
+                break  # Only report the most concentrated layer
+
+        return recs
+
+    def _analyze_density(
+        self,
+        entities: list[EntityRef],
+    ) -> list[LayoutRecommendation]:
+        recs: list[LayoutRecommendation] = []
+        positioned = [e for e in entities if e.insert_point is not None]
+        if len(positioned) < 5:
+            return recs
+
+        xs = [e.insert_point.x for e in positioned]  # type: ignore[union-attr]
+        ys = [e.insert_point.y for e in positioned]  # type: ignore[union-attr]
+        x_range = max(xs) - min(xs) if xs else 0
+        y_range = max(ys) - min(ys) if ys else 0
+        area = max(x_range * y_range, 1.0)
+        density = len(positioned) / area
+
+        if density > 0.1:
+            sample = positioned[:5]
+            evidence = [entity_to_evidence(e) for e in sample]
+            recs.append(
+                LayoutRecommendation(
+                    type=RecommendationType.PLACEMENT_GUIDANCE,
+                    title="High entity density detected",
+                    description=(
+                        f"{len(positioned)} positioned entities across "
+                        f"{x_range:.0f}x{y_range:.0f} area "
+                        f"(density: {density:.3f}/unit\u00b2)."
+                    ),
+                    rationale="Dense areas may benefit from spacing adjustments.",
+                    evidence=evidence,
+                    confidence=0.70,
+                )
+            )
+
+        return recs
+
+    def _analyze_block_placement(
+        self,
+        entities: list[EntityRef],
+    ) -> list[LayoutRecommendation]:
+        recs: list[LayoutRecommendation] = []
+        inserts = [e for e in entities if e.entity_type == EntityType.INSERT]
+        if not inserts:
+            return recs
+
+        block_counts = Counter(e.block_name for e in inserts if e.block_name)
+        for block_name, count in block_counts.most_common(3):
+            if count >= 3:
+                block_entities = [e for e in inserts if e.block_name == block_name]
+                evidence = [entity_to_evidence(e) for e in block_entities[:5]]
+                layers = sorted({e.layer for e in block_entities})
+                recs.append(
+                    LayoutRecommendation(
+                        type=RecommendationType.REGION_USAGE,
+                        title=f"Repeated block '{block_name}' ({count} instances)",
+                        description=(
+                            f"Block '{block_name}' appears {count} times. "
+                            f"Placement pattern analysis available."
+                        ),
+                        rationale="Repeated blocks often indicate structural grid or fixture.",
+                        evidence=evidence,
+                        confidence=0.90,
+                        affected_layers=layers,
+                    )
+                )
+
+        return recs
+
+    def _analyze_text_labels(
+        self,
+        entities: list[EntityRef],
+    ) -> list[LayoutRecommendation]:
+        recs: list[LayoutRecommendation] = []
+        text_entities = [e for e in entities if e.entity_type in _TEXT_TYPES]
+        if not text_entities:
+            return recs
+
+        # Check for low-trust text
+        low_trust = [
+            e for e in text_entities if e.text_geometry and not e.text_geometry.is_high_trust
+        ]
+        if low_trust:
+            evidence = [entity_to_evidence(e) for e in low_trust[:3]]
+            recs.append(
+                LayoutRecommendation(
+                    type=RecommendationType.GENERAL_OBSERVATION,
+                    title=f"Low-trust text detected ({len(low_trust)} entities)",
+                    description=(
+                        f"{len(low_trust)} text entities have OCR or vector-outline "
+                        f"provenance. Labels may be inaccurate."
+                    ),
+                    rationale="OCR-derived text has lower confidence for identification.",
+                    evidence=evidence,
+                    confidence=0.60,
+                    caveats=["Text content may not exactly match the original drawing."],
+                )
+            )
+
+        return recs
+
+    def _build_summary(
+        self,
+        entities: list[EntityRef],
+        layer_counts: Counter[str],
+    ) -> str:
+        type_counts = Counter(e.entity_type.value for e in entities)
+        parts = [f"{len(entities)} entities across {len(layer_counts)} layers"]
+        for etype, count in type_counts.most_common(3):
+            parts.append(f"{count} {etype}")
+        return "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# 09.2 — Revision Summarizer
+# ---------------------------------------------------------------------------
+
+
+class RevisionSummarizer:
+    """Translate comparison results or changesets into plain-language summaries."""
+
+    def summarize(
+        self,
+        comparison_result: ComparisonResult | None = None,
+        changeset: ChangeSet | None = None,
+        context: DrawingContext | None = None,
+    ) -> CustomerRevisionSummary:
+        if comparison_result is not None:
+            return self._from_comparison(comparison_result, context)
+        if changeset is not None:
+            return self._from_changeset(changeset, context)
+        return CustomerRevisionSummary(
+            headline="No revision data available.",
+            caveats=["Neither comparison result nor changeset was provided."],
+            missing_context=["comparison_result", "changeset"],
+        )
+
+    def _from_comparison(
+        self,
+        result: ComparisonResult,
+        context: DrawingContext | None,
+    ) -> CustomerRevisionSummary:
+        from ..models.comparison_schema import ChangeCategory
+
+        entries: list[ChangeSummaryEntry] = []
+        areas: set[str] = set()
+        ambiguity_flags: list[str] = []
+        caveats: list[str] = []
+
+        category_counts: Counter[str] = Counter()
+        for change in result.changes:
+            if change.category == ChangeCategory.UNCHANGED:
+                continue
+            category_counts[change.category.value] += 1
+
+            # Build plain-language description
+            snapshot = change.revision_snapshot or change.master_snapshot
+            if snapshot is None:
+                continue
+
+            layer = snapshot.layer
+            areas.add(layer)
+            entity_type = snapshot.entity_type.value if snapshot.entity_type else "entity"
+
+            desc = self._plain_description(change.category, entity_type, snapshot)
+            tech = self._technical_detail(change)
+
+            evidence: list[EvidenceRef] = []
+            if snapshot.handle:
+                evidence.append(
+                    EvidenceRef(
+                        entity_handle=snapshot.handle,
+                        layer=layer,
+                        entity_type=entity_type,
+                        description=desc,
+                    )
+                )
+
+            entries.append(
+                ChangeSummaryEntry(
+                    change_type=change.category.value,
+                    plain_description=desc,
+                    technical_detail=tech,
+                    layer=layer,
+                    evidence=evidence,
+                    confidence=change.confidence,
+                )
+            )
+
+        # Build headline
+        total = sum(category_counts.values())
+        parts = []
+        for cat in ["added", "removed", "modified", "moved"]:
+            cnt = category_counts.get(cat, 0)
+            if cnt > 0:
+                parts.append(f"{cnt} {cat}")
+        headline = (
+            f"{total} change(s) detected: {', '.join(parts)}" if parts else "No changes detected."
+        )
+
+        if result.warnings:
+            caveats.extend(result.warnings)
+
+        return CustomerRevisionSummary(
+            headline=headline,
+            key_changes=entries,
+            overall_assessment=self._overall_assessment(category_counts, total),
+            change_count=total,
+            areas_affected=sorted(areas),
+            ambiguity_flags=ambiguity_flags,
+            caveats=caveats,
+        )
+
+    def _from_changeset(
+        self,
+        changeset: ChangeSet,
+        context: DrawingContext | None,
+    ) -> CustomerRevisionSummary:
+        entries: list[ChangeSummaryEntry] = []
+        areas: set[str] = set()
+
+        for op in changeset.operations:
+            op_type = op.op_type.value if hasattr(op.op_type, "value") else str(op.op_type)
+            layer = op.target_layer or "unknown"
+            areas.add(layer)
+
+            desc = self._op_to_plain(op_type, op, context)
+            entries.append(
+                ChangeSummaryEntry(
+                    change_type=op_type,
+                    plain_description=desc,
+                    layer=layer,
+                )
+            )
+
+        total = len(entries)
+        headline = f"{total} planned operation(s)." if total > 0 else "No operations planned."
+
+        return CustomerRevisionSummary(
+            headline=headline,
+            key_changes=entries,
+            overall_assessment=f"{total} edit operation(s) from the change plan.",
+            change_count=total,
+            areas_affected=sorted(areas),
+        )
+
+    # -- Helpers --
+
+    def _plain_description(self, category: object, entity_type: str, snapshot: object) -> str:
+        cat = str(category.value) if hasattr(category, "value") else str(category)
+        text_hint = ""
+        if hasattr(snapshot, "text_content") and snapshot.text_content:
+            preview = snapshot.text_content[:40]
+            text_hint = f" ('{preview}')"
+
+        templates = {
+            "added": f"A {entity_type} was added{text_hint}",
+            "removed": f"A {entity_type} was removed{text_hint}",
+            "modified": f"A {entity_type} was modified{text_hint}",
+            "moved": f"A {entity_type} was repositioned{text_hint}",
+        }
+        return templates.get(cat, f"A {entity_type} was changed{text_hint}")
+
+    def _technical_detail(self, change: object) -> str:
+        parts: list[str] = []
+        if hasattr(change, "displacement") and change.displacement:
+            d = change.displacement
+            parts.append(f"displacement=({d.x:.1f}, {d.y:.1f})")
+        if hasattr(change, "modifications") and change.modifications:
+            parts.append(f"fields={list(change.modifications.keys())}")
+        return "; ".join(parts) if parts else ""
+
+    def _op_to_plain(self, op_type: str, op: object, context: DrawingContext | None) -> str:
+        entity_desc = ""
+        if context and hasattr(op, "target_handle") and op.target_handle:
+            entity = context.get_entity_by_handle(op.target_handle)
+            if entity:
+                entity_desc = describe_entity(entity)
+
+        templates = {
+            "move_entity": "An element was repositioned",
+            "delete_entity": "An element was removed",
+            "edit_text": "A text label was updated",
+            "add_block": "A new block was inserted",
+        }
+        base = templates.get(op_type, f"Operation: {op_type}")
+        return f"{base} — {entity_desc}" if entity_desc else base
+
+    def _overall_assessment(self, counts: Counter[str], total: int) -> str:
+        if total == 0:
+            return "No changes were detected between the drawings."
+        parts = []
+        if counts.get("added"):
+            parts.append(f"{counts['added']} element(s) were added")
+        if counts.get("removed"):
+            parts.append(f"{counts['removed']} element(s) were removed")
+        if counts.get("modified"):
+            parts.append(f"{counts['modified']} element(s) were modified")
+        if counts.get("moved"):
+            parts.append(f"{counts['moved']} element(s) were repositioned")
+        return ". ".join(parts) + "."
+
+
+# ---------------------------------------------------------------------------
+# 09.3 — Takeoff Generator
+# ---------------------------------------------------------------------------
+
+_QUANTITY_PATTERN = re.compile(r"(\d+)\s*(?:x|ea|pcs?|units?|nos?\.?)\b", re.IGNORECASE)
+
+
+class TakeoffGenerator:
+    """Generate takeoff candidates by counting blocks, layers, and text hints."""
+
+    def generate(
+        self,
+        context: DrawingContext,
+        prompt: str,
+        region: RegionContext | None = None,
+    ) -> TakeoffCandidateResult:
+        entities = list(region.entities) if region else list(context.entities)
+        if not entities:
+            return TakeoffCandidateResult(
+                caveats=["No entities in drawing."],
+                ambiguity_flags=["empty_drawing"],
+            )
+
+        items: list[TakeoffItem] = []
+        provenance_warnings: list[str] = []
+        ambiguity_flags: list[str] = []
+        caveats: list[str] = []
+
+        # Block-based counting
+        block_items = self._count_blocks(entities)
+        items.extend(block_items)
+
+        # Layer-based counting (only for layers not already covered by blocks)
+        block_layers = {item.source_layer for item in block_items}
+        layer_items = self._count_by_layer(entities, exclude_layers=block_layers)
+        items.extend(layer_items)
+
+        # Text-derived quantity hints
+        text_items, text_warnings = self._extract_text_quantities(entities)
+        items.extend(text_items)
+        provenance_warnings.extend(text_warnings)
+
+        # Region caveats
+        if region and not region.is_whole_drawing:
+            ambiguity_flags.append("partial_region")
+            caveats.append("Counts are from the selected region only, not the entire drawing.")
+
+        # Compute aggregates
+        total_items = len(items)
+        total_quantity = sum(item.quantity for item in items)
+
+        # Aggregate confidence
+        if items:
+            confidence_order = [
+                TakeoffConfidence.ESTIMATE_ONLY,
+                TakeoffConfidence.LOW,
+                TakeoffConfidence.MEDIUM,
+                TakeoffConfidence.HIGH,
+            ]
+            worst = min(items, key=lambda i: confidence_order.index(i.confidence))
+            agg = worst.confidence
+        else:
+            agg = TakeoffConfidence.MEDIUM
+
+        return TakeoffCandidateResult(
+            items=items,
+            total_items=total_items,
+            total_quantity_items=total_quantity,
+            aggregate_confidence=agg,
+            ambiguity_flags=ambiguity_flags,
+            provenance_warnings=provenance_warnings,
+            caveats=caveats,
+        )
+
+    def _count_blocks(self, entities: list[EntityRef]) -> list[TakeoffItem]:
+        inserts = [e for e in entities if e.entity_type == EntityType.INSERT and e.block_name]
+        if not inserts:
+            return []
+
+        by_block: dict[str, list[EntityRef]] = {}
+        for e in inserts:
+            by_block.setdefault(e.block_name, []).append(e)  # type: ignore[arg-type]
+
+        items: list[TakeoffItem] = []
+        for block_name, block_entities in sorted(by_block.items()):
+            layers = sorted({e.layer for e in block_entities})
+            handles = [e.handle for e in block_entities]
+            items.append(
+                TakeoffItem(
+                    name=block_name,
+                    quantity=len(block_entities),
+                    unit="ea",
+                    source_layer=layers[0],
+                    source_block_name=block_name,
+                    entity_handles=handles,
+                    confidence=TakeoffConfidence.HIGH,
+                )
+            )
+        return items
+
+    def _count_by_layer(
+        self,
+        entities: list[EntityRef],
+        exclude_layers: set[str],
+    ) -> list[TakeoffItem]:
+        items: list[TakeoffItem] = []
+        layer_counts: Counter[str] = Counter()
+        layer_handles: dict[str, list[str]] = {}
+
+        for e in entities:
+            if e.layer in exclude_layers:
+                continue
+            if e.entity_type == EntityType.INSERT:
+                continue  # Already counted in block pass
+            layer_counts[e.layer] += 1
+            layer_handles.setdefault(e.layer, []).append(e.handle)
+
+        for layer, count in layer_counts.most_common():
+            if count >= 2:
+                items.append(
+                    TakeoffItem(
+                        name=f"Entities on '{layer}'",
+                        quantity=count,
+                        source_layer=layer,
+                        entity_handles=layer_handles.get(layer, [])[:20],
+                        confidence=TakeoffConfidence.MEDIUM,
+                        caveats=["Count based on layer membership, not element type."],
+                    )
+                )
+        return items
+
+    def _extract_text_quantities(
+        self,
+        entities: list[EntityRef],
+    ) -> tuple[list[TakeoffItem], list[str]]:
+        items: list[TakeoffItem] = []
+        warnings: list[str] = []
+
+        text_entities = [e for e in entities if e.entity_type in _TEXT_TYPES and e.text_content]
+        for e in text_entities:
+            match = _QUANTITY_PATTERN.search(e.text_content or "")
+            if not match:
+                continue
+
+            qty = int(match.group(1))
+            if qty <= 0 or qty > 10000:
+                continue
+
+            # SQ67: check text provenance
+            is_ocr = e.text_geometry is not None and not e.text_geometry.is_high_trust
+            if is_ocr:
+                confidence = TakeoffConfidence.ESTIMATE_ONLY
+                caveat_list = [
+                    "Quantity extracted from OCR text — may be inaccurate.",
+                    f"Text provenance: {e.text_geometry.provenance.value}",  # type: ignore[union-attr]
+                ]
+                warnings.append(
+                    f"OCR-derived quantity '{e.text_content}' on layer '{e.layer}' "
+                    f"— confidence downgraded to ESTIMATE_ONLY."
+                )
+                provenance = e.text_geometry.provenance if e.text_geometry else None  # type: ignore[union-attr]
+            else:
+                confidence = TakeoffConfidence.MEDIUM
+                caveat_list = ["Quantity derived from text label — verify against schedule."]
+                provenance = e.text_geometry.provenance if e.text_geometry else None
+
+            label = e.text_content[:60] if e.text_content else "unknown"
+            items.append(
+                TakeoffItem(
+                    name=f"Text-derived: '{label}'",
+                    quantity=qty,
+                    source_layer=e.layer,
+                    entity_handles=[e.handle],
+                    confidence=confidence,
+                    caveats=caveat_list,
+                    text_provenance=provenance,
+                )
+            )
+
+        return items, warnings
+
+
+# ---------------------------------------------------------------------------
+# 09.4 — Scope Builder
+# ---------------------------------------------------------------------------
+
+
+class ScopeBuilder:
+    """Assemble layout, summary, and takeoff into a scope-style report."""
+
+    def build(
+        self,
+        context: DrawingContext,
+        prompt: str,
+        region: RegionContext | None = None,
+        comparison_result: ComparisonResult | None = None,
+        changeset: ChangeSet | None = None,
+    ) -> ScopeSummary:
+        sections: list[ScopeSection] = []
+        omitted: list[str] = []
+        all_caveats: list[str] = []
+        ambiguity_flags: list[str] = []
+
+        # Layout recommendations
+        layout_result = LayoutRecommender().recommend(context, prompt, region)
+        if layout_result.recommendations:
+            sections.append(
+                ScopeSection(
+                    section_type=ScopeSectionType.LAYOUT_RECOMMENDATIONS,
+                    title="Layout Recommendations",
+                    content=layout_result.model_dump(),
+                    confidence=layout_result.aggregate_confidence,
+                    caveats=layout_result.limitations,
+                )
+            )
+        else:
+            omitted.append("layout_recommendations")
+
+        ambiguity_flags.extend(layout_result.ambiguity_flags)
+
+        # Revision summary
+        if comparison_result is not None or changeset is not None:
+            summary_result = RevisionSummarizer().summarize(
+                comparison_result=comparison_result,
+                changeset=changeset,
+                context=context,
+            )
+            sections.append(
+                ScopeSection(
+                    section_type=ScopeSectionType.REVISION_SUMMARY,
+                    title="Revision Summary",
+                    content=summary_result.model_dump(),
+                    confidence=min(
+                        (e.confidence for e in summary_result.key_changes),
+                        default=0.5,
+                    ),
+                    caveats=summary_result.caveats,
+                )
+            )
+            all_caveats.extend(summary_result.caveats)
+        else:
+            omitted.append("revision_summary")
+
+        # Takeoff candidates
+        takeoff_result = TakeoffGenerator().generate(context, prompt, region)
+        if takeoff_result.items:
+            _conf_to_float = {
+                TakeoffConfidence.HIGH: 0.95,
+                TakeoffConfidence.MEDIUM: 0.7,
+                TakeoffConfidence.LOW: 0.4,
+                TakeoffConfidence.ESTIMATE_ONLY: 0.2,
+            }
+            sections.append(
+                ScopeSection(
+                    section_type=ScopeSectionType.TAKEOFF_CANDIDATES,
+                    title="Takeoff Candidates",
+                    content=takeoff_result.model_dump(),
+                    confidence=_conf_to_float.get(takeoff_result.aggregate_confidence, 0.5),
+                    caveats=takeoff_result.caveats,
+                )
+            )
+            all_caveats.extend(takeoff_result.caveats)
+            ambiguity_flags.extend(takeoff_result.ambiguity_flags)
+        else:
+            omitted.append("takeoff_candidates")
+
+        # Aggregate confidence = min of available sections
+        agg_conf = min(
+            (s.confidence for s in sections if s.available),
+            default=0.0,
+        )
+
+        return ScopeSummary(
+            sections=sections,
+            aggregate_confidence=round(agg_conf, 2),
+            ambiguity_flags=ambiguity_flags,
+            omitted_sections=omitted,
+            caveats=all_caveats,
+        )

--- a/src/cad_dxf_agent/llm/capability_registry.py
+++ b/src/cad_dxf_agent/llm/capability_registry.py
@@ -17,6 +17,9 @@ _DEFAULT_ENABLED: frozenset[TaskFamily] = frozenset(
         TaskFamily.COMPARE,
         TaskFamily.QNA,
         TaskFamily.REPEATED_CONDITION,
+        TaskFamily.DESIGN_ASSIST,
+        TaskFamily.SUMMARY,
+        TaskFamily.TAKEOFF_ESTIMATE,
     }
 )
 

--- a/src/cad_dxf_agent/llm/intent_router.py
+++ b/src/cad_dxf_agent/llm/intent_router.py
@@ -120,6 +120,13 @@ _RULES: list[HeuristicRule] = [
             r"\boptimize\b",
             r"\brecommend\b",
             r"\bbetter\s+layout\b",
+            r"\blayout\b",
+            r"\bplacement\b",
+            r"\bspacing\b",
+            r"\barrangement\b",
+            r"\bscope\s+of\s+work\b",
+            r"\bfull\s+report\b",
+            r"\bdesign\s+summary\b",
         ),
     ),
     # Priority 7: Summary
@@ -131,6 +138,9 @@ _RULES: list[HeuristicRule] = [
             r"\bdescribe\b",
             r"\bstatistics\b",
             r"\bstats\b",
+            r"\brevision\s+summary\b",
+            r"\bexplain\s+changes\b",
+            r"\bwhat\s+was\s+updated\b",
         ),
     ),
     # Priority 8: Q&A

--- a/src/cad_dxf_agent/llm/response_builder.py
+++ b/src/cad_dxf_agent/llm/response_builder.py
@@ -121,6 +121,75 @@ class ResponseBuilder:
         )
 
     @staticmethod
+    def design_assist(
+        *,
+        message: str,
+        data: dict[str, Any],
+        evidence: list[Any] | None = None,
+        confidence: float | None = None,
+        ambiguity_flags: list[str] | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build a design_assist response (layout recommendations, scope summaries)."""
+        return PlatformResponse(
+            task_family=TaskFamily.DESIGN_ASSIST,
+            response_type=ResponseType.ANSWER_ONLY,
+            message=message,
+            evidence=evidence or [],
+            confidence=confidence,
+            data=data,
+            ambiguity_flags=ambiguity_flags or [],
+            risk_level=RiskLevel.NONE,
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
+    def summary_result(
+        *,
+        message: str,
+        data: dict[str, Any],
+        evidence: list[Any] | None = None,
+        confidence: float | None = None,
+        ambiguity_flags: list[str] | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build a summary response (revision summaries)."""
+        return PlatformResponse(
+            task_family=TaskFamily.SUMMARY,
+            response_type=ResponseType.ANSWER_ONLY,
+            message=message,
+            evidence=evidence or [],
+            confidence=confidence,
+            data=data,
+            ambiguity_flags=ambiguity_flags or [],
+            risk_level=RiskLevel.NONE,
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
+    def takeoff_result(
+        *,
+        message: str,
+        data: dict[str, Any],
+        evidence: list[Any] | None = None,
+        confidence: float | None = None,
+        ambiguity_flags: list[str] | None = None,
+        audit: AuditMetadata | None = None,
+    ) -> PlatformResponse:
+        """Build a takeoff_estimate response."""
+        return PlatformResponse(
+            task_family=TaskFamily.TAKEOFF_ESTIMATE,
+            response_type=ResponseType.ANSWER_ONLY,
+            message=message,
+            evidence=evidence or [],
+            confidence=confidence,
+            data=data,
+            ambiguity_flags=ambiguity_flags or [],
+            risk_level=RiskLevel.NONE,
+            audit=audit or AuditMetadata(),
+        )
+
+    @staticmethod
     def repeated_condition(
         *,
         message: str,

--- a/src/cad_dxf_agent/models/design_ops_schema.py
+++ b/src/cad_dxf_agent/models/design_ops_schema.py
@@ -1,0 +1,140 @@
+"""Design operations schemas — layout recommendations, revision summaries,
+takeoff candidates, and scope-style summary outputs.
+
+All deterministic (no LLM). Outputs surface confidence, caveats, and evidence.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .cad_schema import TextProvenance
+from .response_schema import EvidenceRef
+
+# ---------------------------------------------------------------------------
+# 09.1 — Layout Recommendations
+# ---------------------------------------------------------------------------
+
+
+class RecommendationType(StrEnum):
+    REGION_USAGE = "region_usage"
+    PLACEMENT_GUIDANCE = "placement_guidance"
+    LAYOUT_ALTERNATIVE = "layout_alternative"
+    GENERAL_OBSERVATION = "general_observation"
+
+
+class LayoutRecommendation(BaseModel):
+    type: RecommendationType
+    title: str
+    description: str
+    rationale: str
+    evidence: list[EvidenceRef] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    caveats: list[str] = Field(default_factory=list)
+    affected_layers: list[str] = Field(default_factory=list)
+    affected_region: str | None = None
+
+
+class LayoutRecommendationResult(BaseModel):
+    recommendations: list[LayoutRecommendation] = Field(default_factory=list)
+    drawing_summary: str = ""
+    methodology: str = "deterministic_analysis"
+    total_recommendations: int = 0
+    aggregate_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    ambiguity_flags: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# 09.2 — Customer-Facing Revision Summaries
+# ---------------------------------------------------------------------------
+
+
+class ChangeSummaryEntry(BaseModel):
+    change_type: str  # "added", "removed", "modified", "moved"
+    plain_description: str
+    technical_detail: str = ""
+    layer: str | None = None
+    evidence: list[EvidenceRef] = Field(default_factory=list)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class CustomerRevisionSummary(BaseModel):
+    headline: str
+    key_changes: list[ChangeSummaryEntry] = Field(default_factory=list)
+    overall_assessment: str = ""
+    change_count: int = 0
+    areas_affected: list[str] = Field(default_factory=list)
+    ambiguity_flags: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
+    missing_context: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# 09.3 — Takeoff Candidate Generation
+# ---------------------------------------------------------------------------
+
+
+class TakeoffConfidence(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    ESTIMATE_ONLY = "estimate_only"
+
+
+class TakeoffItem(BaseModel):
+    name: str
+    quantity: int
+    unit: str | None = None
+    source_layer: str
+    source_block_name: str | None = None
+    entity_handles: list[str] = Field(default_factory=list)
+    confidence: TakeoffConfidence = TakeoffConfidence.MEDIUM
+    caveats: list[str] = Field(default_factory=list)
+    text_provenance: TextProvenance | None = None
+
+
+class TakeoffCandidateResult(BaseModel):
+    items: list[TakeoffItem] = Field(default_factory=list)
+    methodology: str = "entity_counting"
+    total_items: int = 0
+    total_quantity_items: int = 0
+    aggregate_confidence: TakeoffConfidence = TakeoffConfidence.MEDIUM
+    ambiguity_flags: list[str] = Field(default_factory=list)
+    provenance_warnings: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# 09.4 — Scope-Style Summary
+# ---------------------------------------------------------------------------
+
+
+class ScopeSectionType(StrEnum):
+    LAYOUT_RECOMMENDATIONS = "layout_recommendations"
+    REVISION_SUMMARY = "revision_summary"
+    TAKEOFF_CANDIDATES = "takeoff_candidates"
+    GENERAL_NOTES = "general_notes"
+
+
+class ScopeSection(BaseModel):
+    section_type: ScopeSectionType
+    title: str
+    content: dict[str, Any] = Field(default_factory=dict)
+    available: bool = True
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    caveats: list[str] = Field(default_factory=list)
+
+
+class ScopeSummary(BaseModel):
+    title: str = "Design Operations Scope Summary"
+    sections: list[ScopeSection] = Field(default_factory=list)
+    generated_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    aggregate_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    ambiguity_flags: list[str] = Field(default_factory=list)
+    omitted_sections: list[str] = Field(default_factory=list)
+    caveats: list[str] = Field(default_factory=list)

--- a/tests/fixtures/trajectories/design_ops_layout_recommendation.json
+++ b/tests/fixtures/trajectories/design_ops_layout_recommendation.json
@@ -1,0 +1,10 @@
+{
+  "prompt": "Suggest layout improvements for the structural grid",
+  "description": "Design-ops returns layout recommendations with evidence, no edit ops",
+  "task_family": "design_assist",
+  "response_type": "answer_only",
+  "expected_data_keys": ["recommendations", "drawing_summary", "methodology", "total_recommendations", "aggregate_confidence"],
+  "must_not_produce_ops": true,
+  "must_have_evidence": false,
+  "risk_level": "none"
+}

--- a/tests/fixtures/trajectories/design_ops_revision_summary.json
+++ b/tests/fixtures/trajectories/design_ops_revision_summary.json
@@ -1,0 +1,10 @@
+{
+  "prompt": "Summarize what changed in the revision",
+  "description": "Design-ops returns customer-facing revision summary in plain language",
+  "task_family": "summary",
+  "response_type": "answer_only",
+  "expected_data_keys": ["headline", "key_changes", "overall_assessment", "change_count", "areas_affected"],
+  "must_not_produce_ops": true,
+  "must_have_evidence": false,
+  "risk_level": "none"
+}

--- a/tests/fixtures/trajectories/design_ops_scope_summary.json
+++ b/tests/fixtures/trajectories/design_ops_scope_summary.json
@@ -1,0 +1,10 @@
+{
+  "prompt": "Generate a full report scope of work for this drawing",
+  "description": "Design-ops assembles scope with layout, takeoff, and optional revision sections",
+  "task_family": "design_assist",
+  "response_type": "answer_only",
+  "expected_data_keys": ["sections", "aggregate_confidence", "omitted_sections", "caveats"],
+  "must_not_produce_ops": true,
+  "must_have_evidence": false,
+  "risk_level": "none"
+}

--- a/tests/fixtures/trajectories/design_ops_takeoff_candidate.json
+++ b/tests/fixtures/trajectories/design_ops_takeoff_candidate.json
@@ -1,0 +1,11 @@
+{
+  "prompt": "Generate a takeoff estimate for all blocks",
+  "description": "Design-ops counts blocks and text quantities, OCR text is caveated",
+  "task_family": "takeoff_estimate",
+  "response_type": "answer_only",
+  "expected_data_keys": ["items", "methodology", "total_items", "total_quantity_items", "aggregate_confidence"],
+  "must_not_produce_ops": true,
+  "must_have_evidence": false,
+  "risk_level": "none",
+  "ocr_must_be_estimate_only": true
+}

--- a/tests/integration/test_agent_loop_integration.py
+++ b/tests/integration/test_agent_loop_integration.py
@@ -112,7 +112,7 @@ class TestGoldenTrajectories:
             with open(path) as f:
                 data = json.load(f)
             # Skip non-agent-loop fixtures (different format, no expected_turns)
-            if data.get("task_family") in ("qna", "repeated_condition"):
+            if "expected_turns" not in data:
                 continue
             data["_file"] = path.name
             trajectories.append(data)

--- a/tests/integration/test_routing_pipeline.py
+++ b/tests/integration/test_routing_pipeline.py
@@ -88,8 +88,8 @@ class TestRoutingPipelineIntegration:
         assert data["audit"]["llm_time_ms"] is None
         assert data["audit"]["validation_time_ms"] is None
 
-    def test_unsupported_never_reaches_planner(self, client, uploaded_session):
-        """Summary prompt should return unsupported without calling the planner."""
+    def test_summary_is_deterministic_no_llm(self, client, uploaded_session):
+        """Summary prompt should return answer_only without calling the LLM."""
         session_id, _ = uploaded_session
 
         resp = client.post(
@@ -99,7 +99,7 @@ class TestRoutingPipelineIntegration:
         data = resp.json()
 
         assert data["task_family"] == "summary"
-        assert data["response_type"] == "unsupported_operation"
+        assert data["response_type"] == "answer_only"
         assert data["audit"]["llm_time_ms"] is None
         assert data["audit"]["validation_time_ms"] is None
 

--- a/tests/unit/test_design_ops_anti_regression.py
+++ b/tests/unit/test_design_ops_anti_regression.py
@@ -1,0 +1,340 @@
+"""Anti-regression tests for design-ops pipeline.
+
+Invariants enforced here:
+- LayoutRecommender, RevisionSummarizer, TakeoffGenerator, and ScopeBuilder
+  NEVER produce edit operations of any kind.
+- OCR-derived text quantities are always capped at ESTIMATE_ONLY confidence.
+- All result models are fully serializable via model_dump().
+- No EditOperation or OpType references appear in any output.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.design_ops import (
+    LayoutRecommender,
+    RevisionSummarizer,
+    ScopeBuilder,
+    TakeoffGenerator,
+)
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.design_ops_schema import TakeoffConfidence
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity(
+    handle: str,
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.INSERT,
+    block_name: str | None = "MARK",
+    x: float = 0.0,
+    y: float = 0.0,
+    text_content: str | None = None,
+    text_geometry: TextGeometry | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        block_name=block_name,
+        insert_point=Point2D(x=x, y=y),
+        text_content=text_content,
+        text_geometry=text_geometry,
+    )
+
+
+def _context(entities: list[EntityRef]) -> DrawingContext:
+    layer_names = sorted({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+def _rich_context() -> DrawingContext:
+    """20 block inserts spread across a wide area to trigger density/block recs."""
+    entities = [
+        _entity(f"H{i:03d}", layer="STRUCTURAL", block_name="COL", x=float(i * 5), y=0.0)
+        for i in range(20)
+    ]
+    return _context(entities)
+
+
+def _ocr_text_entity(handle: str, text: str, layer: str = "NOTES") -> EntityRef:
+    tg = TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT, height=2.5)
+    return _entity(
+        handle=handle,
+        layer=layer,
+        entity_type=EntityType.TEXT,
+        block_name=None,
+        text_content=text,
+        text_geometry=tg,
+    )
+
+
+def _native_text_entity(handle: str, text: str, layer: str = "NOTES") -> EntityRef:
+    tg = TextGeometry.for_provenance(TextProvenance.NATIVE_CAD_TEXT, height=2.5)
+    return _entity(
+        handle=handle,
+        layer=layer,
+        entity_type=EntityType.TEXT,
+        block_name=None,
+        text_content=text,
+        text_geometry=tg,
+    )
+
+
+def _comparison_with_adds() -> object:
+    from cad_dxf_agent.models.comparison_schema import (
+        ChangeCategory,
+        ComparisonResult,
+        EntityChange,
+        GeometrySnapshot,
+    )
+
+    snap = GeometrySnapshot(
+        handle="CMP1",
+        entity_type=EntityType.LINE,
+        layer="STRUCTURAL",
+        points=[Point2D(x=0, y=0), Point2D(x=10, y=0)],
+    )
+    return ComparisonResult(
+        changes=[
+            EntityChange(category=ChangeCategory.ADDED, revision_snapshot=snap, confidence=0.85)
+        ],
+        summary={"added": 1, "removed": 0, "modified": 0, "moved": 0, "unchanged": 0},
+    )
+
+
+# ---------------------------------------------------------------------------
+# No operations in model_dump() — four analyzers
+# ---------------------------------------------------------------------------
+
+
+class TestNoEditOperationsInOutput:
+    def test_layout_recommender_has_no_operations_key(self):
+        ctx = _rich_context()
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        dumped = result.model_dump()
+        assert "operations" not in dumped, (
+            "LayoutRecommendationResult must not contain an 'operations' key"
+        )
+
+    def test_revision_summarizer_has_no_operations_key(self):
+        comparison = _comparison_with_adds()
+        result = RevisionSummarizer().summarize(comparison_result=comparison)
+        dumped = result.model_dump()
+        assert "operations" not in dumped, (
+            "CustomerRevisionSummary must not contain an 'operations' key"
+        )
+
+    def test_takeoff_generator_has_no_operations_key(self):
+        ctx = _rich_context()
+        result = TakeoffGenerator().generate(ctx, "estimate columns")
+        dumped = result.model_dump()
+        assert "operations" not in dumped, (
+            "TakeoffCandidateResult must not contain an 'operations' key"
+        )
+
+    def test_scope_builder_has_no_operations_key(self):
+        ctx = _rich_context()
+        result = ScopeBuilder().build(ctx, "scope of work")
+        dumped = result.model_dump()
+        assert "operations" not in dumped, "ScopeSummary must not contain an 'operations' key"
+
+    def test_no_op_type_in_layout_output(self):
+        ctx = _rich_context()
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        dumped_str = str(result.model_dump())
+        assert "op_type" not in dumped_str
+
+    def test_no_op_type_in_takeoff_output(self):
+        ctx = _rich_context()
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        dumped_str = str(result.model_dump())
+        assert "op_type" not in dumped_str
+
+    def test_no_edit_operation_class_in_scope_output(self):
+        """Verify no EditOperation or OpType values appear in any section content."""
+        ctx = _rich_context()
+        comparison = _comparison_with_adds()
+        scope = ScopeBuilder().build(ctx, "scope of work", comparison_result=comparison)
+        for section in scope.sections:
+            content_str = str(section.content)
+            assert "EditOperation" not in content_str
+            # OpType string values: move_entity, edit_text, delete_entity, add_block
+            for op_val in ("move_entity", "edit_text", "delete_entity", "add_block"):
+                assert op_val not in content_str, (
+                    f"Section '{section.section_type}' content references op_type '{op_val}'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# OCR text provenance: confidence caps
+# ---------------------------------------------------------------------------
+
+
+class TestOCRTextConfidenceCap:
+    def test_ocr_text_quantity_is_estimate_only(self):
+        entities = [_ocr_text_entity("T1", "12 ea columns")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        ocr_items = [
+            item for item in result.items if item.confidence == TakeoffConfidence.ESTIMATE_ONLY
+        ]
+        assert len(ocr_items) >= 1, "OCR-derived quantity must be ESTIMATE_ONLY"
+
+    def test_ocr_text_quantity_has_provenance_warning(self):
+        entities = [_ocr_text_entity("T1", "12 ea columns")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        assert len(result.provenance_warnings) >= 1
+
+    def test_ocr_text_quantity_has_caveat_about_ocr(self):
+        entities = [_ocr_text_entity("T1", "12 ea columns")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        ocr_items = [
+            item for item in result.items if item.confidence == TakeoffConfidence.ESTIMATE_ONLY
+        ]
+        assert len(ocr_items) >= 1
+        ocr_item = ocr_items[0]
+        assert any("OCR" in c or "inaccurate" in c for c in ocr_item.caveats)
+
+    def test_many_ocr_matches_cannot_become_high_confidence(self):
+        """Flooding OCR text into the drawing must never yield HIGH confidence items."""
+        entities = [_ocr_text_entity(f"T{i}", f"{i + 1} ea columns") for i in range(30)]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        for item in result.items:
+            # Text-derived items originating from OCR must stay at ESTIMATE_ONLY
+            if item.text_provenance is not None:
+                assert item.confidence != TakeoffConfidence.HIGH, (
+                    f"OCR item '{item.name}' must not reach HIGH confidence"
+                )
+
+    def test_native_cad_text_not_downgraded_to_estimate_only(self):
+        """Native CAD text quantities must not be penalised to ESTIMATE_ONLY."""
+        entities = [_native_text_entity("T1", "5 ea beams")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        native_items = [
+            item for item in result.items if item.text_provenance == TextProvenance.NATIVE_CAD_TEXT
+        ]
+        assert len(native_items) >= 1
+        for item in native_items:
+            assert item.confidence != TakeoffConfidence.ESTIMATE_ONLY, (
+                "Native CAD text quantity was incorrectly downgraded to ESTIMATE_ONLY"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Low-confidence propagation to layout recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestLowConfidencePropagation:
+    def test_low_trust_text_adds_caveat_to_layout_result(self):
+        entities = [_entity(f"I{i}", block_name="COL", x=float(i * 5)) for i in range(20)] + [
+            _ocr_text_entity("T1", "notes here", layer="NOTES")
+        ]
+        ctx = _context(entities)
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        # Low-trust text triggers a GENERAL_OBSERVATION recommendation with caveats
+        all_caveats = [c for rec in result.recommendations for c in rec.caveats]
+        # At minimum the limitations list or rec caveats should mention text
+        assert result.limitations or all_caveats or result.ambiguity_flags
+
+
+# ---------------------------------------------------------------------------
+# Empty-drawing robustness
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDrawingRobustness:
+    def test_layout_recommender_empty_drawing_does_not_crash(self):
+        ctx = _context([])
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        assert result is not None
+
+    def test_revision_summarizer_no_data_does_not_crash(self):
+        result = RevisionSummarizer().summarize()
+        assert result is not None
+        assert result.headline != ""
+
+    def test_takeoff_generator_empty_drawing_does_not_crash(self):
+        ctx = _context([])
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        assert result is not None
+
+    def test_scope_builder_empty_drawing_does_not_crash(self):
+        ctx = _context([])
+        result = ScopeBuilder().build(ctx, "scope of work")
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Serialisability
+# ---------------------------------------------------------------------------
+
+
+class TestSerialisation:
+    def test_layout_result_serialisable(self):
+        ctx = _rich_context()
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        dumped = result.model_dump()
+        assert isinstance(dumped, dict)
+
+    def test_revision_summary_serialisable(self):
+        comparison = _comparison_with_adds()
+        result = RevisionSummarizer().summarize(comparison_result=comparison)
+        dumped = result.model_dump()
+        assert isinstance(dumped, dict)
+
+    def test_takeoff_result_serialisable(self):
+        ctx = _rich_context()
+        result = TakeoffGenerator().generate(ctx, "takeoff estimate")
+        dumped = result.model_dump()
+        assert isinstance(dumped, dict)
+
+    def test_scope_result_serialisable(self):
+        ctx = _rich_context()
+        comparison = _comparison_with_adds()
+        result = ScopeBuilder().build(ctx, "scope of work", comparison_result=comparison)
+        dumped = result.model_dump()
+        assert isinstance(dumped, dict)
+
+
+# ---------------------------------------------------------------------------
+# Confidence bounds for sparse evidence
+# ---------------------------------------------------------------------------
+
+
+class TestSparseEvidenceConfidence:
+    def test_sparse_drawing_confidence_below_one(self):
+        """With only one entity, aggregate confidence must be strictly below 1.0."""
+        entities = [_entity("H001", block_name="COL")]
+        ctx = _context(entities)
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        # Either no recommendations (empty = 0.0) or confidence < 1.0
+        assert result.aggregate_confidence < 1.0
+
+    def test_layout_recommendations_have_bounded_confidence(self):
+        """Every individual recommendation confidence must be in [0, 1]."""
+        ctx = _rich_context()
+        result = LayoutRecommender().recommend(ctx, "suggest improvements")
+        for rec in result.recommendations:
+            assert 0.0 <= rec.confidence <= 1.0, (
+                f"Recommendation '{rec.title}' has out-of-bounds confidence {rec.confidence}"
+            )

--- a/tests/unit/test_design_ops_schema.py
+++ b/tests/unit/test_design_ops_schema.py
@@ -1,0 +1,387 @@
+"""Tests for design_ops_schema — layout recommendations, revision summaries,
+takeoff candidates, and scope-style summary outputs."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cad_dxf_agent.models.cad_schema import TextProvenance
+from cad_dxf_agent.models.design_ops_schema import (
+    ChangeSummaryEntry,
+    CustomerRevisionSummary,
+    LayoutRecommendation,
+    LayoutRecommendationResult,
+    RecommendationType,
+    ScopeSection,
+    ScopeSectionType,
+    ScopeSummary,
+    TakeoffCandidateResult,
+    TakeoffConfidence,
+    TakeoffItem,
+)
+
+# ---------------------------------------------------------------------------
+# RecommendationType
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationType:
+    def test_has_all_four_values(self):
+        assert len(RecommendationType) == 4
+
+    def test_string_values(self):
+        assert RecommendationType.REGION_USAGE == "region_usage"
+        assert RecommendationType.PLACEMENT_GUIDANCE == "placement_guidance"
+        assert RecommendationType.LAYOUT_ALTERNATIVE == "layout_alternative"
+        assert RecommendationType.GENERAL_OBSERVATION == "general_observation"
+
+    def test_is_str_enum(self):
+        assert isinstance(RecommendationType.REGION_USAGE, str)
+
+
+# ---------------------------------------------------------------------------
+# LayoutRecommendation
+# ---------------------------------------------------------------------------
+
+
+class TestLayoutRecommendation:
+    def test_creation_with_all_fields(self):
+        rec = LayoutRecommendation(
+            type=RecommendationType.PLACEMENT_GUIDANCE,
+            title="Space columns evenly",
+            description="Columns are unevenly distributed.",
+            rationale="Even spacing reduces coordination errors.",
+            confidence=0.85,
+            caveats=["Verify against grid plan."],
+            affected_layers=["STRUCTURAL"],
+            affected_region="Grid A-D",
+        )
+        assert rec.type == RecommendationType.PLACEMENT_GUIDANCE
+        assert rec.title == "Space columns evenly"
+        assert rec.confidence == 0.85
+        assert rec.caveats == ["Verify against grid plan."]
+        assert rec.affected_layers == ["STRUCTURAL"]
+        assert rec.affected_region == "Grid A-D"
+
+    def test_defaults(self):
+        rec = LayoutRecommendation(
+            type=RecommendationType.GENERAL_OBSERVATION,
+            title="Observation",
+            description="Something was observed.",
+            rationale="Because.",
+            confidence=0.5,
+        )
+        assert rec.evidence == []
+        assert rec.caveats == []
+        assert rec.affected_layers == []
+        assert rec.affected_region is None
+
+    def test_confidence_lower_bound(self):
+        rec = LayoutRecommendation(
+            type=RecommendationType.GENERAL_OBSERVATION,
+            title="T",
+            description="D",
+            rationale="R",
+            confidence=0.0,
+        )
+        assert rec.confidence == 0.0
+
+    def test_confidence_upper_bound(self):
+        rec = LayoutRecommendation(
+            type=RecommendationType.GENERAL_OBSERVATION,
+            title="T",
+            description="D",
+            rationale="R",
+            confidence=1.0,
+        )
+        assert rec.confidence == 1.0
+
+    def test_confidence_out_of_range_raises(self):
+        with pytest.raises(ValidationError):
+            LayoutRecommendation(
+                type=RecommendationType.GENERAL_OBSERVATION,
+                title="T",
+                description="D",
+                rationale="R",
+                confidence=1.1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# LayoutRecommendationResult
+# ---------------------------------------------------------------------------
+
+
+class TestLayoutRecommendationResult:
+    def test_defaults(self):
+        result = LayoutRecommendationResult()
+        assert result.recommendations == []
+        assert result.drawing_summary == ""
+        assert result.methodology == "deterministic_analysis"
+        assert result.total_recommendations == 0
+        assert result.aggregate_confidence == 0.0
+        assert result.ambiguity_flags == []
+        assert result.limitations == []
+
+    def test_serialization_to_dict(self):
+        result = LayoutRecommendationResult(
+            drawing_summary="10 entities across 3 layers",
+            total_recommendations=2,
+            aggregate_confidence=0.75,
+            ambiguity_flags=["partial_region"],
+        )
+        data = result.model_dump()
+        assert data["drawing_summary"] == "10 entities across 3 layers"
+        assert data["total_recommendations"] == 2
+        assert data["aggregate_confidence"] == 0.75
+        assert "partial_region" in data["ambiguity_flags"]
+
+
+# ---------------------------------------------------------------------------
+# ChangeSummaryEntry
+# ---------------------------------------------------------------------------
+
+
+class TestChangeSummaryEntry:
+    def test_creation(self):
+        entry = ChangeSummaryEntry(
+            change_type="added",
+            plain_description="A line was added to the drawing.",
+            technical_detail="handle=A1F",
+            layer="STRUCTURAL",
+            confidence=0.9,
+        )
+        assert entry.change_type == "added"
+        assert entry.plain_description == "A line was added to the drawing."
+        assert entry.layer == "STRUCTURAL"
+        assert entry.confidence == 0.9
+
+    def test_change_type_field_accepts_any_string(self):
+        for change_type in ("added", "removed", "modified", "moved"):
+            entry = ChangeSummaryEntry(
+                change_type=change_type,
+                plain_description="desc",
+            )
+            assert entry.change_type == change_type
+
+    def test_defaults(self):
+        entry = ChangeSummaryEntry(change_type="added", plain_description="desc")
+        assert entry.technical_detail == ""
+        assert entry.layer is None
+        assert entry.evidence == []
+        assert entry.confidence == 1.0
+
+
+# ---------------------------------------------------------------------------
+# CustomerRevisionSummary
+# ---------------------------------------------------------------------------
+
+
+class TestCustomerRevisionSummary:
+    def test_creation(self):
+        summary = CustomerRevisionSummary(
+            headline="3 change(s) detected: 1 added, 2 removed",
+            change_count=3,
+            areas_affected=["STRUCTURAL", "NOTES"],
+        )
+        assert summary.headline == "3 change(s) detected: 1 added, 2 removed"
+        assert summary.change_count == 3
+        assert "STRUCTURAL" in summary.areas_affected
+
+    def test_defaults(self):
+        summary = CustomerRevisionSummary(headline="No changes detected.")
+        assert summary.key_changes == []
+        assert summary.overall_assessment == ""
+        assert summary.change_count == 0
+        assert summary.areas_affected == []
+        assert summary.ambiguity_flags == []
+        assert summary.caveats == []
+        assert summary.missing_context == []
+
+    def test_empty_key_changes(self):
+        summary = CustomerRevisionSummary(headline="No changes.", key_changes=[])
+        assert summary.key_changes == []
+
+
+# ---------------------------------------------------------------------------
+# TakeoffConfidence
+# ---------------------------------------------------------------------------
+
+
+class TestTakeoffConfidence:
+    def test_has_all_four_values(self):
+        assert len(TakeoffConfidence) == 4
+
+    def test_string_values(self):
+        assert TakeoffConfidence.HIGH == "high"
+        assert TakeoffConfidence.MEDIUM == "medium"
+        assert TakeoffConfidence.LOW == "low"
+        assert TakeoffConfidence.ESTIMATE_ONLY == "estimate_only"
+
+    def test_is_str_enum(self):
+        assert isinstance(TakeoffConfidence.HIGH, str)
+
+
+# ---------------------------------------------------------------------------
+# TakeoffItem
+# ---------------------------------------------------------------------------
+
+
+class TestTakeoffItem:
+    def test_creation(self):
+        item = TakeoffItem(
+            name="COLUMN",
+            quantity=12,
+            unit="ea",
+            source_layer="STRUCTURAL",
+            source_block_name="COL-A",
+            entity_handles=["A1", "A2"],
+            confidence=TakeoffConfidence.HIGH,
+        )
+        assert item.name == "COLUMN"
+        assert item.quantity == 12
+        assert item.unit == "ea"
+        assert item.source_layer == "STRUCTURAL"
+        assert item.source_block_name == "COL-A"
+        assert item.confidence == TakeoffConfidence.HIGH
+
+    def test_text_provenance_field(self):
+        item = TakeoffItem(
+            name="Beam count",
+            quantity=4,
+            source_layer="NOTES",
+            text_provenance=TextProvenance.RASTER_OCR_TEXT,
+        )
+        assert item.text_provenance == TextProvenance.RASTER_OCR_TEXT
+
+    def test_text_provenance_none_by_default(self):
+        item = TakeoffItem(name="Beam", quantity=1, source_layer="STRUCTURAL")
+        assert item.text_provenance is None
+
+    def test_defaults(self):
+        item = TakeoffItem(name="Item", quantity=5, source_layer="LAYER-A")
+        assert item.unit is None
+        assert item.source_block_name is None
+        assert item.entity_handles == []
+        assert item.confidence == TakeoffConfidence.MEDIUM
+        assert item.caveats == []
+
+
+# ---------------------------------------------------------------------------
+# TakeoffCandidateResult
+# ---------------------------------------------------------------------------
+
+
+class TestTakeoffCandidateResult:
+    def test_defaults(self):
+        result = TakeoffCandidateResult()
+        assert result.items == []
+        assert result.methodology == "entity_counting"
+        assert result.total_items == 0
+        assert result.total_quantity_items == 0
+        assert result.aggregate_confidence == TakeoffConfidence.MEDIUM
+        assert result.ambiguity_flags == []
+        assert result.provenance_warnings == []
+        assert result.caveats == []
+
+    def test_with_items(self):
+        item = TakeoffItem(name="DOOR", quantity=6, source_layer="DOORS")
+        result = TakeoffCandidateResult(items=[item], total_items=1, total_quantity_items=6)
+        assert len(result.items) == 1
+        assert result.items[0].name == "DOOR"
+
+
+# ---------------------------------------------------------------------------
+# ScopeSectionType
+# ---------------------------------------------------------------------------
+
+
+class TestScopeSectionType:
+    def test_has_all_four_values(self):
+        assert len(ScopeSectionType) == 4
+
+    def test_string_values(self):
+        assert ScopeSectionType.LAYOUT_RECOMMENDATIONS == "layout_recommendations"
+        assert ScopeSectionType.REVISION_SUMMARY == "revision_summary"
+        assert ScopeSectionType.TAKEOFF_CANDIDATES == "takeoff_candidates"
+        assert ScopeSectionType.GENERAL_NOTES == "general_notes"
+
+
+# ---------------------------------------------------------------------------
+# ScopeSection
+# ---------------------------------------------------------------------------
+
+
+class TestScopeSection:
+    def test_creation(self):
+        section = ScopeSection(
+            section_type=ScopeSectionType.LAYOUT_RECOMMENDATIONS,
+            title="Layout Recommendations",
+            content={"total_recommendations": 2},
+            available=True,
+            confidence=0.8,
+            caveats=["Partial region only."],
+        )
+        assert section.section_type == ScopeSectionType.LAYOUT_RECOMMENDATIONS
+        assert section.title == "Layout Recommendations"
+        assert section.content["total_recommendations"] == 2
+        assert section.available is True
+        assert section.confidence == 0.8
+
+    def test_available_defaults_true(self):
+        section = ScopeSection(
+            section_type=ScopeSectionType.GENERAL_NOTES,
+            title="Notes",
+        )
+        assert section.available is True
+
+    def test_available_can_be_false(self):
+        section = ScopeSection(
+            section_type=ScopeSectionType.TAKEOFF_CANDIDATES,
+            title="Takeoff",
+            available=False,
+        )
+        assert section.available is False
+
+
+# ---------------------------------------------------------------------------
+# ScopeSummary
+# ---------------------------------------------------------------------------
+
+
+class TestScopeSummary:
+    def test_creation(self):
+        section = ScopeSection(
+            section_type=ScopeSectionType.GENERAL_NOTES,
+            title="Notes",
+            confidence=0.7,
+        )
+        summary = ScopeSummary(
+            sections=[section],
+            aggregate_confidence=0.7,
+            ambiguity_flags=["partial_region"],
+            caveats=["Region-scoped only."],
+        )
+        assert len(summary.sections) == 1
+        assert summary.aggregate_confidence == 0.7
+        assert "partial_region" in summary.ambiguity_flags
+
+    def test_generated_at_auto_set(self):
+        summary = ScopeSummary()
+        assert summary.generated_at != ""
+        # ISO 8601 format — contains a 'T' separator
+        assert "T" in summary.generated_at
+
+    def test_caveats_list(self):
+        summary = ScopeSummary(caveats=["caveat one", "caveat two"])
+        assert len(summary.caveats) == 2
+
+    def test_defaults(self):
+        summary = ScopeSummary()
+        assert summary.title == "Design Operations Scope Summary"
+        assert summary.sections == []
+        assert summary.aggregate_confidence == 0.0
+        assert summary.ambiguity_flags == []
+        assert summary.omitted_sections == []
+        assert summary.caveats == []

--- a/tests/unit/test_layout_recommender.py
+++ b/tests/unit/test_layout_recommender.py
@@ -1,0 +1,501 @@
+"""Tests for LayoutRecommender (design_ops EPIC-CAD-09).
+
+Covers:
+- Empty drawing path
+- Non-empty drawing produces recommendations
+- Layer concentration detection (>60%, >10 entities)
+- No concentration when evenly distributed
+- Block placement pattern detection (3+ repeated blocks)
+- Entity density calculation
+- Low-trust text detection (RASTER_OCR_TEXT)
+- No low-trust warning when all text is native CAD
+- Region context reduces confidence
+- Truncated context adds ambiguity flag
+- Sparse text evidence reduces confidence
+- Aggregate confidence is min of all recommendations
+- Drawing summary content
+- Anti-regression: no EditOperation objects in result
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.design_ops import LayoutRecommender
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.design_ops_schema import RecommendationType
+from cad_dxf_agent.models.qna_schema import RegionContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity(
+    handle: str,
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.LINE,
+    text: str | None = None,
+    block_name: str | None = None,
+    x: float = 0.0,
+    y: float = 0.0,
+    text_geometry: TextGeometry | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        text_content=text,
+        block_name=block_name,
+        insert_point=Point2D(x=x, y=y) if (x or y) else None,
+        text_geometry=text_geometry,
+    )
+
+
+def _context(entities: list[EntityRef], layers: list[str] | None = None) -> DrawingContext:
+    layer_names = layers or sorted({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+def _region(
+    entities: list[EntityRef],
+    *,
+    is_whole_drawing: bool = False,
+    ambiguity_flags: list[str] | None = None,
+) -> RegionContext:
+    layers = sorted({e.layer for e in entities})
+    layer_counts = {}
+    for e in entities:
+        layer_counts[e.layer] = layer_counts.get(e.layer, 0) + 1
+    return RegionContext(
+        entities=entities,
+        text_entities=[e for e in entities if e.entity_type in (EntityType.TEXT, EntityType.MTEXT)],
+        dimension_entities=[],
+        block_refs=[e for e in entities if e.entity_type == EntityType.INSERT],
+        layers=layers,
+        layer_counts=layer_counts,
+        block_names=sorted({e.block_name for e in entities if e.block_name}),
+        entity_count=len(entities),
+        total_drawing_entities=100,
+        confidence=0.8,
+        ambiguity_flags=ambiguity_flags or [],
+        is_whole_drawing=is_whole_drawing,
+    )
+
+
+_recommender = LayoutRecommender()
+
+
+# ---------------------------------------------------------------------------
+# Empty drawing
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDrawing:
+    def test_empty_drawing_returns_empty_recommendations(self):
+        ctx = _context([])
+        result = _recommender.recommend(ctx, "analyze layout")
+        assert result.recommendations == []
+
+    def test_empty_drawing_sets_empty_drawing_flag(self):
+        ctx = _context([])
+        result = _recommender.recommend(ctx, "analyze layout")
+        assert "empty_drawing" in result.ambiguity_flags
+
+    def test_empty_drawing_summary_describes_empty(self):
+        ctx = _context([])
+        result = _recommender.recommend(ctx, "analyze layout")
+        assert "empty" in result.drawing_summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Non-empty drawing produces recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestNonEmptyDrawing:
+    def test_drawing_with_entities_returns_result(self):
+        entities = [_entity(f"H{i}", x=float(i), y=float(i)) for i in range(5)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "analyze layout")
+        # Result should be a valid LayoutRecommendationResult with a drawing_summary
+        assert result.drawing_summary != ""
+
+    def test_drawing_with_many_entities_has_nonzero_summary_count(self):
+        entities = [_entity(f"H{i}", x=float(i * 10), y=float(i * 10)) for i in range(15)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "analyze layout")
+        assert "15 entities" in result.drawing_summary
+
+
+# ---------------------------------------------------------------------------
+# Layer concentration
+# ---------------------------------------------------------------------------
+
+
+class TestLayerConcentration:
+    def test_detects_concentration_above_60_percent_with_more_than_10_entities(self):
+        # 9 of 11 entities on STRUCTURAL = 81.8%
+        dominant = [_entity(f"S{i}", layer="STRUCTURAL") for i in range(9)]
+        others = [_entity(f"O{i}", layer="NOTES") for i in range(2)]
+        ctx = _context(dominant + others)
+        result = _recommender.recommend(ctx, "check layers")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.GENERAL_OBSERVATION in types
+        titles = [r.title for r in result.recommendations]
+        assert any("STRUCTURAL" in t for t in titles)
+
+    def test_no_concentration_warning_when_evenly_distributed(self):
+        # 5 entities per layer, 4 layers = 25% each — no concentration
+        entities = []
+        for layer in ("A", "B", "C", "D"):
+            for i in range(5):
+                entities.append(_entity(f"{layer}{i}", layer=layer))
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check layers")
+        titles = [r.title for r in result.recommendations]
+        assert not any("concentration" in t.lower() for t in titles)
+
+    def test_no_concentration_warning_when_total_is_10_or_fewer(self):
+        # 8 of 10 on one layer = 80%, but total == 10 so threshold not met (> 10 required)
+        dominant = [_entity(f"S{i}", layer="STRUCTURAL") for i in range(8)]
+        others = [_entity(f"O{i}", layer="NOTES") for i in range(2)]
+        ctx = _context(dominant + others)
+        result = _recommender.recommend(ctx, "check layers")
+        titles = [r.title for r in result.recommendations]
+        assert not any("concentration" in t.lower() for t in titles)
+
+
+# ---------------------------------------------------------------------------
+# Block placement patterns
+# ---------------------------------------------------------------------------
+
+
+class TestBlockPlacementPatterns:
+    def test_detects_repeated_block_with_3_or_more_instances(self):
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="COL-A", x=float(i * 5))
+            for i in range(4)
+        ]
+        ctx = _context(inserts)
+        result = _recommender.recommend(ctx, "find patterns")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.REGION_USAGE in types
+        titles = [r.title for r in result.recommendations]
+        assert any("COL-A" in t for t in titles)
+
+    def test_no_block_recommendation_for_fewer_than_3_instances(self):
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="COL-A", x=float(i * 5))
+            for i in range(2)
+        ]
+        ctx = _context(inserts)
+        result = _recommender.recommend(ctx, "find patterns")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.REGION_USAGE not in types
+
+    def test_block_recommendation_confidence_is_high(self):
+        # Block recs start at 0.90. A drawing with no text entities triggers the
+        # sparse_text_evidence penalty (-0.15), landing at 0.75. Add 3+ text
+        # entities so the sparse penalty does not fire and confidence stays at 0.90.
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="BEAM", x=float(i * 5))
+            for i in range(5)
+        ]
+        text_ents = [
+            _entity(
+                f"T{i}", entity_type=EntityType.TEXT, text=f"Label {i}", x=float(i * 50), y=100.0
+            )
+            for i in range(3)
+        ]
+        ctx = _context(inserts + text_ents)
+        result = _recommender.recommend(ctx, "find patterns")
+        block_recs = [
+            r for r in result.recommendations if r.type == RecommendationType.REGION_USAGE
+        ]
+        assert block_recs, "Expected at least one REGION_USAGE recommendation"
+        assert all(r.confidence >= 0.8 for r in block_recs)
+
+
+# ---------------------------------------------------------------------------
+# Entity density
+# ---------------------------------------------------------------------------
+
+
+class TestEntityDensity:
+    def test_high_density_produces_placement_guidance(self):
+        # 10 entities in a 3x3 area → density > 0.1
+        entities = [_entity(f"E{i}", x=float(i % 3), y=float(i // 3)) for i in range(10)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check density")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.PLACEMENT_GUIDANCE in types
+
+    def test_low_density_produces_no_density_recommendation(self):
+        # 5 entities spread across 1000 units — density far below 0.1
+        entities = [_entity(f"E{i}", x=float(i * 200), y=0.0) for i in range(5)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check density")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.PLACEMENT_GUIDANCE not in types
+
+
+# ---------------------------------------------------------------------------
+# Low-trust text detection
+# ---------------------------------------------------------------------------
+
+
+class TestLowTrustTextDetection:
+    def test_ocr_text_triggers_low_trust_warning(self):
+        ocr_geom = TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT)
+        text_ent = _entity(
+            "T1",
+            entity_type=EntityType.TEXT,
+            text="12 pcs",
+            text_geometry=ocr_geom,
+        )
+        ctx = _context([text_ent])
+        result = _recommender.recommend(ctx, "check text")
+        types = [r.type for r in result.recommendations]
+        assert RecommendationType.GENERAL_OBSERVATION in types
+        titles = [r.title for r in result.recommendations]
+        assert any("low-trust" in t.lower() for t in titles)
+
+    def test_native_cad_text_produces_no_low_trust_warning(self):
+        native_geom = TextGeometry.for_provenance(TextProvenance.NATIVE_CAD_TEXT)
+        text_ent = _entity(
+            "T1",
+            entity_type=EntityType.TEXT,
+            text="Footing schedule",
+            text_geometry=native_geom,
+        )
+        ctx = _context([text_ent])
+        result = _recommender.recommend(ctx, "check text")
+        titles = [r.title for r in result.recommendations]
+        assert not any("low-trust" in t.lower() for t in titles)
+
+    def test_no_text_entities_skips_text_analysis(self):
+        entities = [_entity(f"L{i}") for i in range(5)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check text")
+        # No crash and no low-trust recommendation
+        titles = [r.title for r in result.recommendations]
+        assert not any("low-trust" in t.lower() for t in titles)
+
+
+# ---------------------------------------------------------------------------
+# Region context effects
+# ---------------------------------------------------------------------------
+
+
+class TestRegionContext:
+    def test_partial_region_adds_partial_region_flag(self):
+        # Need enough entities that there's at least one recommendation to downgrade
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="DOOR", x=float(i))
+            for i in range(4)
+        ]
+        ctx = _context(inserts)
+        region = _region(inserts, is_whole_drawing=False)
+        result = _recommender.recommend(ctx, "check region", region=region)
+        assert "partial_region" in result.ambiguity_flags
+
+    def test_whole_drawing_region_no_partial_flag(self):
+        entities = [_entity(f"E{i}", x=float(i)) for i in range(5)]
+        ctx = _context(entities)
+        region = _region(entities, is_whole_drawing=True)
+        result = _recommender.recommend(ctx, "check region", region=region)
+        assert "partial_region" not in result.ambiguity_flags
+
+    def test_partial_region_reduces_confidence_of_recommendations(self):
+        # Build a scenario that produces a high-confidence block recommendation,
+        # then verify confidence is reduced when a partial region is supplied.
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="COL", x=float(i * 5))
+            for i in range(4)
+        ]
+        ctx = _context(inserts)
+
+        result_no_region = _recommender.recommend(ctx, "p")
+        block_recs_no_region = [
+            r for r in result_no_region.recommendations if r.type == RecommendationType.REGION_USAGE
+        ]
+
+        region = _region(inserts, is_whole_drawing=False)
+        result_with_region = _recommender.recommend(ctx, "p", region=region)
+        block_recs_with_region = [
+            r
+            for r in result_with_region.recommendations
+            if r.type == RecommendationType.REGION_USAGE
+        ]
+
+        if block_recs_no_region and block_recs_with_region:
+            assert block_recs_with_region[0].confidence < block_recs_no_region[0].confidence
+
+    def test_truncated_context_adds_context_truncated_flag(self):
+        entities = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="BEAM", x=float(i))
+            for i in range(4)
+        ]
+        ctx = _context(entities)
+        region = _region(entities, ambiguity_flags=["context_truncated"])
+        result = _recommender.recommend(ctx, "check", region=region)
+        assert "context_truncated" in result.ambiguity_flags
+
+
+# ---------------------------------------------------------------------------
+# Sparse text evidence
+# ---------------------------------------------------------------------------
+
+
+class TestSparseTextEvidence:
+    def test_fewer_than_3_text_entities_adds_sparse_flag(self):
+        # 2 text entities + several lines → sparse
+        entities = [
+            _entity("T1", entity_type=EntityType.TEXT, text="Label A"),
+            _entity("T2", entity_type=EntityType.TEXT, text="Label B"),
+            _entity("L1"),
+            _entity("L2"),
+            _entity("L3"),
+        ]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check labels")
+        assert "sparse_text_evidence" in result.ambiguity_flags
+
+    def test_three_or_more_text_entities_no_sparse_flag(self):
+        entities = [
+            _entity(f"T{i}", entity_type=EntityType.TEXT, text=f"Label {i}") for i in range(4)
+        ]
+        # Add some spread so density doesn't kick in
+        for i, e in enumerate(entities):
+            e.insert_point = Point2D(x=float(i * 100), y=0.0)
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "check labels")
+        assert "sparse_text_evidence" not in result.ambiguity_flags
+
+    def test_sparse_text_reduces_recommendation_confidence(self):
+        # Block recs start at 0.90; after sparse (-0.15) should be ≤ 0.75
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="DOOR", x=float(i * 5))
+            for i in range(4)
+        ]
+        # Only 1 text entity — sparse
+        text_ent = _entity("T1", entity_type=EntityType.TEXT, text="Note")
+        ctx = _context(inserts + [text_ent])
+        result = _recommender.recommend(ctx, "check")
+        block_recs = [
+            r for r in result.recommendations if r.type == RecommendationType.REGION_USAGE
+        ]
+        if block_recs:
+            assert block_recs[0].confidence <= 0.75
+
+
+# ---------------------------------------------------------------------------
+# Aggregate confidence
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateConfidence:
+    def test_aggregate_confidence_is_min_of_all_recommendations(self):
+        # Produce both a block rec (0.90) and an OCR-text rec (0.60)
+        # after sparse reduction (2 text entities → -0.15 each), OCR rec = 0.45, block = 0.75
+        # aggregate = min = 0.45
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="COL", x=float(i * 5))
+            for i in range(4)
+        ]
+        ocr_geom = TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT)
+        text_ents = [
+            _entity("T1", entity_type=EntityType.TEXT, text="OCR label", text_geometry=ocr_geom),
+            _entity("T2", entity_type=EntityType.TEXT, text="Another label"),
+        ]
+        ctx = _context(inserts + text_ents)
+        result = _recommender.recommend(ctx, "analyze")
+        if result.recommendations:
+            expected_min = min(r.confidence for r in result.recommendations)
+            assert abs(result.aggregate_confidence - round(expected_min, 2)) < 1e-6
+
+    def test_empty_recommendations_give_zero_aggregate_confidence(self):
+        ctx = _context([])
+        result = _recommender.recommend(ctx, "analyze")
+        assert result.aggregate_confidence == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Drawing summary
+# ---------------------------------------------------------------------------
+
+
+class TestDrawingSummary:
+    def test_summary_includes_entity_count(self):
+        entities = [_entity(f"E{i}", x=float(i)) for i in range(7)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "summarize")
+        assert "7" in result.drawing_summary
+
+    def test_summary_includes_layer_count(self):
+        entities = [
+            _entity("E1", layer="A"),
+            _entity("E2", layer="B"),
+            _entity("E3", layer="C"),
+        ]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "summarize")
+        assert "3" in result.drawing_summary
+
+
+# ---------------------------------------------------------------------------
+# Anti-regression: no edit operations
+# ---------------------------------------------------------------------------
+
+
+class TestNoEditOperationsProduced:
+    def test_result_has_no_operations_attribute(self):
+        entities = [_entity(f"E{i}", x=float(i)) for i in range(5)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "layout advice")
+        assert not hasattr(result, "operations")
+
+    def test_result_has_no_edit_operation_objects(self):
+        from cad_dxf_agent.models.ops_schema import EditOperation
+
+        entities = [_entity(f"E{i}", x=float(i)) for i in range(5)]
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "layout advice")
+        # Walk the recommendations and assert none contain EditOperation instances
+        for rec in result.recommendations:
+            assert not isinstance(rec, EditOperation)
+            for ev in rec.evidence:
+                assert not isinstance(ev, EditOperation)
+
+    def test_design_ops_never_returns_edit_operation_type(self):
+        from cad_dxf_agent.models.ops_schema import EditOperation
+
+        # Even with a complex drawing, LayoutRecommender must not produce EditOperations
+        inserts = [
+            _entity(f"I{i}", entity_type=EntityType.INSERT, block_name="BEAM", x=float(i * 5))
+            for i in range(5)
+        ]
+        dominant = [_entity(f"S{i}", layer="DOMINANT") for i in range(10)]
+        entities = inserts + dominant
+        ctx = _context(entities)
+        result = _recommender.recommend(ctx, "redesign layout")
+
+        def _contains_edit_op(obj: object) -> bool:
+            if isinstance(obj, EditOperation):
+                return True
+            if isinstance(obj, list):
+                return any(_contains_edit_op(item) for item in obj)
+            return False
+
+        assert not _contains_edit_op(result.recommendations)

--- a/tests/unit/test_revision_summarizer.py
+++ b/tests/unit/test_revision_summarizer.py
@@ -1,0 +1,305 @@
+"""Tests for RevisionSummarizer in cad_dxf_agent.core.design_ops."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.design_ops import RevisionSummarizer
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.comparison_schema import (
+    ChangeCategory,
+    ComparisonResult,
+    EntityChange,
+    GeometrySnapshot,
+)
+from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+# ---------------------------------------------------------------------------
+# Test data factories
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(
+    handle: str = "A1",
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.LINE,
+    text: str | None = None,
+) -> GeometrySnapshot:
+    return GeometrySnapshot(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        points=[Point2D(x=0, y=0)],
+        text_content=text,
+    )
+
+
+def _change(
+    category: ChangeCategory,
+    master: GeometrySnapshot | None = None,
+    revision: GeometrySnapshot | None = None,
+    displacement: Point2D | None = None,
+    confidence: float = 0.95,
+) -> EntityChange:
+    return EntityChange(
+        category=category,
+        master_snapshot=master,
+        revision_snapshot=revision,
+        displacement=displacement,
+        confidence=confidence,
+    )
+
+
+def _comparison(*changes: EntityChange, warnings: list[str] | None = None) -> ComparisonResult:
+    summary: dict[str, int] = {"added": 0, "removed": 0, "modified": 0, "moved": 0, "unchanged": 0}
+    for c in changes:
+        summary[c.category.value] += 1
+    return ComparisonResult(changes=list(changes), summary=summary, warnings=warnings or [])
+
+
+def _context(entities: list[EntityRef], layers: list[str] | None = None) -> DrawingContext:
+    layer_names = layers or sorted({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+def _entity(
+    handle: str,
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.LINE,
+    text: str | None = None,
+) -> EntityRef:
+    return EntityRef(handle=handle, entity_type=entity_type, layer=layer, text_content=text)
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestRevisionSummarizerNoInputs:
+    """Behaviour when neither comparison_result nor changeset is given."""
+
+    def test_no_inputs_returns_no_revision_data_headline(self):
+        result = RevisionSummarizer().summarize()
+        assert result.headline == "No revision data available."
+
+    def test_no_inputs_adds_missing_context_entries(self):
+        result = RevisionSummarizer().summarize()
+        assert "comparison_result" in result.missing_context
+        assert "changeset" in result.missing_context
+
+    def test_no_inputs_adds_caveat(self):
+        result = RevisionSummarizer().summarize()
+        assert result.caveats  # at least one caveat explaining the missing data
+
+
+class TestRevisionSummarizerFromComparisonResult:
+    """RevisionSummarizer.summarize(comparison_result=...) path."""
+
+    def test_added_entities_in_summary(self):
+        snap = _snapshot(handle="B1", layer="WALLS")
+        comp = _comparison(_change(ChangeCategory.ADDED, revision=snap))
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.change_count == 1
+        assert any("added" in e.change_type for e in result.key_changes)
+
+    def test_removed_entities_in_summary(self):
+        snap = _snapshot(handle="C1", layer="WALLS")
+        comp = _comparison(_change(ChangeCategory.REMOVED, master=snap))
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.change_count == 1
+        assert any("removed" in e.change_type for e in result.key_changes)
+
+    def test_moved_entities_include_displacement_in_technical_detail(self):
+        master = _snapshot(handle="D1", layer="GRID")
+        revision = _snapshot(handle="D2", layer="GRID")
+        disp = Point2D(x=5.0, y=3.0)
+        comp = _comparison(
+            _change(ChangeCategory.MOVED, master=master, revision=revision, displacement=disp)
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        tech = result.key_changes[0].technical_detail
+        assert "5.0" in tech
+        assert "3.0" in tech
+
+    def test_modified_entities_in_summary(self):
+        snap = _snapshot(handle="E1", layer="STRUCTURAL")
+        comp = _comparison(_change(ChangeCategory.MODIFIED, master=snap, revision=snap))
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.change_count == 1
+        assert any("modified" in e.change_type for e in result.key_changes)
+
+    def test_mixed_changes_counted_correctly(self):
+        added_snap = _snapshot(handle="F1", layer="LAYER_A")
+        removed_snap = _snapshot(handle="F2", layer="LAYER_B")
+        modified_snap = _snapshot(handle="F3", layer="LAYER_A")
+        comp = _comparison(
+            _change(ChangeCategory.ADDED, revision=added_snap),
+            _change(ChangeCategory.REMOVED, master=removed_snap),
+            _change(ChangeCategory.MODIFIED, master=modified_snap, revision=modified_snap),
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.change_count == 3
+
+    def test_unchanged_entities_excluded_from_summary(self):
+        snap = _snapshot(handle="G1", layer="STRUCTURAL")
+        comp = _comparison(
+            _change(ChangeCategory.UNCHANGED, master=snap, revision=snap),
+            _change(ChangeCategory.ADDED, revision=_snapshot(handle="G2", layer="STRUCTURAL")),
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        # Only the ADDED change should appear; UNCHANGED is excluded
+        assert result.change_count == 1
+
+    def test_headline_format_with_counts(self):
+        added = _snapshot(handle="H1", layer="LAYER_A")
+        removed = _snapshot(handle="H2", layer="LAYER_B")
+        comp = _comparison(
+            _change(ChangeCategory.ADDED, revision=added),
+            _change(ChangeCategory.ADDED, revision=_snapshot(handle="H3", layer="LAYER_A")),
+            _change(ChangeCategory.REMOVED, master=removed),
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert "3 change(s) detected" in result.headline
+        assert "2 added" in result.headline
+        assert "1 removed" in result.headline
+
+    def test_areas_affected_sorted_layer_names(self):
+        snap_z = _snapshot(handle="I1", layer="ZONE_Z")
+        snap_a = _snapshot(handle="I2", layer="ZONE_A")
+        snap_m = _snapshot(handle="I3", layer="ZONE_M")
+        comp = _comparison(
+            _change(ChangeCategory.ADDED, revision=snap_z),
+            _change(ChangeCategory.ADDED, revision=snap_a),
+            _change(ChangeCategory.ADDED, revision=snap_m),
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.areas_affected == sorted(result.areas_affected)
+        assert set(result.areas_affected) == {"ZONE_A", "ZONE_M", "ZONE_Z"}
+
+    def test_comparison_warnings_propagate_to_caveats(self):
+        snap = _snapshot(handle="J1", layer="STRUCTURAL")
+        comp = _comparison(
+            _change(ChangeCategory.ADDED, revision=snap),
+            warnings=["Too many entities excluded by profile filter."],
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert any("excluded" in c for c in result.caveats)
+
+    def test_all_unchanged_returns_no_changes_headline(self):
+        snap = _snapshot(handle="K1", layer="STRUCTURAL")
+        comp = _comparison(_change(ChangeCategory.UNCHANGED, master=snap, revision=snap))
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.headline == "No changes detected."
+
+    def test_overall_assessment_includes_human_readable_counts(self):
+        added = _snapshot(handle="L1", layer="STRUCTURAL")
+        removed = _snapshot(handle="L2", layer="WALLS")
+        comp = _comparison(
+            _change(ChangeCategory.ADDED, revision=added),
+            _change(ChangeCategory.REMOVED, master=removed),
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert "1 element(s) were added" in result.overall_assessment
+        assert "1 element(s) were removed" in result.overall_assessment
+
+    def test_moved_plain_description_uses_repositioned_not_op_type(self):
+        master = _snapshot(handle="M1", layer="GRID")
+        revision = _snapshot(handle="M2", layer="GRID")
+        comp = _comparison(
+            _change(
+                ChangeCategory.MOVED,
+                master=master,
+                revision=revision,
+                displacement=Point2D(x=1.0, y=0.0),
+            )
+        )
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        desc = result.key_changes[0].plain_description
+        assert "repositioned" in desc.lower()
+        assert "MOVE" not in desc  # raw op type must not appear
+
+    def test_result_has_no_operations_attribute(self):
+        comp = _comparison()
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert not hasattr(result, "operations")
+
+    def test_empty_comparison_returns_no_changes_headline(self):
+        comp = _comparison()  # zero changes
+        result = RevisionSummarizer().summarize(comparison_result=comp)
+        assert result.headline == "No changes detected."
+
+
+class TestRevisionSummarizerFromChangeset:
+    """RevisionSummarizer.summarize(changeset=...) path."""
+
+    def test_move_operations_in_summary(self):
+        cs = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY, target_handle="N1", target_layer="STRUCTURAL"
+                )
+            ]
+        )
+        result = RevisionSummarizer().summarize(changeset=cs)
+        assert result.change_count == 1
+        assert any("repositioned" in e.plain_description.lower() for e in result.key_changes)
+
+    def test_delete_operations_in_summary(self):
+        cs = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY, target_handle="O1", target_layer="WALLS"
+                )
+            ]
+        )
+        result = RevisionSummarizer().summarize(changeset=cs)
+        assert result.change_count == 1
+        assert any("removed" in e.plain_description.lower() for e in result.key_changes)
+
+    def test_edit_text_operations_in_summary(self):
+        cs = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.EDIT_TEXT,
+                    target_handle="P1",
+                    target_layer="NOTES",
+                    params={"new_text": "Revised label"},
+                )
+            ]
+        )
+        result = RevisionSummarizer().summarize(changeset=cs)
+        assert result.change_count == 1
+        assert any("text" in e.plain_description.lower() for e in result.key_changes)
+
+    def test_plain_language_no_raw_op_types_in_descriptions(self):
+        cs = ChangeSet(
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY, target_handle="Q1", target_layer="STRUCTURAL"
+                ),
+                EditOperation(
+                    op_type=OpType.DELETE_ENTITY, target_handle="Q2", target_layer="WALLS"
+                ),
+                EditOperation(op_type=OpType.EDIT_TEXT, target_handle="Q3", target_layer="NOTES"),
+            ]
+        )
+        result = RevisionSummarizer().summarize(changeset=cs)
+        for entry in result.key_changes:
+            assert "move_entity" not in entry.plain_description
+            assert "delete_entity" not in entry.plain_description
+            assert "edit_text" not in entry.plain_description
+
+    def test_missing_context_when_neither_provided(self):
+        # Verify the missing_context list names both keys
+        result = RevisionSummarizer().summarize()
+        assert "comparison_result" in result.missing_context
+        assert "changeset" in result.missing_context

--- a/tests/unit/test_scope_builder.py
+++ b/tests/unit/test_scope_builder.py
@@ -1,0 +1,257 @@
+"""Tests for ScopeBuilder — assembles layout, revision, and takeoff sections
+into a unified scope-style report. All deterministic, no LLM calls.
+"""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.design_ops import ScopeBuilder
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.design_ops_schema import ScopeSectionType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity(
+    handle: str,
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.INSERT,
+    block_name: str = "MARK",
+    x: float = 0.0,
+    y: float = 0.0,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        block_name=block_name,
+        insert_point=Point2D(x=x, y=y),
+    )
+
+
+def _context(entities: list[EntityRef]) -> DrawingContext:
+    layer_names = sorted({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+def _comparison_with_changes():
+    from cad_dxf_agent.models.comparison_schema import (
+        ChangeCategory,
+        ComparisonResult,
+        EntityChange,
+        GeometrySnapshot,
+    )
+
+    snap = GeometrySnapshot(
+        handle="X1",
+        entity_type=EntityType.LINE,
+        layer="STRUCTURAL",
+        points=[Point2D(x=0, y=0)],
+    )
+    change = EntityChange(
+        category=ChangeCategory.ADDED,
+        revision_snapshot=snap,
+        confidence=0.9,
+    )
+    return ComparisonResult(
+        changes=[change],
+        summary={
+            "added": 1,
+            "removed": 0,
+            "modified": 0,
+            "moved": 0,
+            "unchanged": 0,
+        },
+    )
+
+
+def _rich_entities() -> list[EntityRef]:
+    """20+ inserts on a single layer so layout density/block recs fire."""
+    return [
+        _entity(f"H{i:03d}", layer="STRUCTURAL", block_name="COL", x=float(i), y=0.0)
+        for i in range(20)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestScopeBuilderEmptyDrawing:
+    def test_empty_drawing_returns_scope(self):
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert scope is not None
+
+    def test_empty_drawing_omits_layout_recommendations(self):
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert "layout_recommendations" in scope.omitted_sections
+
+    def test_empty_drawing_omits_takeoff_candidates(self):
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert "takeoff_candidates" in scope.omitted_sections
+
+    def test_empty_drawing_omits_revision_summary_without_comparison(self):
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert "revision_summary" in scope.omitted_sections
+
+    def test_empty_drawing_has_no_sections(self):
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert len(scope.sections) == 0
+
+
+class TestScopeBuilderWithEntities:
+    def test_full_scope_produces_layout_section(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "suggest layout improvements")
+        section_types = [s.section_type for s in scope.sections]
+        assert ScopeSectionType.LAYOUT_RECOMMENDATIONS in section_types
+
+    def test_full_scope_produces_takeoff_section(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        section_types = [s.section_type for s in scope.sections]
+        assert ScopeSectionType.TAKEOFF_CANDIDATES in section_types
+
+    def test_section_types_are_enum_values(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        for section in scope.sections:
+            assert isinstance(section.section_type, ScopeSectionType)
+
+    def test_each_section_has_confidence(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        for section in scope.sections:
+            assert 0.0 <= section.confidence <= 1.0
+
+    def test_each_section_has_caveats_list(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        for section in scope.sections:
+            assert isinstance(section.caveats, list)
+
+    def test_aggregate_confidence_is_min_of_sections(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        if scope.sections:
+            expected_min = min(s.confidence for s in scope.sections if s.available)
+            assert abs(scope.aggregate_confidence - round(expected_min, 2)) < 1e-9
+
+    def test_aggregate_confidence_in_valid_range(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert 0.0 <= scope.aggregate_confidence <= 1.0
+
+
+class TestScopeBuilderWithComparison:
+    def test_comparison_result_produces_revision_summary_section(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        comparison = _comparison_with_changes()
+        scope = ScopeBuilder().build(ctx, "scope of work", comparison_result=comparison)
+        section_types = [s.section_type for s in scope.sections]
+        assert ScopeSectionType.REVISION_SUMMARY in section_types
+
+    def test_missing_comparison_puts_revision_summary_in_omitted(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert "revision_summary" in scope.omitted_sections
+
+    def test_revision_summary_not_in_omitted_when_comparison_provided(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        comparison = _comparison_with_changes()
+        scope = ScopeBuilder().build(ctx, "scope of work", comparison_result=comparison)
+        assert "revision_summary" not in scope.omitted_sections
+
+    def test_scope_with_both_comparison_and_changeset(self):
+        from cad_dxf_agent.models.ops_schema import ChangeSet, EditOperation, OpType
+
+        entities = _rich_entities()
+        ctx = _context(entities)
+        comparison = _comparison_with_changes()
+        changeset = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MOVE_ENTITY,
+                    target_handle="H001",
+                    target_layer="STRUCTURAL",
+                    params={"dx": 10, "dy": 0},
+                )
+            ],
+        )
+        # comparison_result takes priority per RevisionSummarizer logic
+        scope = ScopeBuilder().build(
+            ctx,
+            "scope of work",
+            comparison_result=comparison,
+            changeset=changeset,
+        )
+        section_types = [s.section_type for s in scope.sections]
+        assert ScopeSectionType.REVISION_SUMMARY in section_types
+
+
+class TestScopeBuilderAmbiguityAndCaveats:
+    def test_ambiguity_flags_propagated(self):
+        # Sparse entities should trigger sparse_text_evidence flag from LayoutRecommender
+        entities = [_entity("H001", entity_type=EntityType.LINE, block_name=None)]
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "suggest improvements")
+        # The scope collects flags from sub-analyzers — just assert it's a list
+        assert isinstance(scope.ambiguity_flags, list)
+
+    def test_caveats_collected_across_sections(self):
+        entities = _rich_entities()
+        ctx = _context(entities)
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        assert isinstance(scope.caveats, list)
+
+    def test_omitted_sections_not_hallucinated(self):
+        """Sections listed in omitted_sections must not appear in scope.sections."""
+        ctx = _context([])
+        scope = ScopeBuilder().build(ctx, "scope of work")
+        present_types = {s.section_type.value for s in scope.sections}
+        for omitted in scope.omitted_sections:
+            assert omitted not in present_types
+
+    def test_no_edit_operations_in_scope_result(self):
+        """ScopeBuilder must never produce edit operations of any kind."""
+        entities = _rich_entities()
+        ctx = _context(entities)
+        comparison = _comparison_with_changes()
+        scope = ScopeBuilder().build(ctx, "scope of work", comparison_result=comparison)
+        dumped = scope.model_dump()
+        # Top-level result has no 'operations' key (it's a ScopeSummary, not PlatformResponse)
+        assert "operations" not in dumped
+        # Section content must not contain op_type fields
+        for section in dumped.get("sections", []):
+            content = section.get("content", {})
+            assert "op_type" not in str(content), (
+                f"Section '{section['section_type']}' content contains op_type"
+            )

--- a/tests/unit/test_takeoff_generator.py
+++ b/tests/unit/test_takeoff_generator.py
@@ -1,0 +1,405 @@
+"""Tests for TakeoffGenerator in cad_dxf_agent.core.design_ops."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.design_ops import TakeoffGenerator
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+    TextGeometry,
+    TextProvenance,
+)
+from cad_dxf_agent.models.design_ops_schema import TakeoffConfidence
+
+# ---------------------------------------------------------------------------
+# Test data factories
+# ---------------------------------------------------------------------------
+
+
+def _entity(
+    handle: str,
+    layer: str = "STRUCTURAL",
+    entity_type: EntityType = EntityType.LINE,
+    text: str | None = None,
+    block_name: str | None = None,
+    x: float = 0.0,
+    y: float = 0.0,
+    text_geometry: TextGeometry | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        text_content=text,
+        block_name=block_name,
+        insert_point=Point2D(x=x, y=y) if (x or y) else None,
+        text_geometry=text_geometry,
+    )
+
+
+def _context(entities: list[EntityRef], layers: list[str] | None = None) -> DrawingContext:
+    layer_names = layers or sorted({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTakeoffGeneratorEmptyDrawing:
+    def test_empty_drawing_returns_no_items_with_flag(self):
+        ctx = _context([])
+        result = TakeoffGenerator().generate(ctx, prompt="count everything")
+        assert result.items == []
+        assert "empty_drawing" in result.ambiguity_flags
+
+    def test_empty_drawing_has_caveat(self):
+        ctx = _context([])
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        assert result.caveats  # at least one caveat present
+
+
+class TestTakeoffGeneratorBlockCounting:
+    def test_five_column_mark_blocks_produce_single_item_qty_5(self):
+        entities = [
+            _entity(
+                f"H{i}", layer="COLUMNS", entity_type=EntityType.INSERT, block_name="COLUMN_MARK"
+            )
+            for i in range(5)
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count columns")
+        block_items = [it for it in result.items if it.source_block_name == "COLUMN_MARK"]
+        assert len(block_items) == 1
+        assert block_items[0].quantity == 5
+
+    def test_block_items_have_high_confidence(self):
+        entities = [
+            _entity(f"B{i}", layer="BEAMS", entity_type=EntityType.INSERT, block_name="BEAM_MARK")
+            for i in range(3)
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count beams")
+        beam_items = [it for it in result.items if it.source_block_name == "BEAM_MARK"]
+        assert beam_items[0].confidence == TakeoffConfidence.HIGH
+
+    def test_multiple_block_types_counted_separately(self):
+        entities = [
+            _entity("C1", layer="COLS", entity_type=EntityType.INSERT, block_name="COL_A"),
+            _entity("C2", layer="COLS", entity_type=EntityType.INSERT, block_name="COL_A"),
+            _entity("D1", layer="DOORS", entity_type=EntityType.INSERT, block_name="DOOR_B"),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count all")
+        block_names = {it.source_block_name for it in result.items if it.source_block_name}
+        assert "COL_A" in block_names
+        assert "DOOR_B" in block_names
+
+    def test_block_without_block_name_not_counted_as_block(self):
+        # INSERT entity with no block_name must be skipped in the block-counting pass
+        entities = [
+            _entity("N1", layer="MISC", entity_type=EntityType.INSERT, block_name=None),
+            _entity("N2", layer="MISC", entity_type=EntityType.INSERT, block_name=None),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        block_items = [it for it in result.items if it.source_block_name is not None]
+        assert block_items == []
+
+    def test_insert_with_no_block_name_excluded_from_block_items(self):
+        # No block_name means entity_type=INSERT but no block — layer pass should also skip INSERTs
+        entities = [
+            _entity("Z1", layer="STRUCTURAL", entity_type=EntityType.INSERT, block_name=None),
+            _entity("Z2", layer="STRUCTURAL", entity_type=EntityType.INSERT, block_name=None),
+            _entity("Z3", layer="STRUCTURAL", entity_type=EntityType.LINE),
+            _entity("Z4", layer="STRUCTURAL", entity_type=EntityType.LINE),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        # Layer pass picks up 2 LINE entities on STRUCTURAL; nameless INSERT skipped
+        layer_items = [
+            it
+            for it in result.items
+            if it.source_layer == "STRUCTURAL" and it.source_block_name is None
+        ]
+        assert layer_items  # at least one layer-based item for the LINEs
+
+
+class TestTakeoffGeneratorLayerCounting:
+    def test_layer_based_counting_for_non_insert_entities(self):
+        entities = [
+            _entity("L1", layer="WALLS", entity_type=EntityType.LINE),
+            _entity("L2", layer="WALLS", entity_type=EntityType.LINE),
+            _entity("L3", layer="WALLS", entity_type=EntityType.LWPOLYLINE),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count walls")
+        wall_items = [it for it in result.items if it.source_layer == "WALLS"]
+        assert wall_items
+        assert wall_items[0].quantity == 3
+
+    def test_layer_counting_skips_layers_covered_by_blocks(self):
+        # COLUMNS layer has block inserts; layer pass must not double-count it
+        entities = [
+            _entity("BC1", layer="COLUMNS", entity_type=EntityType.INSERT, block_name="COL"),
+            _entity("BC2", layer="COLUMNS", entity_type=EntityType.INSERT, block_name="COL"),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count columns")
+        # Only block item(s) should reference COLUMNS, not a separate layer item
+        layer_items_for_columns = [
+            it
+            for it in result.items
+            if it.source_layer == "COLUMNS" and it.source_block_name is None
+        ]
+        assert layer_items_for_columns == []
+
+    def test_layer_with_single_entity_not_included(self):
+        # Minimum count for a layer item is 2
+        entities = [_entity("S1", layer="LONELY", entity_type=EntityType.LINE)]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        lonely_items = [it for it in result.items if it.source_layer == "LONELY"]
+        assert lonely_items == []
+
+
+class TestTakeoffGeneratorTextQuantityExtraction:
+    def test_text_ea_pattern_extracts_quantity(self):
+        entities = [_entity("T1", layer="NOTES", entity_type=EntityType.TEXT, text="10 ea")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "10 ea" in it.name]
+        assert text_items
+        assert text_items[0].quantity == 10
+
+    def test_text_pcs_pattern_extracts_quantity(self):
+        entities = [_entity("T2", layer="NOTES", entity_type=EntityType.TEXT, text="5 pcs")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "5 pcs" in it.name]
+        assert text_items
+        assert text_items[0].quantity == 5
+
+    def test_text_x_multiplier_pattern_extracts_quantity(self):
+        entities = [_entity("T3", layer="NOTES", entity_type=EntityType.TEXT, text="3x units")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "3x units" in it.name]
+        assert text_items
+        assert text_items[0].quantity == 3
+
+    def test_text_with_no_quantity_pattern_produces_no_item(self):
+        entities = [_entity("T4", layer="NOTES", entity_type=EntityType.TEXT, text="see schedule")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "see schedule" in it.name]
+        assert text_items == []
+
+    def test_quantity_above_10000_ignored(self):
+        entities = [_entity("T5", layer="NOTES", entity_type=EntityType.TEXT, text="99999 ea")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "99999" in it.name]
+        assert text_items == []
+
+    def test_quantity_zero_ignored(self):
+        entities = [_entity("T6", layer="NOTES", entity_type=EntityType.TEXT, text="0 ea")]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "0 ea" in it.name]
+        assert text_items == []
+
+
+class TestTakeoffGeneratorOCRProvenance:
+    """SQ67 — OCR text must be downgraded to ESTIMATE_ONLY, never treated as exact truth."""
+
+    def _ocr_geometry(self) -> TextGeometry:
+        return TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT)
+
+    def test_ocr_text_quantity_confidence_is_estimate_only(self):
+        entities = [
+            _entity(
+                "OCR1",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="10 ea",
+                text_geometry=self._ocr_geometry(),
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "10 ea" in it.name]
+        assert text_items, "Expected a text-derived item for OCR text"
+        assert text_items[0].confidence == TakeoffConfidence.ESTIMATE_ONLY
+
+    def test_ocr_text_adds_provenance_warning(self):
+        entities = [
+            _entity(
+                "OCR2",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="10 ea",
+                text_geometry=self._ocr_geometry(),
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        assert result.provenance_warnings, "Expected at least one OCR provenance warning"
+        assert any(
+            "OCR" in w or "estimate_only" in w.lower() or "ESTIMATE_ONLY" in w
+            for w in result.provenance_warnings
+        )
+
+    def test_native_cad_text_has_medium_confidence_not_estimate_only(self):
+        native_geometry = TextGeometry.for_provenance(TextProvenance.NATIVE_CAD_TEXT)
+        entities = [
+            _entity(
+                "NAT1",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="7 ea",
+                text_geometry=native_geometry,
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "7 ea" in it.name]
+        assert text_items
+        assert text_items[0].confidence == TakeoffConfidence.MEDIUM
+
+    def test_block_attribute_text_has_medium_confidence(self):
+        attr_geometry = TextGeometry.for_provenance(TextProvenance.BLOCK_ATTRIBUTE_TEXT)
+        entities = [
+            _entity(
+                "ATTR1",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="4 ea",
+                text_geometry=attr_geometry,
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "4 ea" in it.name]
+        assert text_items
+        assert text_items[0].confidence == TakeoffConfidence.MEDIUM
+
+    def test_anti_regression_ocr_cannot_become_high_or_medium(self):
+        """OCR text must never yield HIGH or MEDIUM confidence — safety net."""
+        entities = [
+            _entity(
+                "AREG1",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="50 ea",
+                text_geometry=self._ocr_geometry(),
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        text_items = [it for it in result.items if "50 ea" in it.name]
+        assert text_items
+        assert text_items[0].confidence not in (TakeoffConfidence.HIGH, TakeoffConfidence.MEDIUM)
+
+    def test_anti_regression_ocr_must_have_provenance_warning(self):
+        """Every OCR quantity extraction must emit at least one provenance warning."""
+        entities = [
+            _entity(
+                "AREG2",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="12 ea",
+                text_geometry=self._ocr_geometry(),
+            )
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        assert result.provenance_warnings, "OCR text must always emit a provenance warning"
+
+    def test_multiple_ocr_texts_each_emit_warning(self):
+        entities = [
+            _entity(
+                f"MOCR{i}",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text=f"{i + 1} ea",
+                text_geometry=self._ocr_geometry(),
+            )
+            for i in range(3)
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        # Three OCR entities → three warnings
+        assert len(result.provenance_warnings) == 3
+
+
+class TestTakeoffGeneratorAggregates:
+    def test_total_items_and_total_quantity_computed(self):
+        entities = [
+            _entity("BLK1", layer="COLS", entity_type=EntityType.INSERT, block_name="COL"),
+            _entity("BLK2", layer="COLS", entity_type=EntityType.INSERT, block_name="COL"),
+            _entity("TXT1", layer="NOTES", entity_type=EntityType.TEXT, text="3 ea"),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        assert result.total_items == len(result.items)
+        assert result.total_quantity_items == sum(it.quantity for it in result.items)
+
+    def test_aggregate_confidence_is_worst_of_all_items(self):
+        ocr_geom = TextGeometry.for_provenance(TextProvenance.RASTER_OCR_TEXT)
+        entities = [
+            # HIGH confidence block item
+            _entity("AG1", layer="COLS", entity_type=EntityType.INSERT, block_name="COL"),
+            _entity("AG2", layer="COLS", entity_type=EntityType.INSERT, block_name="COL"),
+            # ESTIMATE_ONLY due to OCR
+            _entity(
+                "AG3",
+                layer="NOTES",
+                entity_type=EntityType.TEXT,
+                text="5 ea",
+                text_geometry=ocr_geom,
+            ),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        # Mix of HIGH + ESTIMATE_ONLY → aggregate must be ESTIMATE_ONLY (worst)
+        assert result.aggregate_confidence == TakeoffConfidence.ESTIMATE_ONLY
+
+    def test_mixed_block_and_text_items_in_same_result(self):
+        entities = [
+            _entity("MX1", layer="COLS", entity_type=EntityType.INSERT, block_name="COL_A"),
+            _entity("MX2", layer="COLS", entity_type=EntityType.INSERT, block_name="COL_A"),
+            _entity("MX3", layer="NOTES", entity_type=EntityType.TEXT, text="8 ea"),
+        ]
+        ctx = _context(entities)
+        result = TakeoffGenerator().generate(ctx, prompt="count")
+        block_items = [it for it in result.items if it.source_block_name == "COL_A"]
+        text_items = [it for it in result.items if "8 ea" in it.name]
+        assert block_items
+        assert text_items
+
+    def test_region_subset_adds_partial_region_flag_and_caveat(self):
+        from cad_dxf_agent.models.qna_schema import RegionContext
+
+        entities = [
+            _entity("R1", layer="ZONE_A", entity_type=EntityType.INSERT, block_name="BLK"),
+            _entity("R2", layer="ZONE_A", entity_type=EntityType.INSERT, block_name="BLK"),
+        ]
+        ctx = _context(entities)
+
+        region = RegionContext(
+            entities=entities,
+            is_whole_drawing=False,
+            ambiguity_flags=[],
+        )
+        result = TakeoffGenerator().generate(ctx, prompt="count zone a", region=region)
+        assert "partial_region" in result.ambiguity_flags
+        assert any("region" in c.lower() for c in result.caveats)

--- a/tests/web/test_design_ops_endpoints.py
+++ b/tests/web/test_design_ops_endpoints.py
@@ -1,0 +1,291 @@
+"""Tests for design-ops task family dispatch via POST /api/v2/prompt.
+
+All requests go through the intent router. Session state is injected via
+SessionManager.get mock so no real file upload is required. The planner
+is never called -- design-ops are fully deterministic.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+starlette = pytest.importorskip("starlette", reason="web tests require fastapi/starlette")
+
+# Must be set before importing the app so the auth middleware sees it.
+os.environ["CAD_WEB_DEV_MODE"] = "1"
+
+from starlette.testclient import TestClient  # noqa: E402
+from web.backend.main import app, get_user  # noqa: E402
+from web.backend.session import Session, SessionManager  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _auth_override():
+    """Override auth to return a stable dev user for all tests in this module."""
+
+    async def _dev_user():
+        return {"uid": "dev-user", "email": "dev@test.local"}
+
+    app.dependency_overrides[get_user] = _dev_user
+    yield
+    app.dependency_overrides.pop(get_user, None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_sessions():
+    """Reset session manager between tests."""
+    from web.backend.main import session_mgr
+
+    yield
+    for sid in list(session_mgr._sessions.keys()):
+        session_mgr.delete(sid)
+
+
+@pytest.fixture
+def client():
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture
+def mock_session():
+    """Inject a DrawingContext-loaded session without a real DXF upload."""
+    from cad_dxf_agent.models.cad_schema import (
+        DrawingContext,
+        EntityRef,
+        EntityType,
+        LayerRule,
+        Point2D,
+    )
+
+    entities = [
+        EntityRef(
+            handle=f"H{i}",
+            entity_type=EntityType.INSERT,
+            layer="STRUCTURAL",
+            block_name="COLUMN_MARK",
+            insert_point=Point2D(x=float(i * 10), y=0.0),
+        )
+        for i in range(5)
+    ]
+    ctx = DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name="STRUCTURAL")],
+    )
+
+    session = Session(
+        session_id="test-session",
+        user_id="dev-user",
+        created_at=time.time(),
+        original_path=Path("/tmp/test.dxf"),
+    )
+    session.context = ctx
+
+    with patch.object(SessionManager, "get", return_value=session):
+        yield session
+
+
+# ---------------------------------------------------------------------------
+# DESIGN_ASSIST -- layout recommendations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestDesignAssistEndpoint:
+    def test_design_assist_prompt_returns_200(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "suggest layout improvements"},
+        )
+        assert resp.status_code == 200
+
+    def test_design_assist_task_family(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "suggest layout improvements"},
+        )
+        assert resp.json()["task_family"] == "design_assist"
+
+    def test_design_assist_response_type_is_answer_only(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "suggest layout improvements"},
+        )
+        assert resp.json()["response_type"] == "answer_only"
+
+    def test_design_assist_scope_prompt_has_sections(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "scope of work summary"},
+        )
+        data = resp.json()
+        assert resp.status_code == 200
+        assert "sections" in data["data"]
+
+    def test_design_assist_has_no_edit_operations(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "suggest layout improvements"},
+        )
+        assert resp.json()["operations"] == []
+
+    def test_design_assist_risk_level_is_none(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "suggest layout improvements"},
+        )
+        assert resp.json()["risk_level"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# SUMMARY -- revision summarizer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestSummaryEndpoint:
+    def test_summary_prompt_returns_200(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        assert resp.status_code == 200
+
+    def test_summary_task_family(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        assert resp.json()["task_family"] == "summary"
+
+    def test_summary_response_type_is_answer_only(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        assert resp.json()["response_type"] == "answer_only"
+
+    def test_summary_data_has_headline(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        data = resp.json()
+        assert "headline" in data["data"]
+
+    def test_summary_has_no_edit_operations(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        assert resp.json()["operations"] == []
+
+    def test_summary_risk_level_is_none(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "summarize the drawing"},
+        )
+        assert resp.json()["risk_level"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# TAKEOFF_ESTIMATE -- entity counting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestTakeoffEstimateEndpoint:
+    def test_takeoff_prompt_returns_200(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_takeoff_task_family(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        assert resp.json()["task_family"] == "takeoff_estimate"
+
+    def test_takeoff_response_type_is_answer_only(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        assert resp.json()["response_type"] == "answer_only"
+
+    def test_takeoff_data_has_items(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        data = resp.json()
+        assert "items" in data["data"]
+
+    def test_takeoff_has_no_edit_operations(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        assert resp.json()["operations"] == []
+
+    def test_takeoff_risk_level_is_none(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={
+                "session_id": "test-session",
+                "prompt": "estimate the quantity of columns",
+            },
+        )
+        assert resp.json()["risk_level"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Needs-clarification fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestNeedsClarificationFallback:
+    def test_empty_prompt_returns_needs_clarification(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": ""},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response_type"] == "needs_clarification"
+
+    def test_unrecognised_prompt_returns_needs_clarification(self, client, mock_session):
+        resp = client.post(
+            "/api/v2/prompt",
+            json={"session_id": "test-session", "prompt": "xyzzy frobnicate quux"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["response_type"] == "needs_clarification"

--- a/tests/web/test_v2_prompt.py
+++ b/tests/web/test_v2_prompt.py
@@ -51,7 +51,7 @@ class TestV2PromptRouting:
         assert data["audit"]["total_request_time_ms"] is not None
         assert data["audit"]["context_build_time_ms"] is not None
 
-    def test_summary_returns_unsupported(self, client, upload_dxf):
+    def test_summary_returns_answer_only(self, client, upload_dxf):
         session_id, _ = upload_dxf
         resp = client.post(
             "/api/v2/prompt",
@@ -60,7 +60,7 @@ class TestV2PromptRouting:
         assert resp.status_code == 200
         data = resp.json()
         assert data["task_family"] == "summary"
-        assert data["response_type"] == "unsupported_operation"
+        assert data["response_type"] == "answer_only"
 
     def test_empty_prompt_returns_clarification(self, client, upload_dxf):
         session_id, _ = upload_dxf

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -310,16 +310,32 @@ async def upload(
         raise HTTPException(status_code=422, detail=f"Failed to read DXF: {e}") from None
 
     # Render original preview
-    try:
-        from cad_dxf_agent.core.renderer import render_dxf_to_png
+    # For PDF uploads: render first page directly (fast, no entity limit concern)
+    # For DXF uploads: use ezdxf renderer (skip if too many entities — OOM risk)
+    RENDER_ENTITY_LIMIT = 100_000
+    if ext == ".pdf":
+        try:
+            preview_path = session_dir / "original.png"
+            _render_pdf_page(upload_path, preview_path)
+            session.original_render = preview_path
+        except Exception as e:
+            logger.warning("PDF preview render failed (non-fatal): %s", e, exc_info=True)
+    elif context.entity_count <= RENDER_ENTITY_LIMIT:
+        try:
+            from cad_dxf_agent.core.renderer import render_dxf_to_png
 
-        render_result = render_dxf_to_png(dxf_path, session_dir / "original.png")
-        if render_result.success:
-            session.original_render = render_result.output_path
-        else:
-            logger.warning("Original render returned failure: %s", render_result.error)
-    except Exception as e:
-        logger.warning("Original render failed (non-fatal): %s", e, exc_info=True)
+            render_result = render_dxf_to_png(dxf_path, session_dir / "original.png")
+            if render_result.success:
+                session.original_render = render_result.output_path
+            else:
+                logger.warning("Original render returned failure: %s", render_result.error)
+        except Exception as e:
+            logger.warning("Original render failed (non-fatal): %s", e, exc_info=True)
+    else:
+        logger.info(
+            "Skipping render for large drawing (%d entities > %d limit)",
+            context.entity_count, RENDER_ENTITY_LIMIT,
+        )
 
     response: dict = {
         "session_id": session.session_id,
@@ -1541,6 +1557,19 @@ async def revision_download(session_id: str = Query(...)):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _render_pdf_page(pdf_path: Path, output_path: Path, *, dpi: int = 150) -> None:
+    """Render first page of a PDF to PNG using PyMuPDF. Fast, no entity limit."""
+    import fitz
+
+    doc = fitz.open(str(pdf_path))
+    page = doc[0]
+    mat = fitz.Matrix(dpi / 72, dpi / 72)
+    pix = page.get_pixmap(matrix=mat)
+    pix.save(str(output_path))
+    doc.close()
+    logger.info("Rendered PDF page 1 → %s (%d dpi)", output_path.name, dpi)
 
 
 def _convert_dwg_to_dxf(dwg_path: Path, output_dir: Path, dest_path: Path) -> list[str]:

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -542,6 +542,116 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 audit=audit,
             ).model_dump()
 
+        # Handle design_assist — deterministic layout analysis, no LLM
+        if intent.family == TaskFamily.DESIGN_ASSIST:
+            from cad_dxf_agent.core.design_ops import LayoutRecommender, ScopeBuilder
+            from cad_dxf_agent.core.region_context import RegionContextBuilder
+
+            ctx_start = _time.monotonic()
+            region = None
+            parsed_region = _parse_selected_region(body.selected_regions)
+            if parsed_region:
+                region = RegionContextBuilder().build(session.context, parsed_region)
+
+            # Detect scope workflow
+            prompt_lower = body.prompt.lower()
+            is_scope = any(
+                kw in prompt_lower
+                for kw in ("scope of work", "full report", "design summary", "scope summary")
+            )
+
+            if is_scope:
+                result = ScopeBuilder().build(
+                    context=session.context,
+                    prompt=body.prompt,
+                    region=region,
+                    comparison_result=session.comparison_result,
+                    changeset=session.changeset,
+                )
+                data = result.model_dump()
+                message = f"Scope summary: {len(result.sections)} section(s) available."
+                confidence = result.aggregate_confidence
+                flags = result.ambiguity_flags
+            else:
+                result = LayoutRecommender().recommend(
+                    session.context, body.prompt, region,
+                )
+                data = result.model_dump()
+                message = (
+                    f"{result.total_recommendations} recommendation(s). "
+                    f"{result.drawing_summary}"
+                )
+                confidence = result.aggregate_confidence
+                flags = result.ambiguity_flags
+
+            audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
+            audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
+
+            return ResponseBuilder.design_assist(
+                message=message,
+                data=data,
+                confidence=confidence,
+                ambiguity_flags=flags,
+                audit=audit,
+            ).model_dump()
+
+        # Handle summary — deterministic revision summary, no LLM
+        if intent.family == TaskFamily.SUMMARY:
+            from cad_dxf_agent.core.design_ops import RevisionSummarizer
+
+            ctx_start = _time.monotonic()
+            result = RevisionSummarizer().summarize(
+                comparison_result=session.comparison_result,
+                changeset=session.changeset,
+                context=session.context,
+            )
+            audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
+            audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
+
+            return ResponseBuilder.summary_result(
+                message=result.headline,
+                data=result.model_dump(),
+                confidence=min(
+                    (e.confidence for e in result.key_changes), default=0.5,
+                ),
+                ambiguity_flags=result.ambiguity_flags,
+                audit=audit,
+            ).model_dump()
+
+        # Handle takeoff_estimate — deterministic counting, no LLM
+        if intent.family == TaskFamily.TAKEOFF_ESTIMATE:
+            from cad_dxf_agent.core.design_ops import TakeoffGenerator
+            from cad_dxf_agent.core.region_context import RegionContextBuilder
+
+            ctx_start = _time.monotonic()
+            region = None
+            parsed_region = _parse_selected_region(body.selected_regions)
+            if parsed_region:
+                region = RegionContextBuilder().build(session.context, parsed_region)
+
+            result = TakeoffGenerator().generate(
+                session.context, body.prompt, region,
+            )
+            audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
+            audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
+
+            _conf_labels = {
+                "high": 0.95,
+                "medium": 0.7,
+                "low": 0.4,
+                "estimate_only": 0.2,
+            }
+            return ResponseBuilder.takeoff_result(
+                message=(
+                    f"{result.total_items} takeoff item(s), "
+                    f"{result.total_quantity_items} total quantity."
+                ),
+                data=result.model_dump(),
+                confidence=_conf_labels.get(result.aggregate_confidence.value, 0.5),
+                ambiguity_flags=result.ambiguity_flags,
+                audit=audit,
+            ).model_dump()
+
         # Handle edit_plan — dispatch to existing planner
         if intent.family == TaskFamily.EDIT_PLAN:
             try:

--- a/web/frontend/src/components/ChatPanel.jsx
+++ b/web/frontend/src/components/ChatPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import QnaPanel from './QnaPanel';
+import DesignOpsPanel from './DesignOpsPanel';
 
 const SUGGESTIONS = [
   'Move column A1 24 feet east',
@@ -231,10 +232,20 @@ export default function ChatPanel({
               : msg.role === 'warning' ? 'warning'
               : msg.role;
             const isQna = msg.qnaData && msg.qnaData.task_family === 'qna';
+            const isDesignOps = msg.qnaData && (
+              msg.qnaData.task_family === 'design_assist' ||
+              msg.qnaData.task_family === 'summary' ||
+              msg.qnaData.task_family === 'takeoff_estimate'
+            );
 
             return (
               <div key={msg.id} className={`message-wrapper message-wrapper--${roleClass}`}>
-                {isQna ? (
+                {isDesignOps ? (
+                  <>
+                    <div className={`message message--${roleClass}`}>{msg.text}</div>
+                    <DesignOpsPanel data={msg.qnaData} />
+                  </>
+                ) : isQna ? (
                   <QnaPanel data={msg.qnaData} />
                 ) : (
                   <div className={`message message--${roleClass}`}>

--- a/web/frontend/src/components/DesignOpsPanel.jsx
+++ b/web/frontend/src/components/DesignOpsPanel.jsx
@@ -1,0 +1,203 @@
+/**
+ * DesignOpsPanel -- renders design operations results (layout recommendations,
+ * revision summaries, takeoff candidates, scope summaries) with confidence
+ * badges, caveats, and expand/collapse.
+ */
+
+import { useState } from 'react';
+
+function ConfidenceBadge({ value, label }) {
+  if (value == null && !label) return null;
+  const pct = value != null ? Math.round(value * 100) : null;
+  const level = pct != null
+    ? (pct >= 80 ? 'high' : pct >= 50 ? 'medium' : 'low')
+    : (label === 'high' ? 'high' : label === 'medium' ? 'medium' : 'low');
+  const text = pct != null ? `${pct}%` : label;
+  return (
+    <span className={`badge badge--${level === 'high' ? 'success' : level === 'medium' ? 'warning' : ''}`}>
+      {text}
+    </span>
+  );
+}
+
+function CaveatList({ caveats }) {
+  if (!caveats || caveats.length === 0) return null;
+  return (
+    <ul className="text-xs text-tertiary" style={{ marginTop: 'var(--space-1)', paddingLeft: 'var(--space-3)' }}>
+      {caveats.map((c, i) => <li key={i}>{c}</li>)}
+    </ul>
+  );
+}
+
+function CollapsibleSection({ title, confidence, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div style={{ border: '1px solid var(--border-primary)', borderRadius: 'var(--radius-md)', marginBottom: 'var(--space-2)' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          padding: 'var(--space-2) var(--space-3)', background: 'none', border: 'none',
+          cursor: 'pointer', color: 'var(--text-primary)', fontWeight: 600, fontSize: '0.875rem',
+        }}
+      >
+        <span>{open ? '\u25BC' : '\u25B6'} {title}</span>
+        <ConfidenceBadge value={confidence} />
+      </button>
+      {open && <div style={{ padding: '0 var(--space-3) var(--space-2)' }}>{children}</div>}
+    </div>
+  );
+}
+
+function RecommendationList({ recommendations }) {
+  if (!recommendations || recommendations.length === 0) return <p className="text-sm text-secondary">No recommendations.</p>;
+  return (
+    <div>
+      {recommendations.map((rec, i) => (
+        <div key={i} style={{ marginBottom: 'var(--space-2)', paddingBottom: 'var(--space-2)', borderBottom: '1px solid var(--border-secondary)' }}>
+          <div className="flex items-center gap-2">
+            <span className="badge">{rec.type?.replace(/_/g, ' ')}</span>
+            <ConfidenceBadge value={rec.confidence} />
+          </div>
+          <p className="text-sm" style={{ fontWeight: 600, marginTop: 'var(--space-1)' }}>{rec.title}</p>
+          <p className="text-sm text-secondary">{rec.description}</p>
+          <CaveatList caveats={rec.caveats} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TakeoffTable({ items }) {
+  if (!items || items.length === 0) return <p className="text-sm text-secondary">No takeoff items.</p>;
+  return (
+    <table style={{ width: '100%', fontSize: '0.8125rem', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr style={{ borderBottom: '2px solid var(--border-primary)' }}>
+          <th style={{ textAlign: 'left', padding: 'var(--space-1)' }}>Item</th>
+          <th style={{ textAlign: 'right', padding: 'var(--space-1)' }}>Qty</th>
+          <th style={{ textAlign: 'left', padding: 'var(--space-1)' }}>Layer</th>
+          <th style={{ textAlign: 'center', padding: 'var(--space-1)' }}>Confidence</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((item, i) => (
+          <tr key={i} style={{ borderBottom: '1px solid var(--border-secondary)' }}>
+            <td style={{ padding: 'var(--space-1)' }}>{item.name}</td>
+            <td style={{ textAlign: 'right', padding: 'var(--space-1)' }}>{item.quantity}{item.unit ? ` ${item.unit}` : ''}</td>
+            <td style={{ padding: 'var(--space-1)' }}>{item.source_layer}</td>
+            <td style={{ textAlign: 'center', padding: 'var(--space-1)' }}><ConfidenceBadge label={item.confidence} /></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ChangeSummaryList({ changes }) {
+  if (!changes || changes.length === 0) return <p className="text-sm text-secondary">No changes to summarize.</p>;
+  return (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {changes.map((c, i) => (
+        <li key={i} style={{ marginBottom: 'var(--space-1)', paddingBottom: 'var(--space-1)', borderBottom: '1px solid var(--border-secondary)' }}>
+          <span className="badge" style={{ marginRight: 'var(--space-1)' }}>{c.change_type}</span>
+          <span className="text-sm">{c.plain_description}</span>
+          {c.technical_detail && <span className="text-xs text-tertiary"> ({c.technical_detail})</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function DesignOpsPanel({ data }) {
+  if (!data) return null;
+
+  const taskFamily = data.task_family;
+  const payload = data.data || {};
+
+  // Scope summary (has sections array)
+  if (payload.sections) {
+    return (
+      <div className="design-ops-panel">
+        <h4 style={{ marginBottom: 'var(--space-2)' }}>{payload.title || 'Design Operations Report'}</h4>
+        {payload.omitted_sections?.length > 0 && (
+          <p className="text-xs text-tertiary">
+            Omitted: {payload.omitted_sections.join(', ')}
+          </p>
+        )}
+        {payload.sections.map((section, i) => (
+          <CollapsibleSection key={i} title={section.title} confidence={section.confidence} defaultOpen={i === 0}>
+            {section.section_type === 'layout_recommendations' && (
+              <RecommendationList recommendations={section.content?.recommendations} />
+            )}
+            {section.section_type === 'takeoff_candidates' && (
+              <TakeoffTable items={section.content?.items} />
+            )}
+            {section.section_type === 'revision_summary' && (
+              <ChangeSummaryList changes={section.content?.key_changes} />
+            )}
+            {section.section_type === 'general_notes' && (
+              <pre className="text-sm">{JSON.stringify(section.content, null, 2)}</pre>
+            )}
+            <CaveatList caveats={section.caveats} />
+          </CollapsibleSection>
+        ))}
+        <CaveatList caveats={payload.caveats} />
+      </div>
+    );
+  }
+
+  // Layout recommendations
+  if (payload.recommendations) {
+    return (
+      <div className="design-ops-panel">
+        <div className="flex items-center gap-2" style={{ marginBottom: 'var(--space-2)' }}>
+          <h4>{payload.total_recommendations} Recommendation(s)</h4>
+          <ConfidenceBadge value={payload.aggregate_confidence} />
+        </div>
+        <p className="text-sm text-secondary">{payload.drawing_summary}</p>
+        <RecommendationList recommendations={payload.recommendations} />
+        <CaveatList caveats={payload.limitations} />
+      </div>
+    );
+  }
+
+  // Takeoff candidates
+  if (payload.items) {
+    return (
+      <div className="design-ops-panel">
+        <div className="flex items-center gap-2" style={{ marginBottom: 'var(--space-2)' }}>
+          <h4>{payload.total_items} Takeoff Item(s)</h4>
+          <ConfidenceBadge label={payload.aggregate_confidence} />
+        </div>
+        <TakeoffTable items={payload.items} />
+        {payload.provenance_warnings?.length > 0 && (
+          <div className="text-xs text-tertiary" style={{ marginTop: 'var(--space-2)' }}>
+            {payload.provenance_warnings.map((w, i) => <p key={i}>{w}</p>)}
+          </div>
+        )}
+        <CaveatList caveats={payload.caveats} />
+      </div>
+    );
+  }
+
+  // Revision summary
+  if (payload.key_changes) {
+    return (
+      <div className="design-ops-panel">
+        <h4 style={{ marginBottom: 'var(--space-2)' }}>{payload.headline}</h4>
+        <p className="text-sm text-secondary">{payload.overall_assessment}</p>
+        <ChangeSummaryList changes={payload.key_changes} />
+        <CaveatList caveats={payload.caveats} />
+      </div>
+    );
+  }
+
+  // Fallback: show raw data
+  return (
+    <div className="design-ops-panel">
+      <pre className="text-sm">{JSON.stringify(payload, null, 2)}</pre>
+    </div>
+  );
+}

--- a/web/frontend/src/lib/api.js
+++ b/web/frontend/src/lib/api.js
@@ -2,7 +2,7 @@ import { auth } from './firebase';
 
 const API_BASE = import.meta.env.VITE_API_URL || '';
 const DEFAULT_TIMEOUT_MS = 60_000;   // 60s for most requests
-const UPLOAD_TIMEOUT_MS = 120_000;   // 120s for file uploads
+const UPLOAD_TIMEOUT_MS = 300_000;   // 5min for large PDF uploads
 
 async function getToken() {
   const user = auth.currentUser;


### PR DESCRIPTION
## Epic
EPIC-CAD-09 — Design Operations Workflow Pack

## Bead(s)
cad-ady (parent) + cad-ady.2 through cad-ady.5 (children)

## Summary
- Add four deterministic design-ops pipelines: layout recommendations, revision summaries, takeoff candidates, and scope-style summaries — all with typed schemas, confidence scoring, caveats, and evidence grounding
- Wire DESIGN_ASSIST, SUMMARY, and TAKEOFF_ESTIMATE task families through intent router, capability registry, response builder, and web dispatch
- Add DesignOpsPanel.jsx frontend component for rendering design-ops results with confidence badges, collapsible sections, and caveats
- SQ67 OCR provenance enforcement: takeoff quantities from OCR text are capped at ESTIMATE_ONLY confidence with mandatory provenance warnings

## Test plan
- 176 new tests (156 unit + 20 web endpoint), all passing
- 34 schema tests, 30 layout, 22 revision, 27 takeoff, 20 scope, 23 anti-regression, 20 web
- 4 golden trajectory fixtures for design-ops families
- Full suite: 2256 passed, 21 skipped (excluding pre-existing live/auth failures)
- Lint, format, typecheck all clean (`ruff check`, `ruff format --check`, `mypy`)

## Docs
- 050-PM-AAR: EPIC-CAD-09 after action report
- 041-PM-STAT: Updated with EPIC-09 DONE, test counts, phase status
- 000-INDEX: Added doc 050

🤖 Generated with [Claude Code](https://claude.com/claude-code)