### PR TITLE
feat: EPIC-CAD-15 document persistence — upload once, access always

### DIFF
--- a/src/cad_dxf_agent/core/document_store.py
+++ b/src/cad_dxf_agent/core/document_store.py
@@ -1,0 +1,280 @@
+"""Document store — ABC + InMemory + GCS implementations for persistent user documents.
+
+Documents are permanently stored per-user, independent of ephemeral sessions.
+InMemoryDocumentStore is for testing. GCSDocumentStore is for production.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from threading import Lock
+from typing import Any
+
+from cad_dxf_agent.models.document_schema import UserDocument
+
+logger = logging.getLogger(__name__)
+
+# Storage limits
+MAX_DOCUMENTS_PER_USER = 50
+MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024  # 25 MB
+MAX_TOTAL_STORAGE_BYTES = 100 * 1024 * 1024  # 100 MB per user
+
+
+class StorageLimitError(Exception):
+    """Raised when a storage limit is exceeded."""
+
+
+class DocumentStore(abc.ABC):
+    """Abstract document store for permanent user documents.
+
+    Implementations must be thread-safe for concurrent access.
+    """
+
+    @abc.abstractmethod
+    def save_document(
+        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+    ) -> UserDocument:
+        """Upload and persist a document. Returns the created UserDocument."""
+
+    @abc.abstractmethod
+    def get_document(self, user_id: str, doc_id: str) -> UserDocument | None:
+        """Get document metadata by ID, or None if not found."""
+
+    @abc.abstractmethod
+    def list_documents(self, user_id: str) -> list[UserDocument]:
+        """List all active documents for a user."""
+
+    @abc.abstractmethod
+    def delete_document(self, user_id: str, doc_id: str) -> bool:
+        """Soft-delete a document. Returns True if found and deleted."""
+
+    @abc.abstractmethod
+    def get_file_data(self, user_id: str, doc_id: str) -> bytes | None:
+        """Retrieve the raw file bytes for a document."""
+
+    def _check_limits(
+        self, user_id: str, file_size: int, existing_docs: list[UserDocument],
+    ) -> None:
+        """Validate storage limits before upload. Raises StorageLimitError."""
+        if file_size > MAX_FILE_SIZE_BYTES:
+            raise StorageLimitError(
+                f"File exceeds maximum size of {MAX_FILE_SIZE_BYTES // (1024 * 1024)} MB"
+            )
+
+        active_docs = [d for d in existing_docs if d.status == "active"]
+        if len(active_docs) >= MAX_DOCUMENTS_PER_USER:
+            raise StorageLimitError(
+                f"Document limit reached ({MAX_DOCUMENTS_PER_USER} documents)"
+            )
+
+        total_storage = sum(d.file_size_bytes for d in active_docs)
+        if total_storage + file_size > MAX_TOTAL_STORAGE_BYTES:
+            raise StorageLimitError(
+                f"Storage quota exceeded ({MAX_TOTAL_STORAGE_BYTES // (1024 * 1024)} MB limit)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# InMemoryDocumentStore (testing)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryDocumentStore(DocumentStore):
+    """In-memory document store for testing.
+
+    Stores file data and metadata in dicts. Not durable.
+    """
+
+    def __init__(self) -> None:
+        self._documents: dict[str, dict[str, UserDocument]] = {}  # user_id -> {doc_id -> doc}
+        self._file_data: dict[str, bytes] = {}  # doc_id -> bytes
+        self._lock = Lock()
+
+    def save_document(
+        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+    ) -> UserDocument:
+        with self._lock:
+            existing = list((self._documents.get(user_id) or {}).values())
+
+        self._check_limits(user_id, len(data), existing)
+
+        doc = UserDocument(
+            user_id=user_id,
+            filename=filename,
+            file_size_bytes=len(data),
+            metadata=metadata or {},
+        )
+
+        with self._lock:
+            if user_id not in self._documents:
+                self._documents[user_id] = {}
+            self._documents[user_id][doc.doc_id] = doc
+            self._file_data[doc.doc_id] = data
+
+        logger.info("Stored document %s (%s) for user %s", doc.doc_id, filename, user_id)
+        return doc
+
+    def get_document(self, user_id: str, doc_id: str) -> UserDocument | None:
+        with self._lock:
+            user_docs = self._documents.get(user_id, {})
+            doc = user_docs.get(doc_id)
+        if doc and doc.status == "active":
+            return doc
+        return None
+
+    def list_documents(self, user_id: str) -> list[UserDocument]:
+        with self._lock:
+            user_docs = self._documents.get(user_id, {})
+            return [d for d in user_docs.values() if d.status == "active"]
+
+    def delete_document(self, user_id: str, doc_id: str) -> bool:
+        with self._lock:
+            user_docs = self._documents.get(user_id, {})
+            doc = user_docs.get(doc_id)
+            if doc and doc.status == "active":
+                doc.status = "deleted"
+                return True
+        return False
+
+    def get_file_data(self, user_id: str, doc_id: str) -> bytes | None:
+        doc = self.get_document(user_id, doc_id)
+        if doc is None:
+            return None
+        with self._lock:
+            return self._file_data.get(doc_id)
+
+
+# ---------------------------------------------------------------------------
+# GCSDocumentStore (production)
+# ---------------------------------------------------------------------------
+
+
+class GCSDocumentStore(DocumentStore):
+    """GCS-backed document store for production.
+
+    Layout:
+        gs://{bucket}/{prefix}{user_id}/{doc_id}/original.dxf
+        gs://{bucket}/{prefix}{user_id}/{doc_id}/metadata.json
+    """
+
+    def __init__(
+        self,
+        bucket_name: str = "cad-dxf-agent-documents",
+        prefix: str = "documents/",
+    ):
+        self._bucket_name = bucket_name
+        self._prefix = prefix
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            from google.cloud import storage
+            self._client = storage.Client()
+        return self._client
+
+    def _bucket(self):
+        return self._get_client().bucket(self._bucket_name)
+
+    def _doc_prefix(self, user_id: str, doc_id: str) -> str:
+        return f"{self._prefix}{user_id}/{doc_id}/"
+
+    def save_document(
+        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+    ) -> UserDocument:
+        existing = self.list_documents(user_id)
+        self._check_limits(user_id, len(data), existing)
+
+        doc = UserDocument(
+            user_id=user_id,
+            filename=filename,
+            file_size_bytes=len(data),
+            metadata=metadata or {},
+        )
+        prefix = self._doc_prefix(user_id, doc.doc_id)
+        doc.gcs_path = f"gs://{self._bucket_name}/{prefix}original.dxf"
+
+        try:
+            bucket = self._bucket()
+
+            # Upload file
+            file_blob = bucket.blob(f"{self._doc_prefix(user_id, doc.doc_id)}original.dxf")
+            file_blob.upload_from_string(data, content_type="application/octet-stream")
+
+            # Upload metadata
+            meta_blob = bucket.blob(f"{self._doc_prefix(user_id, doc.doc_id)}metadata.json")
+            meta_blob.upload_from_string(
+                doc.model_dump_json(), content_type="application/json",
+            )
+
+            logger.info("Stored document %s (%s) to GCS for user %s", doc.doc_id, filename, user_id)
+        except Exception as exc:
+            logger.exception("Failed to upload document to GCS: %s", exc)
+            raise
+
+        return doc
+
+    def get_document(self, user_id: str, doc_id: str) -> UserDocument | None:
+        try:
+            meta_blob = self._bucket().blob(
+                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
+            )
+            if not meta_blob.exists():
+                return None
+            doc = UserDocument.model_validate_json(meta_blob.download_as_text())
+            if doc.status != "active":
+                return None
+            return doc
+        except Exception as exc:
+            logger.warning("Failed to fetch document %s from GCS: %s", doc_id, exc)
+            return None
+
+    def list_documents(self, user_id: str) -> list[UserDocument]:
+        results = []
+        try:
+            blobs = self._bucket().list_blobs(prefix=f"{self._prefix}{user_id}/")
+            for blob in blobs:
+                if not blob.name.endswith("metadata.json"):
+                    continue
+                try:
+                    doc = UserDocument.model_validate_json(blob.download_as_text())
+                    if doc.status == "active":
+                        results.append(doc)
+                except Exception as exc:
+                    logger.debug("Skipping malformed doc blob %s: %s", blob.name, exc)
+        except Exception as exc:
+            logger.exception("Failed to list documents from GCS: %s", exc)
+        return results
+
+    def delete_document(self, user_id: str, doc_id: str) -> bool:
+        doc = self.get_document(user_id, doc_id)
+        if doc is None:
+            return False
+
+        doc.status = "deleted"
+        try:
+            meta_blob = self._bucket().blob(
+                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
+            )
+            meta_blob.upload_from_string(
+                doc.model_dump_json(), content_type="application/json",
+            )
+            return True
+        except Exception as exc:
+            logger.exception("Failed to delete document %s from GCS: %s", doc_id, exc)
+            return False
+
+    def get_file_data(self, user_id: str, doc_id: str) -> bytes | None:
+        doc = self.get_document(user_id, doc_id)
+        if doc is None:
+            return None
+        try:
+            file_blob = self._bucket().blob(
+                f"{self._doc_prefix(user_id, doc_id)}original.dxf"
+            )
+            if not file_blob.exists():
+                return None
+            return bytes(file_blob.download_as_bytes())
+        except Exception as exc:
+            logger.warning("Failed to download document %s from GCS: %s", doc_id, exc)
+            return None

--- a/src/cad_dxf_agent/core/document_store.py
+++ b/src/cad_dxf_agent/core/document_store.py
@@ -33,7 +33,11 @@ class DocumentStore(abc.ABC):
 
     @abc.abstractmethod
     def save_document(
-        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+        self,
+        user_id: str,
+        filename: str,
+        data: bytes,
+        metadata: dict[str, Any] | None = None,
     ) -> UserDocument:
         """Upload and persist a document. Returns the created UserDocument."""
 
@@ -58,7 +62,10 @@ class DocumentStore(abc.ABC):
         return False  # Default no-op; subclasses override for persistence
 
     def _check_limits(
-        self, user_id: str, file_size: int, existing_docs: list[UserDocument],
+        self,
+        user_id: str,
+        file_size: int,
+        existing_docs: list[UserDocument],
     ) -> None:
         """Validate storage limits before upload. Raises StorageLimitError."""
         if file_size > MAX_FILE_SIZE_BYTES:
@@ -68,9 +75,7 @@ class DocumentStore(abc.ABC):
 
         active_docs = [d for d in existing_docs if d.status == "active"]
         if len(active_docs) >= MAX_DOCUMENTS_PER_USER:
-            raise StorageLimitError(
-                f"Document limit reached ({MAX_DOCUMENTS_PER_USER} documents)"
-            )
+            raise StorageLimitError(f"Document limit reached ({MAX_DOCUMENTS_PER_USER} documents)")
 
         total_storage = sum(d.file_size_bytes for d in active_docs)
         if total_storage + file_size > MAX_TOTAL_STORAGE_BYTES:
@@ -96,7 +101,11 @@ class InMemoryDocumentStore(DocumentStore):
         self._lock = Lock()
 
     def save_document(
-        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+        self,
+        user_id: str,
+        filename: str,
+        data: bytes,
+        metadata: dict[str, Any] | None = None,
     ) -> UserDocument:
         with self._lock:
             existing = list((self._documents.get(user_id) or {}).values())
@@ -181,6 +190,7 @@ class GCSDocumentStore(DocumentStore):
     def _get_client(self):
         if self._client is None:
             from google.cloud import storage
+
             self._client = storage.Client()
         return self._client
 
@@ -191,7 +201,11 @@ class GCSDocumentStore(DocumentStore):
         return f"{self._prefix}{user_id}/{doc_id}/"
 
     def save_document(
-        self, user_id: str, filename: str, data: bytes, metadata: dict[str, Any] | None = None,
+        self,
+        user_id: str,
+        filename: str,
+        data: bytes,
+        metadata: dict[str, Any] | None = None,
     ) -> UserDocument:
         existing = self.list_documents(user_id)
         self._check_limits(user_id, len(data), existing)
@@ -215,7 +229,8 @@ class GCSDocumentStore(DocumentStore):
             # Upload metadata
             meta_blob = bucket.blob(f"{self._doc_prefix(user_id, doc.doc_id)}metadata.json")
             meta_blob.upload_from_string(
-                doc.model_dump_json(), content_type="application/json",
+                doc.model_dump_json(),
+                content_type="application/json",
             )
 
             logger.info("Stored document %s (%s) to GCS for user %s", doc.doc_id, filename, user_id)
@@ -227,9 +242,7 @@ class GCSDocumentStore(DocumentStore):
 
     def get_document(self, user_id: str, doc_id: str) -> UserDocument | None:
         try:
-            meta_blob = self._bucket().blob(
-                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
-            )
+            meta_blob = self._bucket().blob(f"{self._doc_prefix(user_id, doc_id)}metadata.json")
             if not meta_blob.exists():
                 return None
             doc = UserDocument.model_validate_json(meta_blob.download_as_text())
@@ -264,11 +277,10 @@ class GCSDocumentStore(DocumentStore):
 
         doc.status = "deleted"
         try:
-            meta_blob = self._bucket().blob(
-                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
-            )
+            meta_blob = self._bucket().blob(f"{self._doc_prefix(user_id, doc_id)}metadata.json")
             meta_blob.upload_from_string(
-                doc.model_dump_json(), content_type="application/json",
+                doc.model_dump_json(),
+                content_type="application/json",
             )
             return True
         except Exception as exc:
@@ -281,11 +293,10 @@ class GCSDocumentStore(DocumentStore):
             return False
         doc.touch()
         try:
-            meta_blob = self._bucket().blob(
-                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
-            )
+            meta_blob = self._bucket().blob(f"{self._doc_prefix(user_id, doc_id)}metadata.json")
             meta_blob.upload_from_string(
-                doc.model_dump_json(), content_type="application/json",
+                doc.model_dump_json(),
+                content_type="application/json",
             )
             return True
         except Exception as exc:
@@ -297,9 +308,7 @@ class GCSDocumentStore(DocumentStore):
         if doc is None:
             return None
         try:
-            file_blob = self._bucket().blob(
-                f"{self._doc_prefix(user_id, doc_id)}original.dxf"
-            )
+            file_blob = self._bucket().blob(f"{self._doc_prefix(user_id, doc_id)}original.dxf")
             if not file_blob.exists():
                 return None
             return bytes(file_blob.download_as_bytes())

--- a/src/cad_dxf_agent/core/document_store.py
+++ b/src/cad_dxf_agent/core/document_store.py
@@ -53,6 +53,10 @@ class DocumentStore(abc.ABC):
     def get_file_data(self, user_id: str, doc_id: str) -> bytes | None:
         """Retrieve the raw file bytes for a document."""
 
+    def touch_document(self, user_id: str, doc_id: str) -> bool:
+        """Update last_accessed timestamp. Returns True if document exists."""
+        return False  # Default no-op; subclasses override for persistence
+
     def _check_limits(
         self, user_id: str, file_size: int, existing_docs: list[UserDocument],
     ) -> None:
@@ -96,17 +100,15 @@ class InMemoryDocumentStore(DocumentStore):
     ) -> UserDocument:
         with self._lock:
             existing = list((self._documents.get(user_id) or {}).values())
+            self._check_limits(user_id, len(data), existing)
 
-        self._check_limits(user_id, len(data), existing)
+            doc = UserDocument(
+                user_id=user_id,
+                filename=filename,
+                file_size_bytes=len(data),
+                metadata=metadata or {},
+            )
 
-        doc = UserDocument(
-            user_id=user_id,
-            filename=filename,
-            file_size_bytes=len(data),
-            metadata=metadata or {},
-        )
-
-        with self._lock:
             if user_id not in self._documents:
                 self._documents[user_id] = {}
             self._documents[user_id][doc.doc_id] = doc
@@ -134,6 +136,15 @@ class InMemoryDocumentStore(DocumentStore):
             doc = user_docs.get(doc_id)
             if doc and doc.status == "active":
                 doc.status = "deleted"
+                return True
+        return False
+
+    def touch_document(self, user_id: str, doc_id: str) -> bool:
+        with self._lock:
+            user_docs = self._documents.get(user_id, {})
+            doc = user_docs.get(doc_id)
+            if doc and doc.status == "active":
+                doc.touch()
                 return True
         return False
 
@@ -262,6 +273,23 @@ class GCSDocumentStore(DocumentStore):
             return True
         except Exception as exc:
             logger.exception("Failed to delete document %s from GCS: %s", doc_id, exc)
+            return False
+
+    def touch_document(self, user_id: str, doc_id: str) -> bool:
+        doc = self.get_document(user_id, doc_id)
+        if doc is None:
+            return False
+        doc.touch()
+        try:
+            meta_blob = self._bucket().blob(
+                f"{self._doc_prefix(user_id, doc_id)}metadata.json"
+            )
+            meta_blob.upload_from_string(
+                doc.model_dump_json(), content_type="application/json",
+            )
+            return True
+        except Exception as exc:
+            logger.warning("Failed to touch document %s in GCS: %s", doc_id, exc)
             return False
 
     def get_file_data(self, user_id: str, doc_id: str) -> bytes | None:

--- a/src/cad_dxf_agent/core/session_store.py
+++ b/src/cad_dxf_agent/core/session_store.py
@@ -46,6 +46,7 @@ class SessionMetadata:
     conversation_history: list[dict] = field(default_factory=list)
     audit_events: list = field(default_factory=list)
     # Paths stored as strings for serialization
+    document_id: str = ""  # Links session to a stored document (EPIC-CAD-15)
     original_path: str = ""
     working_path: str = ""
     edited_path: str = ""

--- a/src/cad_dxf_agent/models/document_schema.py
+++ b/src/cad_dxf_agent/models/document_schema.py
@@ -23,12 +23,8 @@ class UserDocument(BaseModel):
     user_id: str
     doc_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
     filename: str
-    upload_time: str = Field(
-        default_factory=lambda: datetime.now(UTC).isoformat()
-    )
-    last_accessed: str = Field(
-        default_factory=lambda: datetime.now(UTC).isoformat()
-    )
+    upload_time: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    last_accessed: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
     gcs_path: str = ""
     file_size_bytes: int = 0
     status: Literal["active", "deleted"] = "active"

--- a/src/cad_dxf_agent/models/document_schema.py
+++ b/src/cad_dxf_agent/models/document_schema.py
@@ -1,0 +1,39 @@
+"""User document models for persistent document storage.
+
+Defines UserDocument — the metadata model for permanently stored user drawings.
+Documents live in GCS under per-user paths and appear in the document library.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class UserDocument(BaseModel):
+    """A permanently stored user document.
+
+    Represents a DXF file uploaded to the user's personal library.
+    The actual file lives in GCS; this model tracks metadata only.
+    """
+
+    user_id: str
+    doc_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:16])
+    filename: str
+    upload_time: str = Field(
+        default_factory=lambda: datetime.now(UTC).isoformat()
+    )
+    last_accessed: str = Field(
+        default_factory=lambda: datetime.now(UTC).isoformat()
+    )
+    gcs_path: str = ""
+    file_size_bytes: int = 0
+    status: Literal["active", "deleted"] = "active"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def touch(self) -> None:
+        """Update last_accessed to now."""
+        self.last_accessed = datetime.now(UTC).isoformat()

