### PR TITLE
feat: EPIC-CAD-13 Area 2 — objective-driven intent layer

### DIFF
--- a/src/cad_dxf_agent/llm/objective_classifier.py
+++ b/src/cad_dxf_agent/llm/objective_classifier.py
@@ -1,0 +1,485 @@
+"""Two-axis objective classifier — wraps IntentRouter with objective intelligence.
+
+Classifies prompts along two axes:
+  1. RequestClass (8 values: understand, estimate, recommend, optimize,
+     modify, summarize, compare, validate)
+  2. ObjectiveTag (15 values: cost_reduction, space_count, missing_items, etc.)
+
+The classifier runs heuristic pattern matching first, falling back to the
+existing IntentRouter for TaskFamily routing. Backward compatible — all
+existing router behavior is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveClassification,
+    ObjectiveTag,
+    RequestClass,
+)
+from cad_dxf_agent.models.response_schema import TaskFamily
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ClassRule:
+    """Pattern rule for RequestClass detection."""
+
+    request_class: RequestClass
+    patterns: tuple[str, ...]
+    confidence: float = 0.90
+
+
+@dataclass(frozen=True)
+class _TagRule:
+    """Pattern rule for ObjectiveTag detection."""
+
+    tag: ObjectiveTag
+    patterns: tuple[str, ...]
+
+
+# --- RequestClass rules (priority-ordered, first match wins) ---
+
+_CLASS_RULES: list[_ClassRule] = [
+    _ClassRule(
+        request_class=RequestClass.COMPARE,
+        patterns=(
+            r"\bcompare\b",
+            r"\bdiff\b",
+            r"\bwhat\s+changed\b",
+            r"\bchanges?\s+between\b",
+            r"\brevision\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.VALIDATE,
+        patterns=(
+            r"\bvalidat",
+            r"\bcheck\s+(for\s+)?(compliance|completeness|consistency|missing)\b",
+            r"\bcode\s+complian",
+            r"\bmissing\s+(sheets?|notes?|dimensions?|labels?)\b",
+            r"\bverify\b",
+            r"\baudit\b",
+            r"\bcompliant\b",
+            r"\bmeeting?\s+(code|requirement|standard)\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.OPTIMIZE,
+        patterns=(
+            r"\bcheaper\b",
+            r"\breduce\s+cost\b",
+            r"\bcut\s+cost\b",
+            r"\bdecrease.*cost\b",
+            r"\bsave\s+money\b",
+            r"\boptimize\b",
+            r"\bmore\s+efficient\b",
+            r"\breduce\s+labor\b",
+            r"\bsimplify\b",
+            r"\bstreamline\b",
+            r"\b\d+%\s+(cheaper|less|smaller|reduction)\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.MODIFY,
+        patterns=(
+            r"\bshrink\b",
+            r"\bgrow\b",
+            r"\bexpand\b",
+            r"\bmake\s+(this|the|it)\b.*\b(bigger|smaller|larger|wider|narrower)\b",
+            r"\bmove\b",
+            r"\bdelete\b",
+            r"\bremove\b",
+            r"\badd\b",
+            r"\binsert\b",
+            r"\breplace\b",
+            r"\bchange\b",
+            r"\bedit\b",
+            r"\bmodify\b",
+            r"\brelocate\b",
+            r"\brotate\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.RECOMMEND,
+        patterns=(
+            r"\brecommend\b",
+            r"\bsuggest\b",
+            r"\bwhat\s+would\s+look\s+good\b",
+            r"\bhow\s+many.*would\s+(look|be|fit)\b",
+            r"\bwhat\s+options\b",
+            r"\balternatives?\b",
+            r"\bideas?\s+for\b",
+            r"\bimprove\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.ESTIMATE,
+        patterns=(
+            r"\bhow\s+much\b.*\bcost\b",
+            r"\bhow\s+much\b.*\bwould\b",
+            r"\bestimate\b",
+            r"\btakeoff\b",
+            r"\bquantity\b",
+            r"\bbill\s+of\b",
+            r"\bmaterial\s+list\b",
+            r"\bcount\b",
+            r"\bhow\s+many\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.SUMMARIZE,
+        patterns=(
+            r"\bsummar(y|ize|ise)\b",
+            r"\boverview\b",
+            r"\bdescribe\b",
+            r"\bfor\s+the\s+(customer|client|homeowner|contractor|reviewer)\b",
+            r"\bpresentation\b",
+            r"\bbrief\b",
+            r"\bexplain\s+to\b",
+        ),
+    ),
+    _ClassRule(
+        request_class=RequestClass.UNDERSTAND,
+        patterns=(
+            r"\bwhat\s+is\b",
+            r"\bwhere\s+is\b",
+            r"\bwhich\s+layer\b",
+            r"\bshow\s+me\b",
+            r"\btell\s+me\b",
+            r"\bwhat\s+are\b",
+            r"\bhow\s+big\b",
+            r"\bare\s+there\b",
+            r"\bis\s+there\b",
+            r"\bfind\b",
+        ),
+        confidence=0.85,
+    ),
+]
+
+# --- ObjectiveTag rules (all matched, best wins) ---
+
+_TAG_RULES: list[_TagRule] = [
+    _TagRule(
+        tag=ObjectiveTag.COST_REDUCTION,
+        patterns=(
+            r"\bcost\b",
+            r"\bcheaper\b",
+            r"\bexpens",
+            r"\bprice\b",
+            r"\bbudget\b",
+            r"\bsave\s+money\b",
+            r"\baffordable\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.LABOR_REDUCTION,
+        patterns=(
+            r"\blabor\b",
+            r"\bwork\s+hours?\b",
+            r"\binstall\s+time\b",
+            r"\bcrew\b",
+            r"\bman\s*hours?\b",
+            r"\bfaster\s+to\s+(build|install)\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.AREA_CHANGE,
+        patterns=(
+            r"\bsq\s*ft\b",
+            r"\bsquare\s+feet\b",
+            r"\barea\b",
+            r"\bshrink\b",
+            r"\bexpand\b",
+            r"\bsmaller\b",
+            r"\bbigger\b",
+            r"\broom\s+size\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.AESTHETICS,
+        patterns=(
+            r"\blook\s+good\b",
+            r"\baesthetic",
+            r"\bbeautif",
+            r"\bvisual",
+            r"\bappearance\b",
+            r"\bstyle\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.QUANTITY_ESTIMATION,
+        patterns=(
+            r"\bhow\s+many\b",
+            r"\bcount\b",
+            r"\bquantity\b",
+            r"\btakeoff\b",
+            r"\binventory\b",
+            r"\bbill\s+of\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
+        patterns=(
+            r"\bcustomer\b",
+            r"\bclient\b",
+            r"\bhomeowner\b",
+            r"\bowner\b",
+            r"\bfor\s+(the|my)\s+(customer|client|homeowner|owner)\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.CONTRACTOR_COMMUNICATION,
+        patterns=(
+            r"\bcontractor\b",
+            r"\bsubcontractor\b",
+            r"\bsub\b",
+            r"\bfield\s+crew\b",
+            r"\bfor\s+(the|my)\s+(contractor|sub|gc|builder)\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.REVIEWER_COMMUNICATION,
+        patterns=(
+            r"\breviewer\b",
+            r"\bplan\s+check",
+            r"\binspector\b",
+            r"\bbuilding\s+department\b",
+            r"\bpermit\s+review\b",
+            r"\bfor\s+(the|my)\s+(reviewer|inspector)\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.CONSTRUCTABILITY,
+        patterns=(
+            r"\bconstructab",
+            r"\bbuild(able|ability)\b",
+            r"\bfield\s+(issue|problem|concern)\b",
+            r"\binstall",
+            r"\bfeasib",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.COMPLIANCE,
+        patterns=(
+            r"\bcode\s+complian",
+            r"\bADA\b",
+            r"\bsetback\b",
+            r"\bzoning\b",
+            r"\bpermit\b",
+            r"\bregulat",
+            r"\brequirement\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.REVISION_EXPLANATION,
+        patterns=(
+            r"\bwhat\s+changed\b",
+            r"\brevision\b",
+            r"\bdiff\b",
+            r"\bcompare\b",
+            r"\bchanges?\s+between\b",
+            r"\bupdated\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.SPACE_COUNT,
+        patterns=(
+            r"\broom(s)?\b",
+            r"\bspace(s)?\b",
+            r"\bzone(s)?\b",
+            r"\benclosure(s)?\b",
+            r"\bhow\s+many\s+rooms?\b",
+            r"\bfloor\s+plan\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.EQUIPMENT_COUNT,
+        patterns=(
+            r"\bfixture(s)?\b",
+            r"\bdevice(s)?\b",
+            r"\bequipment\b",
+            r"\boutlet(s)?\b",
+            r"\bswitch(es)?\b",
+            r"\bpanel(s)?\b",
+            r"\bappliance(s)?\b",
+            r"\bplant(s)?\b",
+            r"\btree(s)?\b",
+            r"\bshrub(s)?\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.LAYOUT_IMPROVEMENT,
+        patterns=(
+            r"\blayout\b",
+            r"\bplacement\b",
+            r"\bspacing\b",
+            r"\barrangement\b",
+            r"\bflow\b",
+            r"\bcirculation\b",
+            r"\bdensity\b",
+        ),
+    ),
+    _TagRule(
+        tag=ObjectiveTag.MISSING_ITEMS,
+        patterns=(
+            r"\bmissing\b",
+            r"\bincomplete\b",
+            r"\bforgotten\b",
+            r"\blacking\b",
+            r"\bwhere\s+is\s+the\b",
+            r"\bshould\s+(there\s+)?be\b",
+        ),
+    ),
+]
+
+# Pre-compile
+_COMPILED_CLASS_RULES: list[tuple[_ClassRule, list[re.Pattern[str]]]] = [
+    (rule, [re.compile(p, re.IGNORECASE) for p in rule.patterns])
+    for rule in _CLASS_RULES
+]
+
+_COMPILED_TAG_RULES: list[tuple[_TagRule, list[re.Pattern[str]]]] = [
+    (rule, [re.compile(p, re.IGNORECASE) for p in rule.patterns])
+    for rule in _TAG_RULES
+]
+
+
+# --- Mapping: TaskFamily -> default RequestClass ---
+
+_FAMILY_TO_CLASS: dict[TaskFamily, RequestClass] = {
+    TaskFamily.COMPARE: RequestClass.COMPARE,
+    TaskFamily.EDIT_PLAN: RequestClass.MODIFY,
+    TaskFamily.APPLY_EDIT: RequestClass.MODIFY,
+    TaskFamily.TAKEOFF_ESTIMATE: RequestClass.ESTIMATE,
+    TaskFamily.DESIGN_ASSIST: RequestClass.RECOMMEND,
+    TaskFamily.SUMMARY: RequestClass.SUMMARIZE,
+    TaskFamily.QNA: RequestClass.UNDERSTAND,
+    TaskFamily.REPEATED_CONDITION: RequestClass.UNDERSTAND,
+    TaskFamily.MARKUP_INTERPRETATION: RequestClass.UNDERSTAND,
+    TaskFamily.NEEDS_CLARIFICATION: RequestClass.UNDERSTAND,
+    TaskFamily.UNSUPPORTED: RequestClass.UNDERSTAND,
+}
+
+
+class ObjectiveClassifier:
+    """Two-axis intent classifier wrapping the existing IntentRouter.
+
+    Adds objective context (RequestClass + ObjectiveTag) above the existing
+    TaskFamily routing. Backward compatible — IntentRouter still runs for
+    TaskFamily classification.
+    """
+
+    def classify(self, prompt: str) -> ObjectiveClassification:
+        """Classify a prompt into RequestClass + optional ObjectiveTag."""
+        start = time.monotonic()
+        stripped = prompt.strip()
+
+        if not stripped:
+            elapsed = (time.monotonic() - start) * 1000
+            return ObjectiveClassification(
+                request_class=RequestClass.UNDERSTAND,
+                confidence=1.0,
+                source="heuristic",
+                matched_patterns=["empty_prompt"],
+                classification_time_ms=elapsed,
+            )
+
+        # Axis 1: RequestClass (priority-ordered, first match)
+        request_class: RequestClass | None = None
+        class_confidence = 0.85
+        class_patterns: list[str] = []
+
+        for rule, compiled in _COMPILED_CLASS_RULES:
+            for pattern in compiled:
+                if pattern.search(stripped):
+                    request_class = rule.request_class
+                    class_confidence = rule.confidence
+                    class_patterns.append(pattern.pattern)
+                    break
+            if request_class is not None:
+                break
+
+        # Axis 2: ObjectiveTag (all matched, pick best by match count)
+        tag_scores: dict[ObjectiveTag, int] = {}
+        tag_patterns: list[str] = []
+        for tag_rule, tag_compiled in _COMPILED_TAG_RULES:
+            matches = sum(1 for p in tag_compiled if p.search(stripped))
+            if matches > 0:
+                tag_scores[tag_rule.tag] = matches
+                tag_patterns.extend(
+                    p.pattern for p in tag_compiled if p.search(stripped)
+                )
+
+        objective_tag: ObjectiveTag | None = None
+        if tag_scores:
+            objective_tag = max(tag_scores, key=tag_scores.get)  # type: ignore[arg-type]
+
+        # Fallback: if no class matched, infer from tag or default
+        if request_class is None:
+            if objective_tag in (
+                ObjectiveTag.COST_REDUCTION,
+                ObjectiveTag.LABOR_REDUCTION,
+            ):
+                request_class = RequestClass.OPTIMIZE
+                class_confidence = 0.75
+            elif objective_tag == ObjectiveTag.AREA_CHANGE:
+                request_class = RequestClass.MODIFY
+                class_confidence = 0.75
+            elif objective_tag in (
+                ObjectiveTag.QUANTITY_ESTIMATION,
+                ObjectiveTag.SPACE_COUNT,
+                ObjectiveTag.EQUIPMENT_COUNT,
+            ):
+                request_class = RequestClass.ESTIMATE
+                class_confidence = 0.75
+            elif objective_tag in (
+                ObjectiveTag.CUSTOMER_COMMUNICATION,
+                ObjectiveTag.CONTRACTOR_COMMUNICATION,
+                ObjectiveTag.REVIEWER_COMMUNICATION,
+            ):
+                request_class = RequestClass.SUMMARIZE
+                class_confidence = 0.75
+            elif objective_tag == ObjectiveTag.MISSING_ITEMS:
+                request_class = RequestClass.VALIDATE
+                class_confidence = 0.75
+            elif objective_tag == ObjectiveTag.LAYOUT_IMPROVEMENT:
+                request_class = RequestClass.RECOMMEND
+                class_confidence = 0.75
+            else:
+                request_class = RequestClass.UNDERSTAND
+                class_confidence = 0.50
+
+        elapsed = (time.monotonic() - start) * 1000
+        return ObjectiveClassification(
+            request_class=request_class,
+            objective_tag=objective_tag,
+            confidence=class_confidence,
+            source="heuristic",
+            matched_patterns=class_patterns + tag_patterns,
+            classification_time_ms=elapsed,
+        )
+
+    def classify_with_family(
+        self, prompt: str, task_family: TaskFamily,
+    ) -> ObjectiveClassification:
+        """Classify using both the objective heuristic and an existing TaskFamily.
+
+        If the heuristic is confident, use it. Otherwise, infer RequestClass
+        from the TaskFamily as a fallback.
+        """
+        result = self.classify(prompt)
+
+        # If heuristic confidence is low, use TaskFamily mapping
+        if result.confidence < 0.70 and task_family in _FAMILY_TO_CLASS:
+            result.request_class = _FAMILY_TO_CLASS[task_family]
+            result.confidence = 0.80
+            result.source = "family_fallback"
+
+        return result

--- a/src/cad_dxf_agent/llm/objective_classifier.py
+++ b/src/cad_dxf_agent/llm/objective_classifier.py
@@ -410,16 +410,17 @@ class ObjectiveClassifier:
         tag_scores: dict[ObjectiveTag, int] = {}
         tag_patterns: list[str] = []
         for tag_rule, tag_compiled in _COMPILED_TAG_RULES:
-            matches = sum(1 for p in tag_compiled if p.search(stripped))
-            if matches > 0:
-                tag_scores[tag_rule.tag] = matches
-                tag_patterns.extend(
-                    p.pattern for p in tag_compiled if p.search(stripped)
-                )
+            matched = [p for p in tag_compiled if p.search(stripped)]
+            if matched:
+                tag_scores[tag_rule.tag] = len(matched)
+                tag_patterns.extend(p.pattern for p in matched)
 
         objective_tag: ObjectiveTag | None = None
         if tag_scores:
-            objective_tag = max(tag_scores, key=tag_scores.get)  # type: ignore[arg-type]
+            # Deterministic: highest score wins, tie-break by tag name (asc)
+            objective_tag = sorted(
+                tag_scores, key=lambda t: (-tag_scores[t], t.value),
+            )[0]
 
         # Fallback: if no class matched, infer from tag or default
         if request_class is None:

--- a/src/cad_dxf_agent/llm/stage_executor.py
+++ b/src/cad_dxf_agent/llm/stage_executor.py
@@ -1,0 +1,174 @@
+"""Stage pipeline executor — runs typed stages with gate checkpoints.
+
+Executes the stages defined by a StagePipelineDefinition in order,
+collecting StageGate checkpoints for each stage. Each stage handler
+receives the accumulated context and returns output data.
+
+Stage handlers are registered by name and called in sequence. If a stage
+handler is not registered, the stage is skipped (logged as warning).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Protocol
+
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveClassification,
+    StageGate,
+    StagePipelineDefinition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StageHandler(Protocol):
+    """Protocol for stage handlers.
+
+    Each handler receives:
+    - classification: the two-axis classification result
+    - context: accumulated data from prior stages + initial drawing context
+    - prompt: the original user prompt
+
+    Returns a dict of output data to merge into context for subsequent stages.
+    """
+
+    def execute(
+        self,
+        classification: ObjectiveClassification,
+        context: dict[str, Any],
+        prompt: str,
+    ) -> dict[str, Any]: ...
+
+
+class StageExecutionResult:
+    """Result of executing a stage pipeline."""
+
+    def __init__(
+        self,
+        *,
+        gates: list[StageGate],
+        output: dict[str, Any],
+        output_mode: str,
+        total_time_ms: float,
+    ) -> None:
+        self.gates = gates
+        self.output = output
+        self.output_mode = output_mode
+        self.total_time_ms = total_time_ms
+
+    @property
+    def completed_stages(self) -> list[str]:
+        return [g.stage_name for g in self.gates if g.status == "completed"]
+
+    @property
+    def skipped_stages(self) -> list[str]:
+        return [g.stage_name for g in self.gates if g.status == "skipped"]
+
+    @property
+    def all_completed(self) -> bool:
+        return all(g.status in ("completed", "skipped") for g in self.gates)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gates": [g.model_dump() for g in self.gates],
+            "output": self.output,
+            "output_mode": self.output_mode,
+            "total_time_ms": self.total_time_ms,
+            "completed_stages": self.completed_stages,
+            "skipped_stages": self.skipped_stages,
+        }
+
+
+class StagePipelineExecutor:
+    """Executes stage pipelines with registered handlers and gate checkpoints."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, StageHandler] = {}
+
+    def register(self, stage_name: str, handler: StageHandler) -> None:
+        """Register a handler for a named stage."""
+        self._handlers[stage_name] = handler
+
+    def has_handler(self, stage_name: str) -> bool:
+        return stage_name in self._handlers
+
+    def execute(
+        self,
+        *,
+        pipeline: StagePipelineDefinition,
+        classification: ObjectiveClassification,
+        initial_context: dict[str, Any],
+        prompt: str,
+    ) -> StageExecutionResult:
+        """Execute all stages in the pipeline definition.
+
+        Stages run in order. Each stage's output is merged into context
+        for subsequent stages. A StageGate checkpoint is recorded for each.
+        """
+        start = time.monotonic()
+        gates: list[StageGate] = []
+        context = dict(initial_context)
+
+        for stage_name in pipeline.stages:
+            gate = StageGate(stage_name=stage_name, status="active")
+
+            handler = self._handlers.get(stage_name)
+            if handler is None:
+                logger.warning("No handler for stage '%s', skipping", stage_name)
+                gate.status = "skipped"
+                gate.output_summary = f"No handler registered for '{stage_name}'"
+                gates.append(gate)
+                continue
+
+            stage_start = time.monotonic()
+            try:
+                output = handler.execute(
+                    classification=classification,
+                    context=context,
+                    prompt=prompt,
+                )
+                stage_ms = (time.monotonic() - stage_start) * 1000
+
+                # Merge output into accumulated context
+                context.update(output)
+
+                gate.status = "completed"
+                gate.output_summary = output.get("summary", f"Stage '{stage_name}' completed")
+                gate.output_data = {
+                    "stage_time_ms": stage_ms,
+                    **{k: v for k, v in output.items() if k != "summary"},
+                }
+            except Exception:
+                stage_ms = (time.monotonic() - stage_start) * 1000
+                logger.exception("Stage '%s' failed", stage_name)
+                gate.status = "rejected"
+                gate.output_summary = f"Stage '{stage_name}' failed"
+                gate.output_data = {"stage_time_ms": stage_ms}
+
+            gates.append(gate)
+
+            # Stop pipeline if a stage was rejected
+            if gate.status == "rejected":
+                # Mark remaining stages as skipped
+                remaining_idx = pipeline.stages.index(stage_name) + 1
+                for remaining in pipeline.stages[remaining_idx:]:
+                    gates.append(StageGate(
+                        stage_name=remaining,
+                        status="skipped",
+                        output_summary=f"Skipped due to '{stage_name}' failure",
+                    ))
+                break
+
+        total_ms = (time.monotonic() - start) * 1000
+        return StageExecutionResult(
+            gates=gates,
+            output=context,
+            output_mode=pipeline.output_mode,
+            total_time_ms=total_ms,
+        )
+
+    @property
+    def registered_stages(self) -> list[str]:
+        return list(self._handlers.keys())

--- a/src/cad_dxf_agent/llm/strategy_registry.py
+++ b/src/cad_dxf_agent/llm/strategy_registry.py
@@ -1,0 +1,193 @@
+"""Strategy selector registry — maps (RequestClass, ObjectiveTag?) to stage pipelines.
+
+Given a two-axis classification (RequestClass + optional ObjectiveTag), the registry
+returns a StagePipelineDefinition that determines which stages run and in what order.
+
+This is the routing brain that sits between classification and execution.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveTag,
+    RequestClass,
+    StagePipelineDefinition,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Default pipelines per RequestClass (when no tag-specific override exists)
+_CLASS_DEFAULTS: dict[RequestClass, StagePipelineDefinition] = {
+    RequestClass.UNDERSTAND: StagePipelineDefinition(
+        stages=["analyze"],
+        output_mode="direct",
+        description="Direct analysis — answer the question from drawing context",
+    ),
+    RequestClass.ESTIMATE: StagePipelineDefinition(
+        stages=["analyze", "quantify"],
+        output_mode="direct",
+        description="Count or measure from drawing context, return structured quantities",
+    ),
+    RequestClass.RECOMMEND: StagePipelineDefinition(
+        stages=["analyze", "recommend"],
+        output_mode="staged",
+        description="Analyze drawing, then generate ranked recommendations with tradeoffs",
+    ),
+    RequestClass.OPTIMIZE: StagePipelineDefinition(
+        stages=["analyze", "recommend", "plan"],
+        output_mode="staged",
+        description="Analyze for optimization targets, recommend options, plan edits",
+    ),
+    RequestClass.MODIFY: StagePipelineDefinition(
+        stages=["plan", "preview"],
+        output_mode="full",
+        description="Plan edit operations, generate preview for user approval",
+    ),
+    RequestClass.SUMMARIZE: StagePipelineDefinition(
+        stages=["analyze", "summarize"],
+        output_mode="direct",
+        description="Analyze drawing context, produce human-readable summary",
+    ),
+    RequestClass.COMPARE: StagePipelineDefinition(
+        stages=["compare"],
+        output_mode="direct",
+        description="Run comparison pipeline between master and revision",
+    ),
+    RequestClass.VALIDATE: StagePipelineDefinition(
+        stages=["analyze", "validate"],
+        output_mode="direct",
+        description="Check drawing for completeness, compliance, or consistency issues",
+    ),
+}
+
+# Tag-specific overrides: (RequestClass, ObjectiveTag) -> pipeline
+# These refine the default when a specific objective is detected
+_TAG_OVERRIDES: dict[tuple[RequestClass, ObjectiveTag], StagePipelineDefinition] = {
+    (RequestClass.OPTIMIZE, ObjectiveTag.COST_REDUCTION): StagePipelineDefinition(
+        stages=["analyze", "quantify", "recommend", "plan"],
+        output_mode="staged",
+        description="Identify cost drivers, quantify savings candidates, recommend reductions",
+    ),
+    (RequestClass.OPTIMIZE, ObjectiveTag.LABOR_REDUCTION): StagePipelineDefinition(
+        stages=["analyze", "quantify", "recommend"],
+        output_mode="staged",
+        description="Identify labor-intensive elements, suggest simplification options",
+    ),
+    (RequestClass.ESTIMATE, ObjectiveTag.SPACE_COUNT): StagePipelineDefinition(
+        stages=["analyze", "detect_zones", "quantify"],
+        output_mode="direct",
+        description="Detect enclosed zones/rooms, count and measure spaces",
+    ),
+    (RequestClass.ESTIMATE, ObjectiveTag.EQUIPMENT_COUNT): StagePipelineDefinition(
+        stages=["analyze", "quantify"],
+        output_mode="direct",
+        description="Count fixtures/devices/equipment by type and zone",
+    ),
+    (RequestClass.SUMMARIZE, ObjectiveTag.CUSTOMER_COMMUNICATION): StagePipelineDefinition(
+        stages=["analyze", "summarize"],
+        output_mode="direct",
+        description="Produce plain-language summary suitable for homeowner/client",
+    ),
+    (RequestClass.SUMMARIZE, ObjectiveTag.CONTRACTOR_COMMUNICATION): StagePipelineDefinition(
+        stages=["analyze", "quantify", "summarize"],
+        output_mode="direct",
+        description="Produce technical summary with quantities for field crew",
+    ),
+    (RequestClass.SUMMARIZE, ObjectiveTag.REVIEWER_COMMUNICATION): StagePipelineDefinition(
+        stages=["analyze", "validate", "summarize"],
+        output_mode="direct",
+        description="Produce compliance-focused summary for plan reviewer",
+    ),
+    (RequestClass.RECOMMEND, ObjectiveTag.LAYOUT_IMPROVEMENT): StagePipelineDefinition(
+        stages=["analyze", "recommend"],
+        output_mode="staged",
+        description="Analyze spatial layout, recommend density/placement improvements",
+    ),
+    (RequestClass.VALIDATE, ObjectiveTag.COMPLIANCE): StagePipelineDefinition(
+        stages=["analyze", "validate"],
+        output_mode="direct",
+        description="Check drawing against code compliance indicators",
+    ),
+    (RequestClass.VALIDATE, ObjectiveTag.MISSING_ITEMS): StagePipelineDefinition(
+        stages=["analyze", "validate"],
+        output_mode="direct",
+        description="Scan for missing sheets, labels, dimensions, or notes",
+    ),
+}
+
+
+class StrategyRegistry:
+    """Registry that maps classification results to stage pipeline definitions.
+
+    Lookup order:
+    1. Tag-specific override: (RequestClass, ObjectiveTag) exact match
+    2. Class default: RequestClass default pipeline
+    3. Fallback: single-stage analyze pipeline
+    """
+
+    def __init__(
+        self,
+        *,
+        class_defaults: dict[RequestClass, StagePipelineDefinition] | None = None,
+        tag_overrides: (
+            dict[tuple[RequestClass, ObjectiveTag], StagePipelineDefinition] | None
+        ) = None,
+    ) -> None:
+        self._class_defaults = class_defaults or dict(_CLASS_DEFAULTS)
+        self._tag_overrides = tag_overrides or dict(_TAG_OVERRIDES)
+
+    def lookup(
+        self,
+        request_class: RequestClass,
+        objective_tag: ObjectiveTag | None = None,
+    ) -> StagePipelineDefinition:
+        """Find the best pipeline definition for a classification result."""
+        # Try tag-specific override first
+        if objective_tag is not None:
+            key = (request_class, objective_tag)
+            if key in self._tag_overrides:
+                logger.debug(
+                    "Strategy override: %s × %s", request_class.value, objective_tag.value,
+                )
+                return self._tag_overrides[key]
+
+        # Fall back to class default
+        if request_class in self._class_defaults:
+            logger.debug("Strategy default: %s", request_class.value)
+            return self._class_defaults[request_class]
+
+        # Ultimate fallback
+        logger.warning("No strategy for %s, using analyze fallback", request_class.value)
+        return StagePipelineDefinition(
+            stages=["analyze"],
+            output_mode="direct",
+            description="Fallback: single-stage analysis",
+        )
+
+    def register_override(
+        self,
+        request_class: RequestClass,
+        objective_tag: ObjectiveTag,
+        pipeline: StagePipelineDefinition,
+    ) -> None:
+        """Register a tag-specific pipeline override."""
+        self._tag_overrides[(request_class, objective_tag)] = pipeline
+
+    def register_default(
+        self,
+        request_class: RequestClass,
+        pipeline: StagePipelineDefinition,
+    ) -> None:
+        """Register or replace a class-level default pipeline."""
+        self._class_defaults[request_class] = pipeline
+
+    @property
+    def all_defaults(self) -> dict[RequestClass, StagePipelineDefinition]:
+        return dict(self._class_defaults)
+
+    @property
+    def all_overrides(self) -> dict[tuple[RequestClass, ObjectiveTag], StagePipelineDefinition]:
+        return dict(self._tag_overrides)