--- a/tests/unit/test_document_schema.py
+++ b/tests/unit/test_document_schema.py
@@ -1,0 +1,71 @@
+"""Tests for document_schema — UserDocument model."""
+
+from __future__ import annotations
+
+import time
+
+from cad_dxf_agent.models.document_schema import UserDocument
+
+
+class TestUserDocument:
+    def test_creation_with_defaults(self):
+        """Newly created document has auto-generated doc_id, timestamps, and sane defaults."""
+        doc = UserDocument(user_id="u1", filename="floor-plan.dxf")
+        assert doc.user_id == "u1"
+        assert doc.filename == "floor-plan.dxf"
+        assert len(doc.doc_id) == 16
+        assert doc.status == "active"
+        assert doc.file_size_bytes == 0
+        assert doc.gcs_path == ""
+        assert doc.metadata == {}
+        assert doc.upload_time  # non-empty ISO string
+        assert doc.last_accessed
+
+    def test_unique_doc_ids(self):
+        """Each document gets a unique ID."""
+        docs = [UserDocument(user_id="u1", filename="a.dxf") for _ in range(10)]
+        ids = {d.doc_id for d in docs}
+        assert len(ids) == 10
+
+    def test_touch_updates_last_accessed(self):
+        """touch() bumps last_accessed to current time."""
+        doc = UserDocument(
+            user_id="u1",
+            filename="a.dxf",
+            last_accessed="2020-01-01T00:00:00+00:00",
+        )
+        old = doc.last_accessed
+        doc.touch()
+        assert doc.last_accessed != old
+        assert doc.last_accessed > old
+
+    def test_json_roundtrip(self):
+        """Model serializes and deserializes cleanly."""
+        doc = UserDocument(
+            user_id="u1",
+            filename="test.dxf",
+            file_size_bytes=12345,
+            gcs_path="gs://bucket/path",
+            metadata={"layers": 5},
+        )
+        json_str = doc.model_dump_json()
+        restored = UserDocument.model_validate_json(json_str)
+        assert restored.user_id == doc.user_id
+        assert restored.doc_id == doc.doc_id
+        assert restored.filename == doc.filename
+        assert restored.file_size_bytes == 12345
+        assert restored.gcs_path == "gs://bucket/path"
+        assert restored.metadata == {"layers": 5}
+
+    def test_status_values(self):
+        """Status accepts 'active' and 'deleted' only."""
+        doc_active = UserDocument(user_id="u1", filename="a.dxf", status="active")
+        assert doc_active.status == "active"
+
+        doc_deleted = UserDocument(user_id="u1", filename="a.dxf", status="deleted")
+        assert doc_deleted.status == "deleted"
+
+    def test_explicit_doc_id(self):
+        """Can provide explicit doc_id."""
+        doc = UserDocument(user_id="u1", filename="a.dxf", doc_id="custom123")
+        assert doc.doc_id == "custom123"

--- a/tests/unit/test_document_schema.py
+++ b/tests/unit/test_document_schema.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 from cad_dxf_agent.models.document_schema import UserDocument
 
 

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -162,10 +162,7 @@ class TestInMemoryDocumentStore:
             except Exception as e:
                 errors.append(e)
 
-        threads = [
-            threading.Thread(target=save_batch, args=("u1", i * 10))
-            for i in range(3)
-        ]
+        threads = [threading.Thread(target=save_batch, args=("u1", i * 10)) for i in range(3)]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -13,7 +13,6 @@ from cad_dxf_agent.core.document_store import (
     InMemoryDocumentStore,
     StorageLimitError,
 )
-from cad_dxf_agent.models.document_schema import UserDocument
 
 
 @pytest.fixture

--- a/tests/unit/test_document_store.py
+++ b/tests/unit/test_document_store.py
@@ -1,0 +1,177 @@
+"""Tests for document_store — InMemoryDocumentStore."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from cad_dxf_agent.core.document_store import (
+    MAX_DOCUMENTS_PER_USER,
+    MAX_FILE_SIZE_BYTES,
+    MAX_TOTAL_STORAGE_BYTES,
+    InMemoryDocumentStore,
+    StorageLimitError,
+)
+from cad_dxf_agent.models.document_schema import UserDocument
+
+
+@pytest.fixture
+def store() -> InMemoryDocumentStore:
+    return InMemoryDocumentStore()
+
+
+SAMPLE_DXF = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+
+
+class TestInMemoryDocumentStore:
+    def test_save_and_get(self, store: InMemoryDocumentStore):
+        """Save a document and retrieve it by ID."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        assert doc.user_id == "u1"
+        assert doc.filename == "floor.dxf"
+        assert doc.file_size_bytes == len(SAMPLE_DXF)
+        assert doc.status == "active"
+
+        retrieved = store.get_document("u1", doc.doc_id)
+        assert retrieved is not None
+        assert retrieved.doc_id == doc.doc_id
+
+    def test_get_nonexistent(self, store: InMemoryDocumentStore):
+        """Getting a nonexistent document returns None."""
+        assert store.get_document("u1", "nope") is None
+
+    def test_get_wrong_user(self, store: InMemoryDocumentStore):
+        """Documents are user-scoped — wrong user gets None."""
+        doc = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        assert store.get_document("u2", doc.doc_id) is None
+
+    def test_list_documents(self, store: InMemoryDocumentStore):
+        """List returns all active documents for a user."""
+        store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        store.save_document("u1", "b.dxf", SAMPLE_DXF)
+        store.save_document("u2", "c.dxf", SAMPLE_DXF)
+
+        u1_docs = store.list_documents("u1")
+        assert len(u1_docs) == 2
+        assert {d.filename for d in u1_docs} == {"a.dxf", "b.dxf"}
+
+        u2_docs = store.list_documents("u2")
+        assert len(u2_docs) == 1
+
+    def test_list_empty_user(self, store: InMemoryDocumentStore):
+        """Listing for a user with no documents returns empty list."""
+        assert store.list_documents("nobody") == []
+
+    def test_delete_document(self, store: InMemoryDocumentStore):
+        """Delete soft-deletes — document no longer appears in list or get."""
+        doc = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        assert store.delete_document("u1", doc.doc_id) is True
+        assert store.get_document("u1", doc.doc_id) is None
+        assert store.list_documents("u1") == []
+
+    def test_delete_nonexistent(self, store: InMemoryDocumentStore):
+        """Deleting a nonexistent document returns False."""
+        assert store.delete_document("u1", "nope") is False
+
+    def test_delete_idempotent(self, store: InMemoryDocumentStore):
+        """Deleting an already-deleted document returns False."""
+        doc = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        assert store.delete_document("u1", doc.doc_id) is True
+        assert store.delete_document("u1", doc.doc_id) is False
+
+    def test_get_file_data(self, store: InMemoryDocumentStore):
+        """Retrieve raw file bytes for a stored document."""
+        doc = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        data = store.get_file_data("u1", doc.doc_id)
+        assert data == SAMPLE_DXF
+
+    def test_get_file_data_deleted(self, store: InMemoryDocumentStore):
+        """Cannot retrieve file data for deleted documents."""
+        doc = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        store.delete_document("u1", doc.doc_id)
+        assert store.get_file_data("u1", doc.doc_id) is None
+
+    def test_get_file_data_nonexistent(self, store: InMemoryDocumentStore):
+        """File data for nonexistent doc returns None."""
+        assert store.get_file_data("u1", "nope") is None
+
+    def test_save_with_metadata(self, store: InMemoryDocumentStore):
+        """Custom metadata is preserved."""
+        doc = store.save_document(
+            "u1", "a.dxf", SAMPLE_DXF, metadata={"layers": 5, "entity_count": 200}
+        )
+        assert doc.metadata == {"layers": 5, "entity_count": 200}
+
+    def test_document_count_limit(self, store: InMemoryDocumentStore):
+        """Cannot exceed MAX_DOCUMENTS_PER_USER."""
+        for i in range(MAX_DOCUMENTS_PER_USER):
+            store.save_document("u1", f"doc{i}.dxf", b"x")
+
+        with pytest.raises(StorageLimitError, match="Document limit"):
+            store.save_document("u1", "one-too-many.dxf", b"x")
+
+    def test_file_size_limit(self, store: InMemoryDocumentStore):
+        """Cannot upload a file exceeding MAX_FILE_SIZE_BYTES."""
+        big_data = b"x" * (MAX_FILE_SIZE_BYTES + 1)
+        with pytest.raises(StorageLimitError, match="maximum size"):
+            store.save_document("u1", "huge.dxf", big_data)
+
+    def test_total_storage_limit(self, store: InMemoryDocumentStore):
+        """Cannot exceed total per-user storage quota."""
+        chunk_size = MAX_TOTAL_STORAGE_BYTES // 4
+        for i in range(4):
+            store.save_document("u1", f"big{i}.dxf", b"x" * chunk_size)
+
+        with pytest.raises(StorageLimitError, match="Storage quota"):
+            store.save_document("u1", "overflow.dxf", b"x" * chunk_size)
+
+    def test_limits_per_user_isolation(self, store: InMemoryDocumentStore):
+        """Storage limits are per-user — u2 is unaffected by u1's usage."""
+        for i in range(MAX_DOCUMENTS_PER_USER):
+            store.save_document("u1", f"doc{i}.dxf", b"x")
+
+        # u2 can still upload
+        doc = store.save_document("u2", "fresh.dxf", SAMPLE_DXF)
+        assert doc.status == "active"
+
+    def test_deleted_docs_dont_count_against_limit(self, store: InMemoryDocumentStore):
+        """Deleted documents free up slots for new uploads."""
+        docs = []
+        for i in range(MAX_DOCUMENTS_PER_USER):
+            docs.append(store.save_document("u1", f"doc{i}.dxf", b"x"))
+
+        # At limit
+        with pytest.raises(StorageLimitError):
+            store.save_document("u1", "blocked.dxf", b"x")
+
+        # Delete one
+        store.delete_document("u1", docs[0].doc_id)
+
+        # Now we can upload
+        new_doc = store.save_document("u1", "freed.dxf", b"x")
+        assert new_doc.status == "active"
+
+    def test_thread_safety(self, store: InMemoryDocumentStore):
+        """Concurrent saves don't corrupt state."""
+        errors = []
+
+        def save_batch(user_id: str, start: int):
+            try:
+                for i in range(10):
+                    store.save_document(user_id, f"doc{start + i}.dxf", b"data")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=save_batch, args=("u1", i * 10))
+            for i in range(3)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        docs = store.list_documents("u1")
+        assert len(docs) == 30