--- a/src/cad_dxf_agent/models/objective_schema.py
+++ b/src/cad_dxf_agent/models/objective_schema.py
@@ -1,0 +1,143 @@
+"""Objective intelligence models for two-axis intent classification.
+
+Defines RequestClass (8 values), ObjectiveTag (15 values), DocumentFamilyHint (20 families),
+AnalysisResult, RecommendationSet, and StageGate models for the multi-stage
+reasoning pipeline.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class RequestClass(StrEnum):
+    """Primary request class — what kind of response the user needs.
+
+    8 values covering all user intent categories.
+    """
+
+    UNDERSTAND = "understand"
+    ESTIMATE = "estimate"
+    RECOMMEND = "recommend"
+    OPTIMIZE = "optimize"
+    MODIFY = "modify"
+    SUMMARIZE = "summarize"
+    COMPARE = "compare"
+    VALIDATE = "validate"
+
+
+class ObjectiveTag(StrEnum):
+    """Domain context — what the user is trying to achieve.
+
+    15 values covering cross-family objectives.
+    """
+
+    COST_REDUCTION = "cost_reduction"
+    LABOR_REDUCTION = "labor_reduction"
+    AREA_CHANGE = "area_change"
+    AESTHETICS = "aesthetics"
+    QUANTITY_ESTIMATION = "quantity_estimation"
+    CUSTOMER_COMMUNICATION = "customer_communication"
+    CONTRACTOR_COMMUNICATION = "contractor_communication"
+    REVIEWER_COMMUNICATION = "reviewer_communication"
+    CONSTRUCTABILITY = "constructability"
+    COMPLIANCE = "compliance"
+    REVISION_EXPLANATION = "revision_explanation"
+    SPACE_COUNT = "space_count"
+    EQUIPMENT_COUNT = "equipment_count"
+    LAYOUT_IMPROVEMENT = "layout_improvement"
+    MISSING_ITEMS = "missing_items"
+
+
+class DocumentFamilyHint(StrEnum):
+    """Inferred document family — refines output phrasing, never gates capability.
+
+    20 families detected from layer names, block names, and text content.
+    """
+
+    RESIDENTIAL_ARCHITECTURAL = "residential_architectural"
+    COMMERCIAL_ARCHITECTURAL = "commercial_architectural"
+    STRUCTURAL = "structural"
+    CIVIL_SITE = "civil_site"
+    LANDSCAPE = "landscape"
+    ELECTRICAL = "electrical"
+    MECHANICAL = "mechanical"
+    PLUMBING = "plumbing"
+    FIRE_SAFETY = "fire_safety"
+    INTERIOR_DESIGN = "interior_design"
+    KITCHEN_BATH = "kitchen_bath"
+    PERMIT_SET = "permit_set"
+    AS_BUILT = "as_built"
+    SHOP_FABRICATION = "shop_fabrication"
+    FACILITY_MAINTENANCE = "facility_maintenance"
+    SURVEY_BOUNDARY = "survey_boundary"
+    CONSTRUCTION_LOGISTICS = "construction_logistics"
+    SOLAR_ENERGY = "solar_energy"
+    SIGNAGE_WAYFINDING = "signage_wayfinding"
+    UNKNOWN = "unknown"
+
+
+class ObjectiveClassification(BaseModel):
+    """Result of two-axis objective classification."""
+
+    request_class: RequestClass
+    objective_tag: ObjectiveTag | None = None
+    document_family: DocumentFamilyHint = DocumentFamilyHint.UNKNOWN
+    confidence: float = Field(ge=0.0, le=1.0)
+    source: str = "heuristic"
+    matched_patterns: list[str] = Field(default_factory=list)
+    classification_time_ms: float = 0.0
+
+
+class AnalysisResult(BaseModel):
+    """Output of the analyze stage — evidence-based drawing analysis."""
+
+    summary: str
+    evidence: list[dict[str, Any]] = Field(default_factory=list)
+    cost_drivers: list[dict[str, Any]] = Field(default_factory=list)
+    area_metrics: dict[str, float] = Field(default_factory=dict)
+    quantity_data: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = Field(ge=0.0, le=1.0, default=0.5)
+
+
+class RecommendationOption(BaseModel):
+    """A single recommendation with tradeoffs."""
+
+    title: str
+    description: str
+    estimated_impact: str
+    tradeoffs: list[str] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0, default=0.5)
+    operations_hint: list[str] = Field(default_factory=list)
+
+
+class RecommendationSet(BaseModel):
+    """Output of the recommend stage — ranked options for the user."""
+
+    options: list[RecommendationOption] = Field(default_factory=list)
+    selected_index: int | None = None
+
+
+class StageGate(BaseModel):
+    """Checkpoint between pipeline stages — inspectable by the user."""
+
+    stage_name: str
+    status: Literal["pending", "active", "completed", "rejected", "skipped"] = "pending"
+    output_summary: str = ""
+    requires_user_input: bool = False
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(UTC).isoformat()
+    )
+    output_data: dict[str, Any] = Field(default_factory=dict)
+
+
+class StagePipelineDefinition(BaseModel):
+    """Defines which stages run for a given (class, objective) pair."""
+
+    stages: list[str]  # e.g. ["analyze", "recommend", "plan", "preview"]
+    output_mode: str = "full"  # "direct", "staged", "full"
+    description: str = ""

--- a/src/cad_dxf_agent/models/objective_schema.py
+++ b/src/cad_dxf_agent/models/objective_schema.py
@@ -139,5 +139,5 @@ class StagePipelineDefinition(BaseModel):
     """Defines which stages run for a given (class, objective) pair."""
 
     stages: list[str]  # e.g. ["analyze", "recommend", "plan", "preview"]
-    output_mode: str = "full"  # "direct", "staged", "full"
+    output_mode: Literal["direct", "staged", "full"] = "full"
     description: str = ""

--- a/src/cad_dxf_agent/models/response_schema.py
+++ b/src/cad_dxf_agent/models/response_schema.py
@@ -141,3 +141,9 @@ class PlatformResponse(BaseModel):
     ambiguity_flags: list[str] = Field(default_factory=list)
     data: dict[str, Any] = Field(default_factory=dict)  # task-specific payload
     session_id: str | None = None
+
+    # Objective intelligence metadata (EPIC-CAD-13)
+    request_class: str | None = None  # RequestClass value
+    objective_tag: str | None = None  # ObjectiveTag value
+    document_family: str | None = None  # DocumentFamilyHint value
+    stage_pipeline: dict[str, Any] | None = None  # stage execution metadata

--- a/tests/unit/test_objective_classifier.py
+++ b/tests/unit/test_objective_classifier.py
@@ -1,0 +1,178 @@
+"""Tests for ObjectiveClassifier — two-axis heuristic classification."""
+
+import pytest
+
+from cad_dxf_agent.llm.objective_classifier import ObjectiveClassifier
+from cad_dxf_agent.models.objective_schema import ObjectiveTag, RequestClass
+from cad_dxf_agent.models.response_schema import TaskFamily
+
+
+@pytest.fixture
+def classifier():
+    return ObjectiveClassifier()
+
+
+class TestRequestClassClassification:
+    """Test Axis 1: RequestClass detection."""
+
+    @pytest.mark.parametrize("prompt,expected", [
+        ("compare these two drawings", RequestClass.COMPARE),
+        ("what changed between revisions", RequestClass.COMPARE),
+        ("diff the plans", RequestClass.COMPARE),
+        ("validate this drawing for completeness", RequestClass.VALIDATE),
+        ("check for missing dimensions", RequestClass.VALIDATE),
+        ("is this code compliant", RequestClass.VALIDATE),
+        ("verify the notes are consistent", RequestClass.VALIDATE),
+        ("audit this plan set", RequestClass.VALIDATE),
+        ("make this cheaper", RequestClass.OPTIMIZE),
+        ("reduce cost by 20%", RequestClass.OPTIMIZE),
+        ("optimize the layout", RequestClass.OPTIMIZE),
+        ("simplify the design", RequestClass.OPTIMIZE),
+        ("move the wall 3 feet north", RequestClass.MODIFY),
+        ("delete the door", RequestClass.MODIFY),
+        ("add a window here", RequestClass.MODIFY),
+        ("rotate this block", RequestClass.MODIFY),
+        ("recommend a better layout", RequestClass.RECOMMEND),
+        ("suggest improvements", RequestClass.RECOMMEND),
+        ("what options do I have", RequestClass.RECOMMEND),
+        ("how much would this cost", RequestClass.ESTIMATE),
+        ("count all the doors", RequestClass.ESTIMATE),
+        ("how many windows are there", RequestClass.ESTIMATE),
+        ("generate a takeoff", RequestClass.ESTIMATE),
+        ("summarize this drawing", RequestClass.SUMMARIZE),
+        ("describe this plan for the homeowner", RequestClass.SUMMARIZE),
+        ("give me an overview", RequestClass.SUMMARIZE),
+        ("explain to the contractor", RequestClass.SUMMARIZE),
+        ("what is on layer WALLS", RequestClass.UNDERSTAND),
+        ("where is the front door", RequestClass.UNDERSTAND),
+        ("show me the title block", RequestClass.UNDERSTAND),
+    ])
+    def test_request_class(self, classifier, prompt, expected):
+        result = classifier.classify(prompt)
+        assert result.request_class == expected, (
+            f"Prompt '{prompt}' classified as {result.request_class}, expected {expected}"
+        )
+
+    def test_empty_prompt(self, classifier):
+        result = classifier.classify("")
+        assert result.request_class == RequestClass.UNDERSTAND
+        assert result.confidence == 1.0
+
+    def test_whitespace_prompt(self, classifier):
+        result = classifier.classify("   ")
+        assert result.request_class == RequestClass.UNDERSTAND
+
+
+class TestObjectiveTagClassification:
+    """Test Axis 2: ObjectiveTag detection."""
+
+    @pytest.mark.parametrize("prompt,expected_tag", [
+        ("how much does this cost", ObjectiveTag.COST_REDUCTION),
+        ("reduce labor hours", ObjectiveTag.LABOR_REDUCTION),
+        ("shrink the room to 200 sq ft", ObjectiveTag.AREA_CHANGE),
+        ("all the fixtures and devices", ObjectiveTag.EQUIPMENT_COUNT),
+        ("how many rooms are there", ObjectiveTag.SPACE_COUNT),
+        ("summarize for the contractor", ObjectiveTag.CONTRACTOR_COMMUNICATION),
+        ("present to the homeowner", ObjectiveTag.CUSTOMER_COMMUNICATION),
+        ("prepare for the plan reviewer", ObjectiveTag.REVIEWER_COMMUNICATION),
+        ("improve the layout spacing", ObjectiveTag.LAYOUT_IMPROVEMENT),
+        ("check for missing dimensions", ObjectiveTag.MISSING_ITEMS),
+        ("is this ADA compliant", ObjectiveTag.COMPLIANCE),
+        ("what changed in revision 3", ObjectiveTag.REVISION_EXPLANATION),
+        ("is this constructable", ObjectiveTag.CONSTRUCTABILITY),
+        ("what does this look like aesthetically", ObjectiveTag.AESTHETICS),
+    ])
+    def test_objective_tag(self, classifier, prompt, expected_tag):
+        result = classifier.classify(prompt)
+        assert result.objective_tag == expected_tag, (
+            f"Prompt '{prompt}' tagged as {result.objective_tag}, expected {expected_tag}"
+        )
+
+
+class TestTwoAxisCombination:
+    """Test combined RequestClass + ObjectiveTag classification."""
+
+    def test_optimize_cost(self, classifier):
+        result = classifier.classify("make this design cheaper to build")
+        assert result.request_class == RequestClass.OPTIMIZE
+        assert result.objective_tag == ObjectiveTag.COST_REDUCTION
+
+    def test_estimate_spaces(self, classifier):
+        result = classifier.classify("how many rooms are in this plan")
+        assert result.request_class == RequestClass.ESTIMATE
+        assert result.objective_tag == ObjectiveTag.SPACE_COUNT
+
+    def test_summarize_for_contractor(self, classifier):
+        result = classifier.classify("summarize for the contractor")
+        assert result.request_class == RequestClass.SUMMARIZE
+        assert result.objective_tag == ObjectiveTag.CONTRACTOR_COMMUNICATION
+
+    def test_validate_compliance(self, classifier):
+        result = classifier.classify("validate ADA compliance")
+        assert result.request_class == RequestClass.VALIDATE
+        assert result.objective_tag == ObjectiveTag.COMPLIANCE
+
+
+class TestClassifyWithFamily:
+    """Test fallback to TaskFamily when heuristic confidence is low."""
+
+    def test_high_confidence_ignores_family(self, classifier):
+        result = classifier.classify_with_family(
+            "compare the drawings", TaskFamily.QNA,
+        )
+        assert result.request_class == RequestClass.COMPARE
+
+    def test_low_confidence_uses_family(self, classifier):
+        result = classifier.classify_with_family(
+            "xyzzy gibberish", TaskFamily.TAKEOFF_ESTIMATE,
+        )
+        assert result.request_class == RequestClass.ESTIMATE
+        assert result.source == "family_fallback"
+
+    def test_medium_confidence_preserved(self, classifier):
+        # "cost" matches COST_REDUCTION tag, infers OPTIMIZE at 0.75
+        result = classifier.classify_with_family(
+            "cost", TaskFamily.QNA,
+        )
+        assert result.request_class == RequestClass.OPTIMIZE
+        assert result.confidence == 0.75
+
+
+class TestTagFallbackInference:
+    """When no RequestClass pattern matches, infer from ObjectiveTag."""
+
+    def test_missing_items_infers_validate(self, classifier):
+        result = classifier.classify("incomplete drawing")
+        assert result.request_class == RequestClass.VALIDATE
+
+    def test_layout_improvement_infers_recommend(self, classifier):
+        result = classifier.classify("layout density")
+        assert result.request_class == RequestClass.RECOMMEND
+
+    def test_space_count_infers_estimate(self, classifier):
+        result = classifier.classify("rooms in the floor plan")
+        assert result.request_class == RequestClass.ESTIMATE
+
+    def test_contractor_comm_infers_summarize(self, classifier):
+        result = classifier.classify("for the contractor")
+        assert result.request_class == RequestClass.SUMMARIZE
+
+
+class TestClassificationMetadata:
+    """Test metadata fields on ObjectiveClassification."""
+
+    def test_confidence_range(self, classifier):
+        result = classifier.classify("move the wall")
+        assert 0.0 <= result.confidence <= 1.0
+
+    def test_matched_patterns_populated(self, classifier):
+        result = classifier.classify("compare these drawings")
+        assert len(result.matched_patterns) > 0
+
+    def test_classification_time_positive(self, classifier):
+        result = classifier.classify("what is this")
+        assert result.classification_time_ms >= 0.0
+
+    def test_source_is_heuristic(self, classifier):
+        result = classifier.classify("count all doors")
+        assert result.source == "heuristic"

--- a/tests/unit/test_objective_schema.py
+++ b/tests/unit/test_objective_schema.py
@@ -1,0 +1,150 @@
+"""Tests for objective_schema models — RequestClass, ObjectiveTag, DocumentFamilyHint."""
+
+from cad_dxf_agent.models.objective_schema import (
+    AnalysisResult,
+    DocumentFamilyHint,
+    ObjectiveClassification,
+    ObjectiveTag,
+    RecommendationOption,
+    RecommendationSet,
+    RequestClass,
+    StageGate,
+    StagePipelineDefinition,
+)
+
+
+class TestRequestClass:
+    """RequestClass enum has 8 members."""
+
+    def test_member_count(self):
+        assert len(RequestClass) == 8
+
+    def test_all_values(self):
+        expected = {
+            "understand", "estimate", "recommend", "optimize",
+            "modify", "summarize", "compare", "validate",
+        }
+        assert {v.value for v in RequestClass} == expected
+
+    def test_validate_is_new(self):
+        assert RequestClass.VALIDATE == "validate"
+
+
+class TestObjectiveTag:
+    """ObjectiveTag enum has 15 members."""
+
+    def test_member_count(self):
+        assert len(ObjectiveTag) == 15
+
+    def test_new_tags_present(self):
+        new_tags = {
+            "contractor_communication", "reviewer_communication",
+            "space_count", "equipment_count",
+            "layout_improvement", "missing_items",
+        }
+        values = {v.value for v in ObjectiveTag}
+        assert new_tags.issubset(values)
+
+    def test_original_tags_preserved(self):
+        original_tags = {
+            "cost_reduction", "labor_reduction", "area_change",
+            "aesthetics", "quantity_estimation", "customer_communication",
+            "constructability", "compliance", "revision_explanation",
+        }
+        values = {v.value for v in ObjectiveTag}
+        assert original_tags.issubset(values)
+
+
+class TestDocumentFamilyHint:
+    """DocumentFamilyHint enum has 20 members."""
+
+    def test_member_count(self):
+        assert len(DocumentFamilyHint) == 20
+
+    def test_unknown_is_default(self):
+        assert DocumentFamilyHint.UNKNOWN == "unknown"
+
+    def test_key_families_present(self):
+        families = {v.value for v in DocumentFamilyHint}
+        assert "residential_architectural" in families
+        assert "landscape" in families
+        assert "electrical" in families
+        assert "structural" in families
+        assert "plumbing" in families
+
+
+class TestObjectiveClassification:
+    """ObjectiveClassification model with document_family field."""
+
+    def test_default_document_family(self):
+        c = ObjectiveClassification(
+            request_class=RequestClass.UNDERSTAND,
+            confidence=0.9,
+        )
+        assert c.document_family == DocumentFamilyHint.UNKNOWN
+
+    def test_all_fields(self):
+        c = ObjectiveClassification(
+            request_class=RequestClass.VALIDATE,
+            objective_tag=ObjectiveTag.MISSING_ITEMS,
+            document_family=DocumentFamilyHint.RESIDENTIAL_ARCHITECTURAL,
+            confidence=0.85,
+            source="heuristic",
+            matched_patterns=["\\bmissing\\b"],
+        )
+        assert c.request_class == RequestClass.VALIDATE
+        assert c.objective_tag == ObjectiveTag.MISSING_ITEMS
+        assert c.document_family == DocumentFamilyHint.RESIDENTIAL_ARCHITECTURAL
+
+    def test_serialization_roundtrip(self):
+        c = ObjectiveClassification(
+            request_class=RequestClass.ESTIMATE,
+            objective_tag=ObjectiveTag.SPACE_COUNT,
+            confidence=0.8,
+        )
+        d = c.model_dump()
+        c2 = ObjectiveClassification(**d)
+        assert c2.request_class == c.request_class
+        assert c2.objective_tag == c.objective_tag
+        assert c2.document_family == c.document_family
+
+
+class TestAnalysisResult:
+    def test_defaults(self):
+        r = AnalysisResult(summary="test")
+        assert r.confidence == 0.5
+        assert r.evidence == []
+
+
+class TestRecommendationSet:
+    def test_with_options(self):
+        opt = RecommendationOption(
+            title="Remove plants",
+            description="Remove 12 plants from east bed",
+            estimated_impact="~$2,400 savings",
+            tradeoffs=["Reduced screening"],
+        )
+        rs = RecommendationSet(options=[opt], selected_index=0)
+        assert len(rs.options) == 1
+        assert rs.selected_index == 0
+
+
+class TestStageGate:
+    def test_default_status(self):
+        g = StageGate(stage_name="analyze")
+        assert g.status == "pending"
+        assert g.timestamp  # auto-set
+
+    def test_completed(self):
+        g = StageGate(stage_name="recommend", status="completed", output_summary="3 options")
+        assert g.status == "completed"
+
+
+class TestStagePipelineDefinition:
+    def test_stages(self):
+        p = StagePipelineDefinition(
+            stages=["analyze", "recommend", "plan"],
+            output_mode="staged",
+        )
+        assert len(p.stages) == 3
+        assert p.output_mode == "staged"

--- a/tests/unit/test_stage_executor.py
+++ b/tests/unit/test_stage_executor.py
@@ -1,0 +1,214 @@
+"""Tests for StagePipelineExecutor — runs stage pipelines with gate checkpoints."""
+
+import pytest
+
+from cad_dxf_agent.llm.stage_executor import (
+    StagePipelineExecutor,
+    StageExecutionResult,
+)
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveClassification,
+    RequestClass,
+    StagePipelineDefinition,
+)
+
+
+class _EchoHandler:
+    """Test handler that echoes its stage name into context."""
+
+    def __init__(self, name: str, extra: dict | None = None):
+        self._name = name
+        self._extra = extra or {}
+
+    def execute(self, classification, context, prompt):
+        return {"summary": f"{self._name} done", self._name: True, **self._extra}
+
+
+class _FailHandler:
+    """Test handler that always raises."""
+
+    def execute(self, classification, context, prompt):
+        raise RuntimeError("Stage failed!")
+
+
+class _ContextReader:
+    """Handler that reads a value from context (proving accumulation works)."""
+
+    def execute(self, classification, context, prompt):
+        upstream = context.get("analyze", False)
+        return {"summary": "read context", "saw_analyze": upstream}
+
+
+@pytest.fixture
+def classification():
+    return ObjectiveClassification(
+        request_class=RequestClass.UNDERSTAND,
+        confidence=0.9,
+    )
+
+
+@pytest.fixture
+def executor():
+    ex = StagePipelineExecutor()
+    ex.register("analyze", _EchoHandler("analyze"))
+    ex.register("quantify", _EchoHandler("quantify", {"count": 42}))
+    ex.register("recommend", _EchoHandler("recommend"))
+    ex.register("reader", _ContextReader())
+    ex.register("fail", _FailHandler())
+    return ex
+
+
+class TestBasicExecution:
+    """Happy-path stage execution."""
+
+    def test_single_stage(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=["analyze"], output_mode="direct")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={"drawing": "test"},
+            prompt="what is this",
+        )
+        assert result.all_completed
+        assert result.completed_stages == ["analyze"]
+        assert result.output["analyze"] is True
+
+    def test_multi_stage(self, executor, classification):
+        pipeline = StagePipelineDefinition(
+            stages=["analyze", "quantify", "recommend"],
+            output_mode="staged",
+        )
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.completed_stages == ["analyze", "quantify", "recommend"]
+        assert result.output["count"] == 42  # from quantify handler
+
+    def test_context_accumulation(self, executor, classification):
+        pipeline = StagePipelineDefinition(
+            stages=["analyze", "reader"],
+            output_mode="direct",
+        )
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.output["saw_analyze"] is True  # reader saw analyze's output
+
+    def test_initial_context_preserved(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=["analyze"], output_mode="direct")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={"foo": "bar"},
+            prompt="test",
+        )
+        assert result.output["foo"] == "bar"
+
+
+class TestSkippedStages:
+    """Unregistered stages are skipped."""
+
+    def test_missing_handler_skipped(self, executor, classification):
+        pipeline = StagePipelineDefinition(
+            stages=["analyze", "nonexistent", "quantify"],
+            output_mode="direct",
+        )
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.skipped_stages == ["nonexistent"]
+        assert result.completed_stages == ["analyze", "quantify"]
+        assert result.all_completed  # skipped counts as "completed" for pipeline
+
+
+class TestFailedStages:
+    """Failed stages stop the pipeline."""
+
+    def test_failure_stops_pipeline(self, executor, classification):
+        pipeline = StagePipelineDefinition(
+            stages=["analyze", "fail", "quantify"],
+            output_mode="direct",
+        )
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.completed_stages == ["analyze"]
+        assert not result.all_completed
+        # quantify should be skipped due to failure
+        gate_statuses = {g.stage_name: g.status for g in result.gates}
+        assert gate_statuses["fail"] == "rejected"
+        assert gate_statuses["quantify"] == "skipped"
+
+
+class TestExecutionResult:
+    """StageExecutionResult metadata."""
+
+    def test_total_time_positive(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=["analyze"], output_mode="direct")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.total_time_ms >= 0.0
+
+    def test_to_dict(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=["analyze"], output_mode="direct")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        d = result.to_dict()
+        assert "gates" in d
+        assert "output" in d
+        assert d["output_mode"] == "direct"
+
+    def test_output_mode_preserved(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=["analyze"], output_mode="staged")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={},
+            prompt="test",
+        )
+        assert result.output_mode == "staged"
+
+
+class TestRegistration:
+    def test_has_handler(self, executor):
+        assert executor.has_handler("analyze")
+        assert not executor.has_handler("nonexistent")
+
+    def test_registered_stages(self, executor):
+        stages = executor.registered_stages
+        assert "analyze" in stages
+        assert "quantify" in stages
+
+
+class TestEmptyPipeline:
+    def test_empty_stages(self, executor, classification):
+        pipeline = StagePipelineDefinition(stages=[], output_mode="direct")
+        result = executor.execute(
+            pipeline=pipeline,
+            classification=classification,
+            initial_context={"x": 1},
+            prompt="test",
+        )
+        assert result.all_completed
+        assert result.output == {"x": 1}
+        assert result.gates == []

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -1,0 +1,108 @@
+"""Tests for StrategyRegistry — maps classification to stage pipelines."""
+
+import pytest
+
+from cad_dxf_agent.llm.strategy_registry import StrategyRegistry
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveTag,
+    RequestClass,
+    StagePipelineDefinition,
+)
+
+
+@pytest.fixture
+def registry():
+    return StrategyRegistry()
+
+
+class TestDefaultLookup:
+    """Every RequestClass has a default pipeline."""
+
+    @pytest.mark.parametrize("request_class", list(RequestClass))
+    def test_all_classes_have_defaults(self, registry, request_class):
+        pipeline = registry.lookup(request_class)
+        assert isinstance(pipeline, StagePipelineDefinition)
+        assert len(pipeline.stages) > 0
+
+    def test_understand_is_direct(self, registry):
+        p = registry.lookup(RequestClass.UNDERSTAND)
+        assert p.output_mode == "direct"
+        assert "analyze" in p.stages
+
+    def test_modify_has_preview(self, registry):
+        p = registry.lookup(RequestClass.MODIFY)
+        assert "preview" in p.stages
+
+    def test_optimize_is_staged(self, registry):
+        p = registry.lookup(RequestClass.OPTIMIZE)
+        assert p.output_mode == "staged"
+
+    def test_validate_has_validate_stage(self, registry):
+        p = registry.lookup(RequestClass.VALIDATE)
+        assert "validate" in p.stages
+
+
+class TestTagOverrides:
+    """Tag-specific overrides refine the default pipeline."""
+
+    def test_cost_reduction_override(self, registry):
+        p = registry.lookup(RequestClass.OPTIMIZE, ObjectiveTag.COST_REDUCTION)
+        assert "quantify" in p.stages
+        assert "recommend" in p.stages
+
+    def test_space_count_override(self, registry):
+        p = registry.lookup(RequestClass.ESTIMATE, ObjectiveTag.SPACE_COUNT)
+        assert "detect_zones" in p.stages
+
+    def test_contractor_summary_override(self, registry):
+        p = registry.lookup(RequestClass.SUMMARIZE, ObjectiveTag.CONTRACTOR_COMMUNICATION)
+        assert "quantify" in p.stages
+
+    def test_reviewer_summary_has_validate(self, registry):
+        p = registry.lookup(RequestClass.SUMMARIZE, ObjectiveTag.REVIEWER_COMMUNICATION)
+        assert "validate" in p.stages
+
+    def test_missing_items_override(self, registry):
+        p = registry.lookup(RequestClass.VALIDATE, ObjectiveTag.MISSING_ITEMS)
+        assert "validate" in p.stages
+
+    def test_no_override_falls_to_default(self, registry):
+        p = registry.lookup(RequestClass.UNDERSTAND, ObjectiveTag.AESTHETICS)
+        # No override for understand × aesthetics — should get default
+        default = registry.lookup(RequestClass.UNDERSTAND)
+        assert p.stages == default.stages
+
+
+class TestCustomRegistration:
+    """Custom overrides and defaults can be registered."""
+
+    def test_register_override(self, registry):
+        custom = StagePipelineDefinition(
+            stages=["custom_stage"],
+            output_mode="direct",
+            description="Custom pipeline",
+        )
+        registry.register_override(RequestClass.UNDERSTAND, ObjectiveTag.AESTHETICS, custom)
+        p = registry.lookup(RequestClass.UNDERSTAND, ObjectiveTag.AESTHETICS)
+        assert p.stages == ["custom_stage"]
+
+    def test_register_default(self, registry):
+        custom = StagePipelineDefinition(
+            stages=["a", "b", "c"],
+            output_mode="full",
+        )
+        registry.register_default(RequestClass.UNDERSTAND, custom)
+        p = registry.lookup(RequestClass.UNDERSTAND)
+        assert p.stages == ["a", "b", "c"]
+
+
+class TestRegistryProperties:
+    """Registry exposes its configuration."""
+
+    def test_all_defaults_populated(self, registry):
+        defaults = registry.all_defaults
+        assert len(defaults) == 8  # one per RequestClass
+
+    def test_all_overrides_populated(self, registry):
+        overrides = registry.all_overrides
+        assert len(overrides) >= 10  # at least 10 tag-specific overrides

--- a/tests/web/test_apply.py
+++ b/tests/web/test_apply.py
@@ -100,4 +100,3 @@ class TestApply:
         )
         # 401 (missing token) or 404 (session not found after auth bypass)
         assert resp.status_code in (401, 404)
->>>>>>> 3ba2349 (feat(eval): add capability scorecard evaluation harness)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1709,7 +1709,7 @@ def _user_friendly_conversion_error(raw_error: str | None, ext: str) -> str:
 
 def _enrich_with_objective(
     response: dict,
-    objective: object | None,
+    objective: "ObjectiveClassification | None",  # noqa: F821
 ) -> dict:
     """Add objective classification metadata to a response dict.
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -444,6 +444,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
     from cad_dxf_agent.llm.capability_registry import CapabilityRegistry
     from cad_dxf_agent.llm.intent_router import IntentRouter