--- a/tests/web/test_document_library.py
+++ b/tests/web/test_document_library.py
@@ -1,0 +1,169 @@
+"""Tests for document library API endpoints (EPIC-CAD-15)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cad_dxf_agent.core.document_store import InMemoryDocumentStore
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+
+SAMPLE_DXF_CONTENT = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+
+
+@pytest.fixture(autouse=True)
+def _use_inmemory_doc_store(monkeypatch):
+    """Force InMemoryDocumentStore for all tests in this module."""
+    import web.backend.main as main_mod
+
+    store = InMemoryDocumentStore()
+    monkeypatch.setattr(main_mod, "_document_store", store)
+    yield store
+    monkeypatch.setattr(main_mod, "_document_store", None)
+
+
+@pytest.mark.web
+class TestListDocuments:
+    def test_empty_library(self, client):
+        resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        assert resp.json()["documents"] == []
+
+    def test_lists_uploaded_documents(self, client):
+        # Upload two documents
+        client.post(
+            "/api/documents",
+            files={"file": ("a.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        client.post(
+            "/api/documents",
+            files={"file": ("b.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+
+        resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        docs = resp.json()["documents"]
+        assert len(docs) == 2
+        filenames = {d["filename"] for d in docs}
+        assert filenames == {"a.dxf", "b.dxf"}
+
+
+@pytest.mark.web
+class TestUploadDocument:
+    def test_upload_success(self, client):
+        resp = client.post(
+            "/api/documents",
+            files={"file": ("floor-plan.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        assert resp.status_code == 200
+        doc = resp.json()["document"]
+        assert doc["filename"] == "floor-plan.dxf"
+        assert doc["status"] == "active"
+        assert doc["file_size_bytes"] == len(SAMPLE_DXF_CONTENT)
+        assert doc["user_id"] == "test-user-123"
+        assert len(doc["doc_id"]) == 16
+
+    def test_upload_rejects_non_dxf(self, client):
+        resp = client.post(
+            "/api/documents",
+            files={"file": ("image.png", b"fakepng", "image/png")},
+        )
+        assert resp.status_code == 400
+        assert "DXF" in resp.json()["detail"]
+
+    def test_upload_rejects_empty_file(self, client):
+        resp = client.post(
+            "/api/documents",
+            files={"file": ("empty.dxf", b"", "application/octet-stream")},
+        )
+        assert resp.status_code == 400
+
+    def test_upload_storage_limit(self, client, _use_inmemory_doc_store):
+        """Exceeding document count limit returns 413."""
+        from cad_dxf_agent.core.document_store import MAX_DOCUMENTS_PER_USER
+
+        store = _use_inmemory_doc_store
+        # Pre-fill to limit
+        for i in range(MAX_DOCUMENTS_PER_USER):
+            store.save_document("test-user-123", f"doc{i}.dxf", b"x")
+
+        resp = client.post(
+            "/api/documents",
+            files={"file": ("overflow.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        assert resp.status_code == 413
+        assert "limit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.web
+class TestGetDocument:
+    def test_get_existing(self, client):
+        upload_resp = client.post(
+            "/api/documents",
+            files={"file": ("test.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        doc_id = upload_resp.json()["document"]["doc_id"]
+
+        resp = client.get(f"/api/documents/{doc_id}")
+        assert resp.status_code == 200
+        assert resp.json()["document"]["doc_id"] == doc_id
+
+    def test_get_nonexistent(self, client):
+        resp = client.get("/api/documents/nonexistent")
+        assert resp.status_code == 404
+
+
+@pytest.mark.web
+class TestDeleteDocument:
+    def test_delete_success(self, client):
+        upload_resp = client.post(
+            "/api/documents",
+            files={"file": ("test.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        doc_id = upload_resp.json()["document"]["doc_id"]
+
+        resp = client.delete(f"/api/documents/{doc_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # No longer in list
+        list_resp = client.get("/api/documents")
+        assert len(list_resp.json()["documents"]) == 0
+
+    def test_delete_nonexistent(self, client):
+        resp = client.delete("/api/documents/nonexistent")
+        assert resp.status_code == 404
+
+    def test_delete_idempotent(self, client):
+        upload_resp = client.post(
+            "/api/documents",
+            files={"file": ("test.dxf", SAMPLE_DXF_CONTENT, "application/octet-stream")},
+        )
+        doc_id = upload_resp.json()["document"]["doc_id"]
+
+        client.delete(f"/api/documents/{doc_id}")
+        resp = client.delete(f"/api/documents/{doc_id}")
+        assert resp.status_code == 404
+
+
+@pytest.mark.web
+class TestLoadDocument:
+    def test_load_creates_session(self, client, sample_dxf_bytes, _use_inmemory_doc_store):
+        """Loading a library document creates a working session."""
+        store = _use_inmemory_doc_store
+        # Upload a real DXF so load_dxf succeeds
+        doc = store.save_document("test-user-123", "real.dxf", sample_dxf_bytes)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "session_id" in data
+        assert data["document_id"] == doc.doc_id
+        assert "file_info" in data
+
+    def test_load_nonexistent_document(self, client):
+        resp = client.post("/api/documents/nonexistent/load")
+        assert resp.status_code == 404

--- a/tests/web/test_document_library.py
+++ b/tests/web/test_document_library.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from cad_dxf_agent.core.document_store import InMemoryDocumentStore

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -342,8 +342,8 @@ async def load_document(doc_id: str, user: dict = Depends(get_user)):
     meta.document_id = doc_id
     session_mgr.store.save(meta)
 
-    # Touch the document's last_accessed
-    doc.touch()
+    # Touch the document's last_accessed (persists to GCS in production)
+    store.touch_document(user["uid"], doc_id)
 
     # Load drawing info
     try:

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -236,6 +236,139 @@ async def get_profiles():
     return {name: p.model_dump() for name, p in BUILTIN_PROFILES.items()}
 
 
+# ---------------------------------------------------------------------------
+# Document Library endpoints (EPIC-CAD-15)
+# ---------------------------------------------------------------------------
+
+# Document store singleton — InMemory for dev, GCS for production
+_document_store = None
+
+
+def _get_document_store():
+    global _document_store
+    if _document_store is None:
+        from cad_dxf_agent.core.document_store import (
+            GCSDocumentStore,
+            InMemoryDocumentStore,
+        )
+
+        if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+            _document_store = InMemoryDocumentStore()
+            logger.info("Using InMemory document store (dev mode)")
+        else:
+            bucket = os.getenv("CAD_DOCUMENT_BUCKET", "cad-dxf-agent-documents")
+            _document_store = GCSDocumentStore(bucket_name=bucket)
+            logger.info("Using GCS document store (bucket=%s)", bucket)
+    return _document_store
+
+
+@app.get("/api/documents")
+async def list_documents(user: dict = Depends(get_user)):
+    """List all documents in the user's library."""
+    store = _get_document_store()
+    docs = store.list_documents(user["uid"])
+    return {"documents": [d.model_dump() for d in docs]}
+
+
+@app.post("/api/documents")
+async def upload_document(
+    file: UploadFile = File(...),
+    user: dict = Depends(get_user),
+):
+    """Upload a DXF to the user's permanent document library."""
+    from cad_dxf_agent.core.document_store import StorageLimitError
+
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file provided")
+
+    suffix = Path(file.filename).suffix.lower()
+    if suffix not in (".dxf",):
+        raise HTTPException(status_code=400, detail="Only DXF files are supported")
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty file")
+
+    store = _get_document_store()
+    try:
+        doc = store.save_document(user["uid"], file.filename, data)
+    except StorageLimitError as e:
+        raise HTTPException(status_code=413, detail=str(e)) from e
+
+    return {"document": doc.model_dump()}
+
+
+@app.get("/api/documents/{doc_id}")
+async def get_document_info(doc_id: str, user: dict = Depends(get_user)):
+    """Get metadata for a specific document."""
+    store = _get_document_store()
+    doc = store.get_document(user["uid"], doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return {"document": doc.model_dump()}
+
+
+@app.delete("/api/documents/{doc_id}")
+async def delete_document(doc_id: str, user: dict = Depends(get_user)):
+    """Delete a document from the user's library."""
+    store = _get_document_store()
+    if not store.delete_document(user["uid"], doc_id):
+        raise HTTPException(status_code=404, detail="Document not found")
+    return {"status": "deleted", "doc_id": doc_id}
+
+
+@app.post("/api/documents/{doc_id}/load")
+async def load_document(doc_id: str, user: dict = Depends(get_user)):
+    """Load a library document into a working session.
+
+    Copies the stored DXF to a session directory so the existing pipeline
+    can work with it. Returns session_id + file_info just like /api/upload.
+    """
+    store = _get_document_store()
+    doc = store.get_document(user["uid"], doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    file_data = store.get_file_data(user["uid"], doc_id)
+    if file_data is None:
+        raise HTTPException(status_code=404, detail="Document file not found")
+
+    # Create a session linked to this document
+    session = session_mgr.create(user["uid"])
+    Path(session.original_path).write_bytes(file_data)
+
+    # Update session with document binding
+    meta = session.to_metadata()
+    meta.document_id = doc_id
+    session_mgr.store.save(meta)
+
+    # Touch the document's last_accessed
+    doc.touch()
+
+    # Load drawing info
+    try:
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+
+        ctx = load_dxf(str(session.original_path))
+        session.context = ctx
+        file_info = {
+            "filename": doc.filename,
+            "entity_count": len(ctx.entities),
+            "layers": list({e.layer for e in ctx.entities}),
+            "drawing_units": ctx.metadata.get("units", "unknown"),
+        }
+        session.file_info = file_info
+    except Exception as e:
+        logger.warning("Failed to load DXF from library doc %s: %s", doc_id, e)
+        file_info = {"filename": doc.filename, "error": str(e)}
+
+    return {
+        "session_id": session.session_id,
+        "file_info": file_info,
+        "document_id": doc_id,
+    }
+
+
 @app.post("/api/upload")
 async def upload(
     file: UploadFile = File(...),


### PR DESCRIPTION
## Epic
EPIC-CAD-15: Document Persistence

## Bead(s)
cad-dxf-agent-aqw

## Summary

Users have been losing their drawings every time they close a browser tab. Sessions lived in `/tmp` with a 2-hour timer. This PR replaces that anxiety with a permanent document library.

- **UserDocument model** — Pydantic schema for permanently stored drawings with auto-generated IDs, timestamps, and extensible metadata
- **DocumentStore ABC** — Same pattern as SessionStore. InMemory for tests, GCS for production. Storage limits enforced (50 docs, 25 MB/file, 100 MB/user)
- **5 new API endpoints** — Full CRUD for the document library plus `POST /api/documents/{id}/load` to create a working session from a stored document
- **Session-document binding** — Sessions now reference their source document via `document_id` on SessionMetadata, surviving page refresh

Also fixes a pre-existing git conflict marker in `tests/web/test_apply.py`.

## Test plan
- [x] 6 unit tests for UserDocument model (defaults, roundtrip, touch, uniqueness)
- [x] 18 unit tests for InMemoryDocumentStore (CRUD, limits, thread safety, user isolation)
- [x] 13 web API tests (upload, list, get, delete, load, error cases, storage limits)
- [x] All 2,518 existing tests pass (0 regressions)
- [x] ruff lint clean
- [x] mypy typecheck clean

## Docs
- Spec: `000-docs/057-AT-SPEC-epic-cad-15-document-persistence.md` (from planning PR #92)
- UI/UX: `000-docs/058-AT-ARCH-v080-ui-ux-design-strategy.md` (from planning PR #92)