+    from cad_dxf_agent.llm.objective_classifier import ObjectiveClassifier
     from cad_dxf_agent.llm.response_builder import ResponseBuilder
     from cad_dxf_agent.models.response_schema import AuditMetadata, TaskFamily
 
@@ -459,9 +460,13 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
         if session.context is None:
             raise HTTPException(status_code=400, detail="No file loaded in session")
 
-        # Classify intent
+        # Classify intent (TaskFamily routing — existing behavior)
         router = IntentRouter.from_settings()
         intent = router.classify(body.prompt)
+
+        # Objective classification (two-axis: RequestClass + ObjectiveTag)
+        objective_cls = ObjectiveClassifier()
+        objective = objective_cls.classify_with_family(body.prompt, intent.family)
 
         audit = AuditMetadata(
             router_time_ms=intent.router_time_ms,
@@ -469,18 +474,22 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             router_confidence=intent.confidence,
         )
 
+        # Helper to enrich response with objective metadata
+        def _enrich(resp_dict: dict) -> dict:
+            return _enrich_with_objective(resp_dict, objective)
+
         # Gate unimplemented families
         registry = CapabilityRegistry()
         if not registry.is_implemented(intent.family):
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-            return ResponseBuilder.unsupported_operation(
+            return _enrich(ResponseBuilder.unsupported_operation(
                 family=intent.family, audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle needs_clarification
         if intent.family == TaskFamily.NEEDS_CLARIFICATION:
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-            return ResponseBuilder.needs_clarification(audit=audit).model_dump()
+            return _enrich(ResponseBuilder.needs_clarification(audit=audit).model_dump())
 
         # Handle Q&A — deterministic, no LLM
         if intent.family == TaskFamily.QNA:
@@ -495,17 +504,17 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
             result.audit = audit
-            return result.model_dump()
+            return _enrich(result.model_dump())
 
         # Handle compare (requires revision file)
         if intent.family == TaskFamily.COMPARE:
             if session.revision_path is None or not session.revision_path.exists():
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return ResponseBuilder.needs_clarification(
+                return _enrich(ResponseBuilder.needs_clarification(
                     message="Upload a revision file first to compare drawings.",
                     family=TaskFamily.COMPARE,
                     audit=audit,
-                ).model_dump()
+                ).model_dump())
 
             # Use cached comparison result if available, else run pipeline
             if session.comparison_result is not None and session.comparison_changelog is not None:
@@ -519,16 +528,16 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                     revision_path=session.revision_path,
                 )
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return _build_typed_compare_response(
+                return _enrich(_build_typed_compare_response(
                     session.comparison_result, outputs, audit=audit
-                )
+                ))
 
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-            return ResponseBuilder.needs_clarification(
+            return _enrich(ResponseBuilder.needs_clarification(
                 message="Use /api/compare for full comparison workflow.",
                 family=TaskFamily.COMPARE,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle markup_interpretation — deterministic redline report, no LLM
         if intent.family == TaskFamily.MARKUP_INTERPRETATION:
@@ -539,7 +548,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return ResponseBuilder.markup_redline(
+            return _enrich(ResponseBuilder.markup_redline(
                 message=(
                     f"{result.total_clouds} revision cloud(s) found, "
                     f"{result.total_affected_entities} affected entity(ies)."
@@ -548,7 +557,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 confidence=result.aggregate_confidence,
                 ambiguity_flags=result.ambiguity_flags,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle repeated_condition — deterministic, no LLM
         if intent.family == TaskFamily.REPEATED_CONDITION:
@@ -571,7 +580,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-                return ResponseBuilder.repeated_condition(
+                return _enrich(ResponseBuilder.repeated_condition(
                     message=(
                         f"{result.total_groups} condition group(s), "
                         f"{result.total_instances} total instance(s)."
@@ -580,15 +589,15 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                     confidence=result.aggregate_confidence,
                     ambiguity_flags=result.ambiguity_flags,
                     audit=audit,
-                ).model_dump()
+                ).model_dump())
 
             if not exemplar_handles:
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return ResponseBuilder.needs_clarification(
+                return _enrich(ResponseBuilder.needs_clarification(
                     message="Select entities to use as the exemplar for repeated-condition search.",
                     family=TaskFamily.REPEATED_CONDITION,
                     audit=audit,
-                ).model_dump()
+                ).model_dump())
 
             ctx_start = _time.monotonic()
             detector = ConditionDetector(session.context)
@@ -596,14 +605,14 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return ResponseBuilder.repeated_condition(
+            return _enrich(ResponseBuilder.repeated_condition(
                 message=result.summary,
                 data=result.model_dump(),
                 evidence=[ev.model_dump() for c in result.candidates for ev in c.evidence[:3]],
                 confidence=result.candidates[0].confidence if result.candidates else 0.0,
                 ambiguity_flags=result.ambiguity_flags,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle design_assist — deterministic layout analysis, no LLM
         if intent.family == TaskFamily.DESIGN_ASSIST:
@@ -688,13 +697,13 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return ResponseBuilder.design_assist(
+            return _enrich(ResponseBuilder.design_assist(
                 message=message,
                 data=data,
                 confidence=confidence,
                 ambiguity_flags=flags,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle summary — deterministic revision summary, no LLM
         if intent.family == TaskFamily.SUMMARY:
@@ -709,7 +718,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return ResponseBuilder.summary_result(
+            return _enrich(ResponseBuilder.summary_result(
                 message=result.headline,
                 data=result.model_dump(),
                 confidence=min(
@@ -717,7 +726,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 ),
                 ambiguity_flags=result.ambiguity_flags,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle takeoff_estimate — deterministic counting, no LLM
         if intent.family == TaskFamily.TAKEOFF_ESTIMATE:
@@ -742,7 +751,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 "low": 0.4,
                 "estimate_only": 0.2,
             }
-            return ResponseBuilder.takeoff_result(
+            return _enrich(ResponseBuilder.takeoff_result(
                 message=(
                     f"{result.total_items} takeoff item(s), "
                     f"{result.total_quantity_items} total quantity."
@@ -751,7 +760,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 confidence=_conf_labels.get(result.aggregate_confidence.value, 0.5),
                 ambiguity_flags=result.ambiguity_flags,
                 audit=audit,
-            ).model_dump()
+            ).model_dump())
 
         # Handle edit_plan — dispatch to existing planner
         if intent.family == TaskFamily.EDIT_PLAN:
@@ -829,7 +838,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-                return ResponseBuilder.plan_only(
+                return _enrich(ResponseBuilder.plan_only(
                     operations=operations,
                     message=llm_message or summary,
                     validation={
@@ -838,7 +847,7 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                         "is_valid": len(validation.blockers) == 0,
                     },
                     audit=audit,
-                ).model_dump()
+                ).model_dump())
 
             except Exception as e:
                 logger.error("v2 plan failed: %s", e, exc_info=True)
@@ -846,9 +855,9 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
         # Catch-all for families that are "implemented" but not yet wired
         audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-        return ResponseBuilder.unsupported_operation(
+        return _enrich(ResponseBuilder.unsupported_operation(
             family=intent.family, audit=audit,
-        ).model_dump()
+        ).model_dump())
 
 
 # ---------------------------------------------------------------------------
@@ -1696,6 +1705,26 @@ def _user_friendly_conversion_error(raw_error: str | None, ext: str) -> str:
             "Please export as DXF from your CAD software."
         )
     return f"Could not convert your {ext} file. Please try exporting as DXF from your CAD software."
+
+
+def _enrich_with_objective(
+    response: dict,
+    objective: object | None,
+) -> dict:
+    """Add objective classification metadata to a response dict.
+
+    Backward compatible — fields are additive. Existing clients ignore them.
+    """
+    if objective is None:
+        return response
+    response["request_class"] = getattr(objective, "request_class", None)
+    if response["request_class"] is not None:
+        response["request_class"] = str(response["request_class"])
+    tag = getattr(objective, "objective_tag", None)
+    response["objective_tag"] = str(tag) if tag is not None else None
+    family = getattr(objective, "document_family", None)
+    response["document_family"] = str(family) if family is not None else None
+    return response
 
 
 def _parse_selected_region(selected_regions: list[dict] | None):


### PR DESCRIPTION
## Epic
EPIC-CAD-13: Objective-Driven Multi-Document Intelligence

## Bead(s)
cad-dxf-agent-lk9

## Summary
- **Expanded two-axis classification**: RequestClass (8 values, +validate) × ObjectiveTag (15 values, +6 new) + DocumentFamilyHint (20 families) — the routing brain that determines output mode for every request
- **Strategy selector registry**: Maps classification results to stage pipeline definitions (8 defaults + 10 tag-specific overrides) with extensible registration API
- **Stage pipeline executor**: Runs typed stages with StageGate checkpoints, context accumulation, and failure handling — the orchestration layer for all future capabilities
- **API wiring**: /api/v2/prompt enriches every response with objective metadata (backward compatible, additive fields only)

### Stories completed
| Story | Title | Status |
|-------|-------|--------|
| 13.2.1 | Expand RequestClass + ObjectiveTag + DocumentFamilyHint | Done |
| 13.2.2 | Expand ObjectiveClassifier patterns | Done |
| 13.2.3 | Strategy selector registry | Done |
| 13.2.4 | Stage pipeline executor | Done |
| 13.2.5 | Wire into /api/v2/prompt | Done |
| 13.2.6 | Response enrichment on PlatformResponse | Done |

### New files
- `src/cad_dxf_agent/models/objective_schema.py` — RequestClass, ObjectiveTag, DocumentFamilyHint, ObjectiveClassification, AnalysisResult, RecommendationSet, StageGate, StagePipelineDefinition
- `src/cad_dxf_agent/llm/objective_classifier.py` — Two-axis heuristic classifier with 8 class rules and 15 tag rules
- `src/cad_dxf_agent/llm/strategy_registry.py` — Registry mapping (class, tag?) to pipeline definitions
- `src/cad_dxf_agent/llm/stage_executor.py` — Pipeline executor with gate checkpoints

### Modified files
- `src/cad_dxf_agent/models/response_schema.py` — 4 new optional fields on PlatformResponse
- `web/backend/main.py` — ObjectiveClassifier wired into /api/v2/prompt, responses enriched
- `tests/web/test_apply.py` — Fixed pre-existing merge conflict artifact

## Test plan
- [x] 112 new unit tests across 4 test files (schema, classifier, registry, executor)
- [x] All 2,593 existing tests pass (zero regressions)
- [x] ruff lint clean on all new files
- [x] mypy typecheck clean on all new/modified files
- [x] Backward compatible: no existing API contracts changed, all new fields optional

## Docs
- Spec doc 055 (EPIC-CAD-13) defines the expanded scope
- CLAUDE.md epic table already has EPIC-CAD-13 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)