### PR TITLE
feat: Phase 1 — complete drafting vocabulary, R-tree spatial index, entity creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "numpy>=1.26",
     "httpx>=0.27",
     "python-dotenv>=1.0",
+    "rtree>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/cad_dxf_agent/core/edit_engine.py
+++ b/src/cad_dxf_agent/core/edit_engine.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 
 import ezdxf
+from ezdxf.math import Matrix44
 
 from ..models.ops_schema import AppliedChange, ChangeSet, EditOperation, OpType
 from ..otel import get_tracer
@@ -68,24 +70,35 @@ class EditEngine:
 
     def _apply_operation(self, op: EditOperation) -> AppliedChange:
         """Apply a single operation. Assumes validation has already passed."""
-        if op.op_type == OpType.MOVE_ENTITY:
-            return self._apply_move(op)
-        elif op.op_type == OpType.EDIT_TEXT:
-            return self._apply_edit_text(op)
-        elif op.op_type == OpType.DELETE_ENTITY:
-            return self._apply_delete(op)
-        elif op.op_type == OpType.ADD_BLOCK:
-            return self._apply_add_block(op)
-        else:
+        handlers = {
+            OpType.MOVE_ENTITY: self._apply_move,
+            OpType.EDIT_TEXT: self._apply_edit_text,
+            OpType.DELETE_ENTITY: self._apply_delete,
+            OpType.ADD_BLOCK: self._apply_add_block,
+            OpType.ROTATE_ENTITY: self._apply_rotate,
+            OpType.COPY_ENTITY: self._apply_copy,
+            OpType.SCALE_ENTITY: self._apply_scale,
+            OpType.MIRROR_ENTITY: self._apply_mirror,
+            OpType.ADD_LINE: self._apply_add_line,
+            OpType.ADD_POLYLINE: self._apply_add_polyline,
+            OpType.ADD_CIRCLE: self._apply_add_circle,
+            OpType.ADD_ARC: self._apply_add_arc,
+            OpType.ADD_TEXT: self._apply_add_text,
+        }
+        handler = handlers.get(op.op_type)
+        if handler is None:
             return AppliedChange(
                 operation=op,
                 success=False,
                 description=f"Unknown op type: {op.op_type}",
             )
+        return handler(op)
 
     def _find_entity(self, handle: str):
         """Find entity by handle in model space."""
         return self.doc.entitydb.get(handle)
+
+    # --- V1 operations ---
 
     def _apply_move(self, op: EditOperation) -> AppliedChange:
         assert op.target_handle is not None
@@ -207,3 +220,311 @@ class EditEngine:
             )
         except Exception as e:
             return AppliedChange(operation=op, success=False, description=f"Add block failed: {e}")
+
+    # --- V2 transform operations ---
+
+    def _apply_rotate(self, op: EditOperation) -> AppliedChange:
+        assert op.target_handle is not None
+        entity = self._find_entity(op.target_handle)
+        if entity is None:
+            return AppliedChange(operation=op, success=False, description="Entity not found")
+
+        angle = op.params.get("angle", 0)
+        cx = op.params.get("cx", 0)
+        cy = op.params.get("cy", 0)
+
+        try:
+            # ezdxf rotation is around Z axis using a transformation matrix
+            m = Matrix44.z_rotate(math.radians(angle))
+            # Translate to origin, rotate, translate back
+            m = Matrix44.translate(-cx, -cy, 0) @ m @ Matrix44.translate(cx, cy, 0)
+            entity.transform(m)
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=op.target_handle,
+                description=f"Rotated entity {op.target_handle} by {angle}° around ({cx}, {cy})",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Rotate failed: {e}")
+
+    def _apply_copy(self, op: EditOperation) -> AppliedChange:
+        assert op.target_handle is not None
+        entity = self._find_entity(op.target_handle)
+        if entity is None:
+            return AppliedChange(operation=op, success=False, description="Entity not found")
+
+        dx = op.params.get("dx", 0)
+        dy = op.params.get("dy", 0)
+
+        try:
+            layout = self._get_layout(op.target_space)
+            # Copy the entity within the same layout
+            new_entity = entity.copy()
+            layout.add_entity(new_entity)
+            new_entity.translate(dx, dy, 0)
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=new_entity.dxf.handle,
+                description=f"Copied entity {op.target_handle} with offset ({dx}, {dy})",
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Copy failed: {e}")
+
+    def _apply_scale(self, op: EditOperation) -> AppliedChange:
+        assert op.target_handle is not None
+        entity = self._find_entity(op.target_handle)
+        if entity is None:
+            return AppliedChange(operation=op, success=False, description="Entity not found")
+
+        factor = op.params.get("factor", 1.0)
+        cx = op.params.get("cx", 0)
+        cy = op.params.get("cy", 0)
+
+        try:
+            # Scale around a center point using transformation matrix
+            m = (
+                Matrix44.translate(-cx, -cy, 0)
+                @ Matrix44.scale(factor, factor, 1)
+                @ Matrix44.translate(cx, cy, 0)
+            )
+            entity.transform(m)
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=op.target_handle,
+                description=f"Scaled entity {op.target_handle} by {factor}x around ({cx}, {cy})",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Scale failed: {e}")
+
+    def _apply_mirror(self, op: EditOperation) -> AppliedChange:
+        assert op.target_handle is not None
+        entity = self._find_entity(op.target_handle)
+        if entity is None:
+            return AppliedChange(operation=op, success=False, description="Entity not found")
+
+        axis = op.params.get("axis", "x")
+        value = op.params.get("value", 0)
+
+        try:
+            if axis == "x":
+                # Mirror across a horizontal line at y=value
+                # Translate so mirror line is at origin, flip Y, translate back
+                m = (
+                    Matrix44.translate(0, -value, 0)
+                    @ Matrix44.scale(1, -1, 1)
+                    @ Matrix44.translate(0, value, 0)
+                )
+            elif axis == "y":
+                # Mirror across a vertical line at x=value
+                m = (
+                    Matrix44.translate(-value, 0, 0)
+                    @ Matrix44.scale(-1, 1, 1)
+                    @ Matrix44.translate(value, 0, 0)
+                )
+            else:
+                return AppliedChange(
+                    operation=op,
+                    success=False,
+                    description=f"Invalid mirror axis: {axis}. Use 'x' or 'y'.",
+                )
+
+            entity.transform(m)
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=op.target_handle,
+                description=f"Mirrored entity {op.target_handle} across {axis}={value}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Mirror failed: {e}")
+
+    # --- V2 entity creation operations ---
+
+    def _apply_add_line(self, op: EditOperation) -> AppliedChange:
+        start = op.params.get("start", {})
+        end = op.params.get("end", {})
+        layer = op.params.get("layer") or op.target_layer
+
+        try:
+            layout = self._get_layout(op.target_space)
+            attribs = {}
+            if layer:
+                attribs["layer"] = layer
+
+            entity = layout.add_line(
+                (start.get("x", 0), start.get("y", 0)),
+                (end.get("x", 0), end.get("y", 0)),
+                dxfattribs=attribs,
+            )
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=entity.dxf.handle,
+                description=(
+                    f"Added line from ({start.get('x', 0)}, {start.get('y', 0)}) "
+                    f"to ({end.get('x', 0)}, {end.get('y', 0)})"
+                ),
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Add line failed: {e}")
+
+    def _apply_add_polyline(self, op: EditOperation) -> AppliedChange:
+        points = op.params.get("points", [])
+        closed = op.params.get("closed", False)
+        layer = op.params.get("layer") or op.target_layer
+
+        try:
+            layout = self._get_layout(op.target_space)
+            attribs = {}
+            if layer:
+                attribs["layer"] = layer
+
+            pts = [(p.get("x", 0), p.get("y", 0)) for p in points]
+            entity = layout.add_lwpolyline(pts, close=closed, dxfattribs=attribs)
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=entity.dxf.handle,
+                description=f"Added polyline with {len(pts)} points (closed={closed})",
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(
+                operation=op, success=False, description=f"Add polyline failed: {e}"
+            )
+
+    def _apply_add_circle(self, op: EditOperation) -> AppliedChange:
+        center = op.params.get("center", {})
+        radius = op.params.get("radius", 1.0)
+        layer = op.params.get("layer") or op.target_layer
+
+        try:
+            layout = self._get_layout(op.target_space)
+            attribs = {}
+            if layer:
+                attribs["layer"] = layer
+
+            entity = layout.add_circle(
+                (center.get("x", 0), center.get("y", 0)),
+                radius=radius,
+                dxfattribs=attribs,
+            )
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=entity.dxf.handle,
+                description=(
+                    f"Added circle at ({center.get('x', 0)}, {center.get('y', 0)}) r={radius}"
+                ),
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Add circle failed: {e}")
+
+    def _apply_add_arc(self, op: EditOperation) -> AppliedChange:
+        center = op.params.get("center", {})
+        radius = op.params.get("radius", 1.0)
+        start_angle = op.params.get("start_angle", 0)
+        end_angle = op.params.get("end_angle", 90)
+        layer = op.params.get("layer") or op.target_layer
+
+        try:
+            layout = self._get_layout(op.target_space)
+            attribs = {}
+            if layer:
+                attribs["layer"] = layer
+
+            entity = layout.add_arc(
+                (center.get("x", 0), center.get("y", 0)),
+                radius=radius,
+                start_angle=start_angle,
+                end_angle=end_angle,
+                dxfattribs=attribs,
+            )
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=entity.dxf.handle,
+                description=(
+                    f"Added arc at ({center.get('x', 0)}, {center.get('y', 0)}) "
+                    f"r={radius} {start_angle}°-{end_angle}°"
+                ),
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Add arc failed: {e}")
+
+    def _apply_add_text(self, op: EditOperation) -> AppliedChange:
+        text = op.params.get("text", "")
+        insert = op.params.get("insert", {})
+        height = op.params.get("height", 2.5)
+        rotation = op.params.get("rotation", 0)
+        layer = op.params.get("layer") or op.target_layer
+        text_type = op.params.get("text_type", "TEXT")
+
+        try:
+            layout = self._get_layout(op.target_space)
+            attribs = {}
+            if layer:
+                attribs["layer"] = layer
+
+            ix = insert.get("x", 0)
+            iy = insert.get("y", 0)
+
+            if text_type == "MTEXT":
+                attribs["char_height"] = height
+                attribs["insert"] = (ix, iy)
+                if rotation:
+                    attribs["rotation"] = rotation
+                entity = layout.add_mtext(text, dxfattribs=attribs)
+            else:
+                attribs["height"] = height
+                attribs["insert"] = (ix, iy)
+                if rotation:
+                    attribs["rotation"] = rotation
+                entity = layout.add_text(text, dxfattribs=attribs)
+
+            return AppliedChange(
+                operation=op,
+                success=True,
+                entity_handle=entity.dxf.handle,
+                description=f"Added {text_type} '{text[:30]}' at ({ix}, {iy})",
+            )
+        except KeyError:
+            return AppliedChange(
+                operation=op,
+                success=False,
+                description=f"Layout not found: {op.target_space}",
+            )
+        except Exception as e:
+            return AppliedChange(operation=op, success=False, description=f"Add text failed: {e}")

--- a/src/cad_dxf_agent/core/entity_index.py
+++ b/src/cad_dxf_agent/core/entity_index.py
@@ -1,9 +1,15 @@
-"""Entity index — fast lookup of entities by handle, layer, type, text, and spatial proximity."""
+"""Entity index — fast lookup of entities by handle, layer, type, text, and spatial proximity.
+
+Uses an R-tree spatial index for O(log n) nearest-neighbor and radius queries,
+replacing the O(n) linear scan that blocked large drawings.
+"""
 
 from __future__ import annotations
 
 import math
 from collections import defaultdict
+
+from rtree import index as rtree_index
 
 from ..models.cad_schema import DrawingContext, EntityRef, EntityType
 
@@ -12,7 +18,7 @@ class EntityIndex:
     """In-memory index over DrawingContext entities for fast lookup.
 
     Supports deterministic lookup by handle, layer, type, text content,
-    and spatial nearest-point queries using bbox-center distance.
+    and spatial queries via R-tree (nearest-point, radius window).
     """
 
     def __init__(self, context: DrawingContext) -> None:
@@ -21,6 +27,15 @@ class EntityIndex:
         self._by_type: dict[EntityType, list[EntityRef]] = defaultdict(list)
         self._text_index: dict[str, list[EntityRef]] = defaultdict(list)
         self._all: list[EntityRef] = list(context.entities)
+
+        # R-tree spatial index for fast nearest/radius queries
+        # Property 0 configures a 2D index; we store (x, y, x, y) bounding boxes
+        p = rtree_index.Property()
+        p.dimension = 2
+        self._rtree = rtree_index.Index(properties=p)
+        # Map R-tree integer IDs back to entity handles
+        self._rtree_id_to_handle: dict[int, str] = {}
+        rtree_id = 0
 
         for entity in context.entities:
             self._by_handle[entity.handle] = entity
@@ -31,6 +46,14 @@ class EntityIndex:
             if entity.text_content:
                 for token in _normalize_tokens(entity.text_content):
                     self._text_index[token].append(entity)
+
+            # Insert into R-tree if entity has a position
+            if entity.insert_point is not None:
+                x = entity.insert_point.x
+                y = entity.insert_point.y
+                self._rtree.insert(rtree_id, (x, y, x, y))
+                self._rtree_id_to_handle[rtree_id] = entity.handle
+                rtree_id += 1
 
     # --- Lookup by handle (aka "id") ---
 
@@ -111,7 +134,7 @@ class EntityIndex:
         # Return in stable insertion order
         return [e for e in self._all if e.handle in candidates]
 
-    # --- Spatial nearest ---
+    # --- Spatial nearest (R-tree accelerated) ---
 
     def nearest(
         self,
@@ -120,12 +143,34 @@ class EntityIndex:
         entity_type: str | None = None,
         layer: str | None = None,
     ) -> EntityRef | None:
-        """Find the nearest entity to the given point using bbox-center distance.
+        """Find the nearest entity to the given point.
 
-        Uses insert_point as the center proxy. Entities without an
-        insert_point are excluded. Optional layer/type filters narrow
-        the candidate set.
+        Uses R-tree for fast spatial lookup. When layer/type filters are
+        applied, falls back to filtered linear scan (filters narrow the
+        candidate set first, then R-tree is not applicable).
         """
+        if layer is not None or entity_type is not None:
+            # Filtered query — use linear scan on filtered candidates
+            return self._nearest_filtered(x, y, entity_type, layer)
+
+        # Unfiltered — use R-tree nearest query
+        results = list(self._rtree.nearest((x, y, x, y), 1))
+        if not results:
+            return None
+
+        handle = self._rtree_id_to_handle.get(results[0])
+        if handle is None:
+            return None
+        return self._by_handle.get(handle)
+
+    def _nearest_filtered(
+        self,
+        x: float,
+        y: float,
+        entity_type: str | None,
+        layer: str | None,
+    ) -> EntityRef | None:
+        """Nearest-entity with layer/type filters (linear scan on filtered set)."""
         candidates = self.filter(layer=layer, entity_type=entity_type)
 
         best: EntityRef | None = None
@@ -144,7 +189,7 @@ class EntityIndex:
 
         return best
 
-    # --- Spatial windowing ---
+    # --- Spatial windowing (R-tree accelerated) ---
 
     def find_in_radius(
         self,
@@ -156,17 +201,47 @@ class EntityIndex:
     ) -> list[EntityRef]:
         """Find all entities within ``radius`` drawing units of (x, y).
 
-        Entities without an insert_point are excluded.
-        Optional type/layer filters narrow the candidate set.
+        Uses R-tree bounding-box query for fast candidate retrieval,
+        then exact distance check. When layer/type filters are applied,
+        results are post-filtered.
+
         Results are sorted by distance (nearest first).
         """
-        candidates = self.filter(layer=layer, entity_type=entity_type)
-        results: list[tuple[float, EntityRef]] = []
-        r_sq = radius * radius
+        # R-tree bounding box query — get candidates in the square
+        bbox = (x - radius, y - radius, x + radius, y + radius)
+        rtree_hits = list(self._rtree.intersection(bbox))
 
-        for entity in candidates:
-            if entity.insert_point is None:
+        # Resolve handles and apply exact circular distance check
+        r_sq = radius * radius
+        results: list[tuple[float, EntityRef]] = []
+
+        # Build filter sets if needed
+        layer_set: set[str] | None = None
+        type_set: set[str] | None = None
+        if layer is not None:
+            layer_set = {e.handle for e in self._by_layer.get(layer.upper(), [])}
+        if entity_type is not None:
+            try:
+                etype = EntityType(entity_type)
+            except ValueError:
+                return []
+            type_set = {e.handle for e in self._by_type.get(etype, [])}
+
+        for rtree_id in rtree_hits:
+            handle = self._rtree_id_to_handle.get(rtree_id)
+            if handle is None:
                 continue
+            entity = self._by_handle.get(handle)
+            if entity is None or entity.insert_point is None:
+                continue
+
+            # Apply filters
+            if layer_set is not None and entity.handle not in layer_set:
+                continue
+            if type_set is not None and entity.handle not in type_set:
+                continue
+
+            # Exact distance check (R-tree gave us a square, we want a circle)
             dx = entity.insert_point.x - x
             dy = entity.insert_point.y - y
             dist_sq = dx * dx + dy * dy

--- a/src/cad_dxf_agent/core/preview_model.py
+++ b/src/cad_dxf_agent/core/preview_model.py
@@ -54,13 +54,52 @@ class PreviewModel:
             return f"Move{entity_label} by ({dx}, {dy})"
         elif op.op_type == OpType.EDIT_TEXT:
             new_text = op.params.get("new_text", "")
-            return f"Edit text{entity_label} → {new_text!r}"
+            return f"Edit text{entity_label} \u2192 {new_text!r}"
         elif op.op_type == OpType.DELETE_ENTITY:
             return f"Delete{entity_label}"
         elif op.op_type == OpType.ADD_BLOCK:
             block = op.params.get("block_name", "?")
             pt = op.params.get("insert_point", {})
             return f"Add block {block} at ({pt.get('x', 0)}, {pt.get('y', 0)})"
+        elif op.op_type == OpType.ROTATE_ENTITY:
+            angle = op.params.get("angle", 0)
+            return f"Rotate{entity_label} by {angle}\u00b0"
+        elif op.op_type == OpType.COPY_ENTITY:
+            dx = op.params.get("dx", 0)
+            dy = op.params.get("dy", 0)
+            return f"Copy{entity_label} with offset ({dx}, {dy})"
+        elif op.op_type == OpType.SCALE_ENTITY:
+            factor = op.params.get("factor", 1.0)
+            return f"Scale{entity_label} by {factor}x"
+        elif op.op_type == OpType.MIRROR_ENTITY:
+            axis = op.params.get("axis", "x")
+            value = op.params.get("value", 0)
+            return f"Mirror{entity_label} across {axis}={value}"
+        elif op.op_type == OpType.ADD_LINE:
+            start = op.params.get("start", {})
+            end = op.params.get("end", {})
+            return (
+                f"Add line from ({start.get('x', 0)}, {start.get('y', 0)}) "
+                f"to ({end.get('x', 0)}, {end.get('y', 0)})"
+            )
+        elif op.op_type == OpType.ADD_POLYLINE:
+            pts = op.params.get("points", [])
+            closed = op.params.get("closed", False)
+            return f"Add {'closed ' if closed else ''}polyline with {len(pts)} points"
+        elif op.op_type == OpType.ADD_CIRCLE:
+            c = op.params.get("center", {})
+            r = op.params.get("radius", 0)
+            return f"Add circle at ({c.get('x', 0)}, {c.get('y', 0)}) r={r}"
+        elif op.op_type == OpType.ADD_ARC:
+            c = op.params.get("center", {})
+            r = op.params.get("radius", 0)
+            sa = op.params.get("start_angle", 0)
+            ea = op.params.get("end_angle", 0)
+            return f"Add arc at ({c.get('x', 0)}, {c.get('y', 0)}) r={r} {sa}\u00b0-{ea}\u00b0"
+        elif op.op_type == OpType.ADD_TEXT:
+            text = op.params.get("text", "")
+            ins = op.params.get("insert", {})
+            return f"Add text {text!r} at ({ins.get('x', 0)}, {ins.get('y', 0)})"
         return f"Unknown op: {op.op_type}"
 
     @property

--- a/src/cad_dxf_agent/core/revision_notes.py
+++ b/src/cad_dxf_agent/core/revision_notes.py
@@ -131,6 +131,51 @@ def _summarize_change(change: AppliedChange) -> str:
         block_name = op.params.get("block_name", "unknown")
         return f"Inserted block {block_name}"
 
+    elif op.op_type == OpType.ROTATE_ENTITY:
+        angle = op.params.get("angle", 0)
+        return f"Rotated entity {angle}\u00b0"
+
+    elif op.op_type == OpType.COPY_ENTITY:
+        dx = op.params.get("dx", 0)
+        dy = op.params.get("dy", 0)
+        return f"Copied entity with offset ({dx}, {dy})"
+
+    elif op.op_type == OpType.SCALE_ENTITY:
+        factor = op.params.get("factor", 1.0)
+        return f"Scaled entity {factor}x"
+
+    elif op.op_type == OpType.MIRROR_ENTITY:
+        axis = op.params.get("axis", "x")
+        value = op.params.get("value", 0)
+        return f"Mirrored entity across {axis}={value}"
+
+    elif op.op_type == OpType.ADD_LINE:
+        start = op.params.get("start", {})
+        end = op.params.get("end", {})
+        return (
+            f"Added line ({start.get('x', 0)}, {start.get('y', 0)}) "
+            f"to ({end.get('x', 0)}, {end.get('y', 0)})"
+        )
+
+    elif op.op_type == OpType.ADD_POLYLINE:
+        pts = op.params.get("points", [])
+        closed = op.params.get("closed", False)
+        return f"Added {'closed ' if closed else ''}polyline with {len(pts)} points"
+
+    elif op.op_type == OpType.ADD_CIRCLE:
+        center = op.params.get("center", {})
+        radius = op.params.get("radius", 0)
+        return f"Added circle at ({center.get('x', 0)}, {center.get('y', 0)}) r={radius}"
+
+    elif op.op_type == OpType.ADD_ARC:
+        center = op.params.get("center", {})
+        return f"Added arc at ({center.get('x', 0)}, {center.get('y', 0)})"
+
+    elif op.op_type == OpType.ADD_TEXT:
+        text = op.params.get("text", "")
+        truncated = text[:30] + "..." if len(text) > 30 else text
+        return f"Added text '{truncated}'"
+
     return ""
 
 

--- a/src/cad_dxf_agent/core/revision_notes.py
+++ b/src/cad_dxf_agent/core/revision_notes.py
@@ -169,7 +169,14 @@ def _summarize_change(change: AppliedChange) -> str:
 
     elif op.op_type == OpType.ADD_ARC:
         center = op.params.get("center", {})
-        return f"Added arc at ({center.get('x', 0)}, {center.get('y', 0)})"
+        radius = op.params.get("radius", 0)
+        start_angle = op.params.get("start_angle", 0)
+        end_angle = op.params.get("end_angle", 0)
+        return (
+            f"Added arc r={radius:.2f} "
+            f"@({center.get('x', 0):.2f}, {center.get('y', 0):.2f}) "
+            f"{start_angle:.1f}\u00b0-{end_angle:.1f}\u00b0"
+        )
 
     elif op.op_type == OpType.ADD_TEXT:
         text = op.params.get("text", "")

--- a/src/cad_dxf_agent/core/semantic_model.py
+++ b/src/cad_dxf_agent/core/semantic_model.py
@@ -15,12 +15,13 @@ from ..otel import get_tracer
 tracer = get_tracer(__name__)
 
 
-ENTITY_CAP = 500
+ENTITY_CAP = 5000
 """Maximum entities included in verbose planner context.
 
-Real-world DXF files can have thousands of entities, producing millions of
-tokens when serialised as JSON.  Cap at 500 to stay safely within LLM
-context limits (~1M tokens for Gemini).
+Real-world DXF files can have thousands of entities. With R-tree spatial
+indexing and compact context mode, the agent uses tool-based discovery
+rather than dumping all entities into the prompt. The cap is a safety
+valve for the verbose context path only.
 """
 
 

--- a/src/cad_dxf_agent/core/validators.py
+++ b/src/cad_dxf_agent/core/validators.py
@@ -13,6 +13,18 @@ from .entity_index import EntityIndex
 
 tracer = get_tracer(__name__)
 
+# Operations that create new entities (no target_handle needed)
+_CREATION_OPS = frozenset(
+    {
+        OpType.ADD_BLOCK,
+        OpType.ADD_LINE,
+        OpType.ADD_POLYLINE,
+        OpType.ADD_CIRCLE,
+        OpType.ADD_ARC,
+        OpType.ADD_TEXT,
+    }
+)
+
 
 def validate_changeset(
     changeset: ChangeSet,
@@ -49,14 +61,14 @@ def _validate_operation(
     result: ValidationResult,
 ) -> None:
     """Validate a single operation."""
-    # Check op type is V1 supported
+    # Check op type is supported
     if op.op_type not in OpType:
         result.add_blocker(f"Unsupported operation type: {op.op_type}", index_pos)
         return
 
-    # For add_block, no target entity needed
-    if op.op_type == OpType.ADD_BLOCK:
-        _validate_add_block(op, index_pos, protected_layers, rules, result)
+    # For creation ops, no target entity needed
+    if op.op_type in _CREATION_OPS:
+        _validate_creation_op(op, index_pos, protected_layers, rules, result)
         return
 
     # All other ops need a target handle
@@ -85,6 +97,17 @@ def _validate_operation(
         _validate_move(op, index_pos, rules, result)
     elif op.op_type == OpType.EDIT_TEXT:
         _validate_edit_text(op, index_pos, result)
+    elif op.op_type == OpType.ROTATE_ENTITY:
+        _validate_rotate(op, index_pos, result)
+    elif op.op_type == OpType.COPY_ENTITY:
+        _validate_copy(op, index_pos, result)
+    elif op.op_type == OpType.SCALE_ENTITY:
+        _validate_scale(op, index_pos, result)
+    elif op.op_type == OpType.MIRROR_ENTITY:
+        _validate_mirror(op, index_pos, result)
+
+
+# --- V1 operation validators ---
 
 
 def _validate_move(
@@ -133,6 +156,127 @@ def _validate_edit_text(
         return
 
 
+# --- V2 transform validators ---
+
+
+def _validate_rotate(
+    op: EditOperation,
+    index_pos: int,
+    result: ValidationResult,
+) -> None:
+    """Validate rotate_entity parameters."""
+    angle = op.params.get("angle")
+    if angle is None:
+        result.add_blocker("rotate_entity requires angle param", index_pos)
+        return
+
+    if not isinstance(angle, (int, float)):
+        result.add_blocker("angle must be numeric", index_pos)
+        return
+
+    if math.isnan(angle) or math.isinf(angle):
+        result.add_blocker("angle contains NaN or Inf", index_pos)
+        return
+
+
+def _validate_copy(
+    op: EditOperation,
+    index_pos: int,
+    result: ValidationResult,
+) -> None:
+    """Validate copy_entity parameters."""
+    dx = op.params.get("dx")
+    dy = op.params.get("dy")
+    if dx is None or dy is None:
+        result.add_blocker("copy_entity requires dx and dy params", index_pos)
+        return
+
+    if not isinstance(dx, (int, float)) or not isinstance(dy, (int, float)):
+        result.add_blocker("dx and dy must be numeric", index_pos)
+        return
+
+    if math.isnan(dx) or math.isnan(dy) or math.isinf(dx) or math.isinf(dy):
+        result.add_blocker("dx/dy contains NaN or Inf", index_pos)
+        return
+
+
+def _validate_scale(
+    op: EditOperation,
+    index_pos: int,
+    result: ValidationResult,
+) -> None:
+    """Validate scale_entity parameters."""
+    factor = op.params.get("factor")
+    if factor is None:
+        result.add_blocker("scale_entity requires factor param", index_pos)
+        return
+
+    if not isinstance(factor, (int, float)):
+        result.add_blocker("factor must be numeric", index_pos)
+        return
+
+    if math.isnan(factor) or math.isinf(factor):
+        result.add_blocker("factor contains NaN or Inf", index_pos)
+        return
+
+    if factor == 0:
+        result.add_blocker("scale factor cannot be zero", index_pos)
+        return
+
+    if factor < 0:
+        result.add_warning("Negative scale factor will mirror the entity", index_pos)
+
+
+def _validate_mirror(
+    op: EditOperation,
+    index_pos: int,
+    result: ValidationResult,
+) -> None:
+    """Validate mirror_entity parameters."""
+    axis = op.params.get("axis")
+    if axis is None:
+        result.add_blocker("mirror_entity requires axis param", index_pos)
+        return
+
+    if axis not in ("x", "y"):
+        result.add_blocker("axis must be 'x' or 'y'", index_pos)
+        return
+
+    value = op.params.get("value")
+    if value is not None:
+        if not isinstance(value, (int, float)):
+            result.add_blocker("mirror value must be numeric", index_pos)
+            return
+        if math.isnan(value) or math.isinf(value):
+            result.add_blocker("mirror value contains NaN or Inf", index_pos)
+            return
+
+
+# --- Creation operation validators ---
+
+
+def _validate_creation_op(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    rules: RuleConfig,
+    result: ValidationResult,
+) -> None:
+    """Validate entity creation operations."""
+    if op.op_type == OpType.ADD_BLOCK:
+        _validate_add_block(op, index_pos, protected_layers, rules, result)
+    elif op.op_type == OpType.ADD_LINE:
+        _validate_add_line(op, index_pos, protected_layers, result)
+    elif op.op_type == OpType.ADD_POLYLINE:
+        _validate_add_polyline(op, index_pos, protected_layers, result)
+    elif op.op_type == OpType.ADD_CIRCLE:
+        _validate_add_circle(op, index_pos, protected_layers, result)
+    elif op.op_type == OpType.ADD_ARC:
+        _validate_add_arc(op, index_pos, protected_layers, result)
+    elif op.op_type == OpType.ADD_TEXT:
+        _validate_add_text(op, index_pos, protected_layers, result)
+
+
 def _validate_add_block(
     op: EditOperation,
     index_pos: int,
@@ -154,5 +298,145 @@ def _validate_add_block(
     if op.target_layer and op.target_layer.upper() in protected_layers:
         result.add_blocker(
             f"Cannot insert block on protected layer: {op.target_layer}",
+            index_pos,
+        )
+
+
+def _validate_add_line(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Validate add_line parameters."""
+    start = op.params.get("start")
+    end = op.params.get("end")
+
+    if not start or "x" not in start or "y" not in start:
+        result.add_blocker("add_line requires start point with x and y", index_pos)
+        return
+
+    if not end or "x" not in end or "y" not in end:
+        result.add_blocker("add_line requires end point with x and y", index_pos)
+        return
+
+    _check_creation_layer(op, index_pos, protected_layers, result)
+
+
+def _validate_add_polyline(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Validate add_polyline parameters."""
+    points = op.params.get("points")
+    if not points or not isinstance(points, list):
+        result.add_blocker("add_polyline requires points list", index_pos)
+        return
+
+    if len(points) < 2:
+        result.add_blocker("add_polyline requires at least 2 points", index_pos)
+        return
+
+    for i, pt in enumerate(points):
+        if not isinstance(pt, dict) or "x" not in pt or "y" not in pt:
+            result.add_blocker(f"Point {i} must have x and y", index_pos)
+            return
+
+    _check_creation_layer(op, index_pos, protected_layers, result)
+
+
+def _validate_add_circle(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Validate add_circle parameters."""
+    center = op.params.get("center")
+    if not center or "x" not in center or "y" not in center:
+        result.add_blocker("add_circle requires center with x and y", index_pos)
+        return
+
+    radius = op.params.get("radius")
+    if radius is None:
+        result.add_blocker("add_circle requires radius", index_pos)
+        return
+
+    if not isinstance(radius, (int, float)) or radius <= 0:
+        result.add_blocker("radius must be a positive number", index_pos)
+        return
+
+    _check_creation_layer(op, index_pos, protected_layers, result)
+
+
+def _validate_add_arc(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Validate add_arc parameters."""
+    center = op.params.get("center")
+    if not center or "x" not in center or "y" not in center:
+        result.add_blocker("add_arc requires center with x and y", index_pos)
+        return
+
+    radius = op.params.get("radius")
+    if radius is None:
+        result.add_blocker("add_arc requires radius", index_pos)
+        return
+
+    if not isinstance(radius, (int, float)) or radius <= 0:
+        result.add_blocker("radius must be a positive number", index_pos)
+        return
+
+    if op.params.get("start_angle") is None:
+        result.add_blocker("add_arc requires start_angle", index_pos)
+        return
+
+    if op.params.get("end_angle") is None:
+        result.add_blocker("add_arc requires end_angle", index_pos)
+        return
+
+    _check_creation_layer(op, index_pos, protected_layers, result)
+
+
+def _validate_add_text(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Validate add_text parameters."""
+    text = op.params.get("text")
+    if text is None:
+        result.add_blocker("add_text requires text param", index_pos)
+        return
+
+    if not isinstance(text, str):
+        result.add_blocker("text must be a string", index_pos)
+        return
+
+    insert = op.params.get("insert")
+    if not insert or "x" not in insert or "y" not in insert:
+        result.add_blocker("add_text requires insert point with x and y", index_pos)
+        return
+
+    _check_creation_layer(op, index_pos, protected_layers, result)
+
+
+def _check_creation_layer(
+    op: EditOperation,
+    index_pos: int,
+    protected_layers: list[str],
+    result: ValidationResult,
+) -> None:
+    """Check that a creation op doesn't target a protected layer."""
+    layer = op.params.get("layer") or op.target_layer
+    if layer and layer.upper() in protected_layers:
+        result.add_blocker(
+            f"Cannot create entity on protected layer: {layer}",
             index_pos,
         )

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -384,34 +384,35 @@ MIRROR_ENTITY = {
 # V2 entity creation tools
 # ---------------------------------------------------------------------------
 
+_POINT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "x": {"type": "number"},
+        "y": {"type": "number"},
+    },
+    "required": ["x", "y"],
+}
+
 ADD_LINE = {
     "name": "add_line",
     "description": ("Draw a new line between two points. Cannot create on protected layers."),
     "parameters": {
         "type": "object",
         "properties": {
-            "start_x": {
-                "type": "number",
-                "description": "X coordinate of start point",
+            "start": {
+                **_POINT_SCHEMA,
+                "description": "Start point {x, y}",
             },
-            "start_y": {
-                "type": "number",
-                "description": "Y coordinate of start point",
-            },
-            "end_x": {
-                "type": "number",
-                "description": "X coordinate of end point",
-            },
-            "end_y": {
-                "type": "number",
-                "description": "Y coordinate of end point",
+            "end": {
+                **_POINT_SCHEMA,
+                "description": "End point {x, y}",
             },
             "layer": {
                 "type": "string",
                 "description": "Target layer name (optional)",
             },
         },
-        "required": ["start_x", "start_y", "end_x", "end_y"],
+        "required": ["start", "end"],
     },
 }
 
@@ -459,13 +460,9 @@ ADD_CIRCLE = {
     "parameters": {
         "type": "object",
         "properties": {
-            "center_x": {
-                "type": "number",
-                "description": "X coordinate of center",
-            },
-            "center_y": {
-                "type": "number",
-                "description": "Y coordinate of center",
+            "center": {
+                **_POINT_SCHEMA,
+                "description": "Center point {x, y}",
             },
             "radius": {
                 "type": "number",
@@ -476,7 +473,7 @@ ADD_CIRCLE = {
                 "description": "Target layer name (optional)",
             },
         },
-        "required": ["center_x", "center_y", "radius"],
+        "required": ["center", "radius"],
     },
 }
 
@@ -490,13 +487,9 @@ ADD_ARC = {
     "parameters": {
         "type": "object",
         "properties": {
-            "center_x": {
-                "type": "number",
-                "description": "X coordinate of arc center",
-            },
-            "center_y": {
-                "type": "number",
-                "description": "Y coordinate of arc center",
+            "center": {
+                **_POINT_SCHEMA,
+                "description": "Center point {x, y}",
             },
             "radius": {
                 "type": "number",
@@ -515,7 +508,7 @@ ADD_ARC = {
                 "description": "Target layer name (optional)",
             },
         },
-        "required": ["center_x", "center_y", "radius", "start_angle", "end_angle"],
+        "required": ["center", "radius", "start_angle", "end_angle"],
     },
 }
 
@@ -533,13 +526,9 @@ ADD_TEXT_TOOL = {
                 "type": "string",
                 "description": "The text content to add",
             },
-            "x": {
-                "type": "number",
-                "description": "X coordinate for text insertion point",
-            },
-            "y": {
-                "type": "number",
-                "description": "Y coordinate for text insertion point",
+            "insert": {
+                **_POINT_SCHEMA,
+                "description": "Insertion point {x, y}",
             },
             "height": {
                 "type": "number",
@@ -559,7 +548,7 @@ ADD_TEXT_TOOL = {
                 "description": "TEXT (single line) or MTEXT (multi-line). Default TEXT.",
             },
         },
-        "required": ["text", "x", "y"],
+        "required": ["text", "insert"],
     },
 }
 

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -151,6 +151,10 @@ IS_PROTECTED = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# V1 edit tools
+# ---------------------------------------------------------------------------
+
 MOVE_ENTITY = {
     "name": "move_entity",
     "description": (
@@ -255,11 +259,333 @@ ADD_BLOCK = {
 }
 
 # ---------------------------------------------------------------------------
+# V2 transform tools
+# ---------------------------------------------------------------------------
+
+ROTATE_ENTITY = {
+    "name": "rotate_entity",
+    "description": (
+        "Rotate an entity by a given angle in degrees. "
+        "Rotation center defaults to origin (0,0) unless cx, cy are specified. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to rotate",
+            },
+            "angle": {
+                "type": "number",
+                "description": "Rotation angle in degrees (positive = counter-clockwise)",
+            },
+            "cx": {
+                "type": "number",
+                "description": "X coordinate of rotation center (default 0)",
+            },
+            "cy": {
+                "type": "number",
+                "description": "Y coordinate of rotation center (default 0)",
+            },
+        },
+        "required": ["handle", "angle"],
+    },
+}
+
+COPY_ENTITY = {
+    "name": "copy_entity",
+    "description": (
+        "Create a copy of an entity at an offset position. "
+        "The original entity is preserved. The copy gets a new handle. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to copy",
+            },
+            "dx": {
+                "type": "number",
+                "description": "X offset for the copy from original position",
+            },
+            "dy": {
+                "type": "number",
+                "description": "Y offset for the copy from original position",
+            },
+        },
+        "required": ["handle", "dx", "dy"],
+    },
+}
+
+SCALE_ENTITY = {
+    "name": "scale_entity",
+    "description": (
+        "Scale an entity by a uniform factor relative to a center point. "
+        "Center defaults to origin (0,0) unless cx, cy are specified. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to scale",
+            },
+            "factor": {
+                "type": "number",
+                "description": "Scale factor (>1 enlarges, <1 shrinks, must be non-zero)",
+            },
+            "cx": {
+                "type": "number",
+                "description": "X coordinate of scale center (default 0)",
+            },
+            "cy": {
+                "type": "number",
+                "description": "Y coordinate of scale center (default 0)",
+            },
+        },
+        "required": ["handle", "factor"],
+    },
+}
+
+MIRROR_ENTITY = {
+    "name": "mirror_entity",
+    "description": (
+        "Mirror an entity across an axis line. "
+        "axis='x' mirrors across horizontal line y=value. "
+        "axis='y' mirrors across vertical line x=value. "
+        "Cannot target entities on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Handle of the entity to mirror",
+            },
+            "axis": {
+                "type": "string",
+                "enum": ["x", "y"],
+                "description": "Mirror axis: 'x' for horizontal, 'y' for vertical",
+            },
+            "value": {
+                "type": "number",
+                "description": "Position of the mirror line (default 0)",
+            },
+        },
+        "required": ["handle", "axis"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# V2 entity creation tools
+# ---------------------------------------------------------------------------
+
+ADD_LINE = {
+    "name": "add_line",
+    "description": ("Draw a new line between two points. Cannot create on protected layers."),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "start_x": {
+                "type": "number",
+                "description": "X coordinate of start point",
+            },
+            "start_y": {
+                "type": "number",
+                "description": "Y coordinate of start point",
+            },
+            "end_x": {
+                "type": "number",
+                "description": "X coordinate of end point",
+            },
+            "end_y": {
+                "type": "number",
+                "description": "Y coordinate of end point",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Target layer name (optional)",
+            },
+        },
+        "required": ["start_x", "start_y", "end_x", "end_y"],
+    },
+}
+
+ADD_POLYLINE = {
+    "name": "add_polyline",
+    "description": (
+        "Draw a new polyline through a series of points. "
+        "Set closed=true to close the shape. "
+        "Cannot create on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "points": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                    },
+                    "required": ["x", "y"],
+                },
+                "description": "List of {x, y} points defining the polyline (minimum 2)",
+            },
+            "closed": {
+                "type": "boolean",
+                "description": "Whether to close the polyline (default false)",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Target layer name (optional)",
+            },
+        },
+        "required": ["points"],
+    },
+}
+
+ADD_CIRCLE = {
+    "name": "add_circle",
+    "description": (
+        "Draw a new circle at a center point with a given radius. "
+        "Cannot create on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "center_x": {
+                "type": "number",
+                "description": "X coordinate of center",
+            },
+            "center_y": {
+                "type": "number",
+                "description": "Y coordinate of center",
+            },
+            "radius": {
+                "type": "number",
+                "description": "Circle radius in drawing units",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Target layer name (optional)",
+            },
+        },
+        "required": ["center_x", "center_y", "radius"],
+    },
+}
+
+ADD_ARC = {
+    "name": "add_arc",
+    "description": (
+        "Draw a new arc (portion of a circle) defined by center, radius, "
+        "start angle, and end angle in degrees. "
+        "Cannot create on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "center_x": {
+                "type": "number",
+                "description": "X coordinate of arc center",
+            },
+            "center_y": {
+                "type": "number",
+                "description": "Y coordinate of arc center",
+            },
+            "radius": {
+                "type": "number",
+                "description": "Arc radius in drawing units",
+            },
+            "start_angle": {
+                "type": "number",
+                "description": "Start angle in degrees (0 = east/right)",
+            },
+            "end_angle": {
+                "type": "number",
+                "description": "End angle in degrees (counter-clockwise from start)",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Target layer name (optional)",
+            },
+        },
+        "required": ["center_x", "center_y", "radius", "start_angle", "end_angle"],
+    },
+}
+
+ADD_TEXT_TOOL = {
+    "name": "add_text",
+    "description": (
+        "Add a new text annotation at a specified point. "
+        "Use text_type='MTEXT' for multi-line text. "
+        "Cannot create on protected layers."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "The text content to add",
+            },
+            "x": {
+                "type": "number",
+                "description": "X coordinate for text insertion point",
+            },
+            "y": {
+                "type": "number",
+                "description": "Y coordinate for text insertion point",
+            },
+            "height": {
+                "type": "number",
+                "description": "Text height in drawing units (default 2.5)",
+            },
+            "rotation": {
+                "type": "number",
+                "description": "Text rotation in degrees (default 0)",
+            },
+            "layer": {
+                "type": "string",
+                "description": "Target layer name (optional)",
+            },
+            "text_type": {
+                "type": "string",
+                "enum": ["TEXT", "MTEXT"],
+                "description": "TEXT (single line) or MTEXT (multi-line). Default TEXT.",
+            },
+        },
+        "required": ["text", "x", "y"],
+    },
+}
+
+# ---------------------------------------------------------------------------
 # Query tools (read-only) vs. edit tools (produce operations)
 # ---------------------------------------------------------------------------
 
 QUERY_TOOLS = [FIND_ENTITIES, GET_ENTITY, FIND_NEAREST, LIST_LAYERS, IS_PROTECTED]
-EDIT_TOOLS = [MOVE_ENTITY, EDIT_TEXT, DELETE_ENTITY, ADD_BLOCK]
+EDIT_TOOLS = [
+    # V1
+    MOVE_ENTITY,
+    EDIT_TEXT,
+    DELETE_ENTITY,
+    ADD_BLOCK,
+    # V2 transforms
+    ROTATE_ENTITY,
+    COPY_ENTITY,
+    SCALE_ENTITY,
+    MIRROR_ENTITY,
+    # V2 creation
+    ADD_LINE,
+    ADD_POLYLINE,
+    ADD_CIRCLE,
+    ADD_ARC,
+    ADD_TEXT_TOOL,
+]
 ALL_TOOLS = QUERY_TOOLS + EDIT_TOOLS
 
 

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -1,7 +1,8 @@
 """Tool executor — runs CAD tools invoked by the LLM agent.
 
 Maps tool names to EntityIndex / drawing context operations.
-Edit tools (move, delete, edit_text, add_block) accumulate
+Edit tools (move, delete, edit_text, add_block, rotate, copy, scale,
+mirror, add_line, add_polyline, add_circle, add_arc, add_text) accumulate
 EditOperation objects instead of mutating the drawing directly.
 The operations are later validated and applied by the pipeline.
 """
@@ -46,15 +47,28 @@ class ToolExecutor:
         Raises KeyError for unknown tool names.
         """
         dispatch = {
+            # Query tools
             "find_entities": self._find_entities,
             "get_entity": self._get_entity,
             "find_nearest": self._find_nearest,
             "list_layers": self._list_layers,
             "is_protected": self._is_protected,
+            # V1 edit tools
             "move_entity": self._move_entity,
             "edit_text": self._edit_text,
             "delete_entity": self._delete_entity,
             "add_block": self._add_block,
+            # V2 transform tools
+            "rotate_entity": self._rotate_entity,
+            "copy_entity": self._copy_entity,
+            "scale_entity": self._scale_entity,
+            "mirror_entity": self._mirror_entity,
+            # V2 creation tools
+            "add_line": self._add_line,
+            "add_polyline": self._add_polyline,
+            "add_circle": self._add_circle,
+            "add_arc": self._add_arc,
+            "add_text": self._add_text,
         }
 
         handler = dispatch.get(tool_name)
@@ -145,7 +159,7 @@ class ToolExecutor:
             "protected": layer.upper() in self._protected,
         }
 
-    # --- Edit tools (accumulate operations) ---
+    # --- V1 edit tools (accumulate operations) ---
 
     def _move_entity(self, args: dict[str, Any]) -> dict[str, Any]:
         handle = args["handle"]
@@ -243,6 +257,235 @@ class ToolExecutor:
             "block_name": block_name,
             "x": x,
             "y": y,
+        }
+
+    # --- V2 transform tools ---
+
+    def _rotate_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot rotate entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.ROTATE_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+            target_space=entity.space,
+            params={
+                "angle": args["angle"],
+                "cx": args.get("cx", 0),
+                "cy": args.get("cy", 0),
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "rotate_entity",
+            "handle": handle,
+            "angle": args["angle"],
+        }
+
+    def _copy_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot copy entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.COPY_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+            target_space=entity.space,
+            params={"dx": args["dx"], "dy": args["dy"]},
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "copy_entity",
+            "handle": handle,
+            "dx": args["dx"],
+            "dy": args["dy"],
+        }
+
+    def _scale_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot scale entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.SCALE_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+            target_space=entity.space,
+            params={
+                "factor": args["factor"],
+                "cx": args.get("cx", 0),
+                "cy": args.get("cy", 0),
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "scale_entity",
+            "handle": handle,
+            "factor": args["factor"],
+        }
+
+    def _mirror_entity(self, args: dict[str, Any]) -> dict[str, Any]:
+        handle = args["handle"]
+        entity = self._index.get_by_handle(handle)
+        if entity is None:
+            return {"error": f"Entity not found: {handle}"}
+        if entity.layer.upper() in self._protected:
+            return {"error": f"Cannot mirror entity on protected layer: {entity.layer}"}
+
+        op = EditOperation(
+            op_type=OpType.MIRROR_ENTITY,
+            target_handle=handle,
+            target_layer=entity.layer,
+            target_space=entity.space,
+            params={
+                "axis": args["axis"],
+                "value": args.get("value", 0),
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "mirror_entity",
+            "handle": handle,
+            "axis": args["axis"],
+        }
+
+    # --- V2 creation tools ---
+
+    def _add_line(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot create entity on protected layer: {layer}"}
+
+        op = EditOperation(
+            op_type=OpType.ADD_LINE,
+            target_layer=layer,
+            params={
+                "start": {"x": args["start_x"], "y": args["start_y"]},
+                "end": {"x": args["end_x"], "y": args["end_y"]},
+                "layer": layer,
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_line",
+            "start": {"x": args["start_x"], "y": args["start_y"]},
+            "end": {"x": args["end_x"], "y": args["end_y"]},
+        }
+
+    def _add_polyline(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot create entity on protected layer: {layer}"}
+
+        points = args["points"]
+        closed = args.get("closed", False)
+
+        op = EditOperation(
+            op_type=OpType.ADD_POLYLINE,
+            target_layer=layer,
+            params={
+                "points": points,
+                "closed": closed,
+                "layer": layer,
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_polyline",
+            "point_count": len(points),
+            "closed": closed,
+        }
+
+    def _add_circle(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot create entity on protected layer: {layer}"}
+
+        op = EditOperation(
+            op_type=OpType.ADD_CIRCLE,
+            target_layer=layer,
+            params={
+                "center": {"x": args["center_x"], "y": args["center_y"]},
+                "radius": args["radius"],
+                "layer": layer,
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_circle",
+            "center": {"x": args["center_x"], "y": args["center_y"]},
+            "radius": args["radius"],
+        }
+
+    def _add_arc(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot create entity on protected layer: {layer}"}
+
+        op = EditOperation(
+            op_type=OpType.ADD_ARC,
+            target_layer=layer,
+            params={
+                "center": {"x": args["center_x"], "y": args["center_y"]},
+                "radius": args["radius"],
+                "start_angle": args["start_angle"],
+                "end_angle": args["end_angle"],
+                "layer": layer,
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_arc",
+            "center": {"x": args["center_x"], "y": args["center_y"]},
+            "radius": args["radius"],
+        }
+
+    def _add_text(self, args: dict[str, Any]) -> dict[str, Any]:
+        layer = args.get("layer")
+        if layer and layer.upper() in self._protected:
+            return {"error": f"Cannot create entity on protected layer: {layer}"}
+
+        text_type = args.get("text_type", "TEXT")
+
+        op = EditOperation(
+            op_type=OpType.ADD_TEXT,
+            target_layer=layer,
+            params={
+                "text": args["text"],
+                "insert": {"x": args["x"], "y": args["y"]},
+                "height": args.get("height", 2.5),
+                "rotation": args.get("rotation", 0),
+                "text_type": text_type,
+                "layer": layer,
+            },
+        )
+        self._operations.append(op)
+        return {
+            "status": "queued",
+            "operation": "add_text",
+            "text": args["text"],
+            "x": args["x"],
+            "y": args["y"],
         }
 
 

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -372,21 +372,21 @@ class ToolExecutor:
         if layer and layer.upper() in self._protected:
             return {"error": f"Cannot create entity on protected layer: {layer}"}
 
+        # Accept both Point2D objects and flat coordinates for backward compat
+        start = args.get("start") or {"x": args.get("start_x", 0), "y": args.get("start_y", 0)}
+        end = args.get("end") or {"x": args.get("end_x", 0), "y": args.get("end_y", 0)}
+
         op = EditOperation(
             op_type=OpType.ADD_LINE,
             target_layer=layer,
-            params={
-                "start": {"x": args["start_x"], "y": args["start_y"]},
-                "end": {"x": args["end_x"], "y": args["end_y"]},
-                "layer": layer,
-            },
+            params={"start": start, "end": end, "layer": layer},
         )
         self._operations.append(op)
         return {
             "status": "queued",
             "operation": "add_line",
-            "start": {"x": args["start_x"], "y": args["start_y"]},
-            "end": {"x": args["end_x"], "y": args["end_y"]},
+            "start": start,
+            "end": end,
         }
 
     def _add_polyline(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -419,20 +419,19 @@ class ToolExecutor:
         if layer and layer.upper() in self._protected:
             return {"error": f"Cannot create entity on protected layer: {layer}"}
 
+        # Accept both Point2D object and flat coordinates
+        center = args.get("center") or {"x": args.get("center_x", 0), "y": args.get("center_y", 0)}
+
         op = EditOperation(
             op_type=OpType.ADD_CIRCLE,
             target_layer=layer,
-            params={
-                "center": {"x": args["center_x"], "y": args["center_y"]},
-                "radius": args["radius"],
-                "layer": layer,
-            },
+            params={"center": center, "radius": args["radius"], "layer": layer},
         )
         self._operations.append(op)
         return {
             "status": "queued",
             "operation": "add_circle",
-            "center": {"x": args["center_x"], "y": args["center_y"]},
+            "center": center,
             "radius": args["radius"],
         }
 
@@ -441,11 +440,14 @@ class ToolExecutor:
         if layer and layer.upper() in self._protected:
             return {"error": f"Cannot create entity on protected layer: {layer}"}
 
+        # Accept both Point2D object and flat coordinates
+        center = args.get("center") or {"x": args.get("center_x", 0), "y": args.get("center_y", 0)}
+
         op = EditOperation(
             op_type=OpType.ADD_ARC,
             target_layer=layer,
             params={
-                "center": {"x": args["center_x"], "y": args["center_y"]},
+                "center": center,
                 "radius": args["radius"],
                 "start_angle": args["start_angle"],
                 "end_angle": args["end_angle"],
@@ -456,7 +458,7 @@ class ToolExecutor:
         return {
             "status": "queued",
             "operation": "add_arc",
-            "center": {"x": args["center_x"], "y": args["center_y"]},
+            "center": center,
             "radius": args["radius"],
         }
 
@@ -467,12 +469,15 @@ class ToolExecutor:
 
         text_type = args.get("text_type", "TEXT")
 
+        # Accept both Point2D object and flat coordinates
+        insert = args.get("insert") or {"x": args.get("x", 0), "y": args.get("y", 0)}
+
         op = EditOperation(
             op_type=OpType.ADD_TEXT,
             target_layer=layer,
             params={
                 "text": args["text"],
-                "insert": {"x": args["x"], "y": args["y"]},
+                "insert": insert,
                 "height": args.get("height", 2.5),
                 "rotation": args.get("rotation", 0),
                 "text_type": text_type,
@@ -484,8 +489,7 @@ class ToolExecutor:
             "status": "queued",
             "operation": "add_text",
             "text": args["text"],
-            "x": args["x"],
-            "y": args["y"],
+            "insert": insert,
         }
 
 

--- a/src/cad_dxf_agent/models/ops_schema.py
+++ b/src/cad_dxf_agent/models/ops_schema.py
@@ -9,12 +9,26 @@ from pydantic import BaseModel, Field
 
 
 class OpType(StrEnum):
-    """Allowed V1 operation types."""
+    """Allowed operation types."""
 
+    # V1 operations
     MOVE_ENTITY = "move_entity"
     EDIT_TEXT = "edit_text"
     DELETE_ENTITY = "delete_entity"
     ADD_BLOCK = "add_block"
+
+    # V2 transform operations
+    ROTATE_ENTITY = "rotate_entity"
+    COPY_ENTITY = "copy_entity"
+    SCALE_ENTITY = "scale_entity"
+    MIRROR_ENTITY = "mirror_entity"
+
+    # V2 entity creation operations
+    ADD_LINE = "add_line"
+    ADD_POLYLINE = "add_polyline"
+    ADD_CIRCLE = "add_circle"
+    ADD_ARC = "add_arc"
+    ADD_TEXT = "add_text"
 
 
 class EditOperation(BaseModel):
@@ -36,6 +50,15 @@ class EditOperation(BaseModel):
     # edit_text params: new_text
     # delete_entity params: (none)
     # add_block params: block_name, insert_point (x, y), scale, rotation
+    # rotate_entity params: angle (degrees), cx, cy (rotation center, optional)
+    # copy_entity params: dx, dy (offset for the copy)
+    # scale_entity params: factor, cx, cy (scale center, optional)
+    # mirror_entity params: axis ("x" or "y"), value (coordinate of mirror line)
+    # add_line params: start (x, y), end (x, y), layer
+    # add_polyline params: points [(x, y), ...], closed (bool), layer
+    # add_circle params: center (x, y), radius, layer
+    # add_arc params: center (x, y), radius, start_angle, end_angle, layer
+    # add_text params: text, insert (x, y), height, layer, rotation (optional)
 
 
 class ChangeSet(BaseModel):

--- a/tests/helpers/changeset_factory.py
+++ b/tests/helpers/changeset_factory.py
@@ -88,6 +88,227 @@ def make_add_block(
     )
 
 
+# --- V2 transform builders ---
+
+
+def make_rotate(
+    handle: str,
+    *,
+    angle: float = 90.0,
+    cx: float = 0,
+    cy: float = 0,
+    prompt: str = "Rotate entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single rotate operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ROTATE_ENTITY,
+                target_handle=handle,
+                params={"angle": angle, "cx": cx, "cy": cy},
+            )
+        ],
+    )
+
+
+def make_copy(
+    handle: str,
+    *,
+    dx: float = 30.0,
+    dy: float = 0.0,
+    prompt: str = "Copy entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single copy operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.COPY_ENTITY,
+                target_handle=handle,
+                params={"dx": dx, "dy": dy},
+            )
+        ],
+    )
+
+
+def make_scale(
+    handle: str,
+    *,
+    factor: float = 2.0,
+    cx: float = 0,
+    cy: float = 0,
+    prompt: str = "Scale entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single scale operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.SCALE_ENTITY,
+                target_handle=handle,
+                params={"factor": factor, "cx": cx, "cy": cy},
+            )
+        ],
+    )
+
+
+def make_mirror(
+    handle: str,
+    *,
+    axis: str = "x",
+    value: float = 0,
+    prompt: str = "Mirror entity",
+) -> ChangeSet:
+    """Build a ChangeSet with a single mirror operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.MIRROR_ENTITY,
+                target_handle=handle,
+                params={"axis": axis, "value": value},
+            )
+        ],
+    )
+
+
+# --- V2 creation builders ---
+
+
+def make_add_line(
+    start_x: float = 0,
+    start_y: float = 0,
+    end_x: float = 100,
+    end_y: float = 0,
+    *,
+    layer: str | None = None,
+    prompt: str = "Add line",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_line operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_LINE,
+                target_layer=layer,
+                params={
+                    "start": {"x": start_x, "y": start_y},
+                    "end": {"x": end_x, "y": end_y},
+                    "layer": layer,
+                },
+            )
+        ],
+    )
+
+
+def make_add_polyline(
+    points: list[dict] | None = None,
+    *,
+    closed: bool = False,
+    layer: str | None = None,
+    prompt: str = "Add polyline",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_polyline operation."""
+    if points is None:
+        points = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 50, "y": 50}, {"x": 0, "y": 50}]
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_POLYLINE,
+                target_layer=layer,
+                params={
+                    "points": points,
+                    "closed": closed,
+                    "layer": layer,
+                },
+            )
+        ],
+    )
+
+
+def make_add_circle(
+    cx: float = 50,
+    cy: float = 50,
+    radius: float = 10,
+    *,
+    layer: str | None = None,
+    prompt: str = "Add circle",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_circle operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_CIRCLE,
+                target_layer=layer,
+                params={
+                    "center": {"x": cx, "y": cy},
+                    "radius": radius,
+                    "layer": layer,
+                },
+            )
+        ],
+    )
+
+
+def make_add_arc(
+    cx: float = 50,
+    cy: float = 50,
+    radius: float = 10,
+    *,
+    start_angle: float = 0,
+    end_angle: float = 90,
+    layer: str | None = None,
+    prompt: str = "Add arc",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_arc operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_ARC,
+                target_layer=layer,
+                params={
+                    "center": {"x": cx, "y": cy},
+                    "radius": radius,
+                    "start_angle": start_angle,
+                    "end_angle": end_angle,
+                    "layer": layer,
+                },
+            )
+        ],
+    )
+
+
+def make_add_text(
+    text: str = "NEW ANNOTATION",
+    x: float = 10,
+    y: float = 10,
+    *,
+    height: float = 2.5,
+    layer: str | None = None,
+    prompt: str = "Add text",
+) -> ChangeSet:
+    """Build a ChangeSet with a single add_text operation."""
+    return ChangeSet(
+        prompt=prompt,
+        operations=[
+            EditOperation(
+                op_type=OpType.ADD_TEXT,
+                target_layer=layer,
+                params={
+                    "text": text,
+                    "insert": {"x": x, "y": y},
+                    "height": height,
+                    "layer": layer,
+                },
+            )
+        ],
+    )
+
+
 def make_multi_op(
     *operations: EditOperation,
     prompt: str = "Multi-op changeset",

--- a/tests/unit/test_planner_parser.py
+++ b/tests/unit/test_planner_parser.py
@@ -66,6 +66,7 @@ class TestResponseParser:
             parse_planner_response(json.dumps({"result": "ok"}))
 
     def test_reject_invalid_op_type(self):
-        response = json.dumps({"operations": [{"op_type": "scale_entity", "target_handle": "A1"}]})
+        payload = {"operations": [{"op_type": "explode_entity", "target_handle": "A1"}]}
+        response = json.dumps(payload)
         with pytest.raises(ValueError, match="Invalid operation"):
             parse_planner_response(response)

--- a/tests/unit/test_rtree_index.py
+++ b/tests/unit/test_rtree_index.py
@@ -1,0 +1,685 @@
+"""Tests for the R-tree spatial index upgrade and ENTITY_CAP raise.
+
+Covers:
+- nearest() — unfiltered (R-tree path) and filtered (linear-scan path)
+- find_in_radius() — R-tree bbox + exact circular distance check
+- Consistency between R-tree and brute-force linear scan
+- ENTITY_CAP is now 5000 (was 500)
+- build_planner_context truncation behaviour at the new threshold
+- Performance smoke tests on large drawings (5000 entities)
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.entity_index import EntityIndex
+from cad_dxf_agent.core.semantic_model import ENTITY_CAP, build_planner_context
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityRef, EntityType, Point2D
+from tests.helpers.dxf_factory import (
+    create_dense_drawing,
+    create_overlapping_drawing,
+    create_structural_drawing,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dist(a: EntityRef, qx: float, qy: float) -> float:
+    """Euclidean distance from entity insert_point to query point."""
+    assert a.insert_point is not None
+    return math.hypot(a.insert_point.x - qx, a.insert_point.y - qy)
+
+
+def _brute_force_nearest(
+    context: DrawingContext,
+    x: float,
+    y: float,
+    entity_type: str | None = None,
+    layer: str | None = None,
+) -> EntityRef | None:
+    """O(n) reference implementation for nearest()."""
+    candidates = [e for e in context.entities if e.insert_point is not None]
+    if entity_type is not None:
+        try:
+            etype = EntityType(entity_type)
+        except ValueError:
+            return None
+        candidates = [e for e in candidates if e.entity_type == etype]
+    if layer is not None:
+        candidates = [e for e in candidates if e.layer.upper() == layer.upper()]
+
+    if not candidates:
+        return None
+    return min(candidates, key=lambda e: math.hypot(e.insert_point.x - x, e.insert_point.y - y))  # type: ignore[union-attr]
+
+
+def _brute_force_in_radius(
+    context: DrawingContext,
+    x: float,
+    y: float,
+    radius: float,
+    entity_type: str | None = None,
+    layer: str | None = None,
+) -> list[EntityRef]:
+    """O(n) reference implementation for find_in_radius()."""
+    candidates = [e for e in context.entities if e.insert_point is not None]
+    if entity_type is not None:
+        try:
+            etype = EntityType(entity_type)
+        except ValueError:
+            return []
+        candidates = [e for e in candidates if e.entity_type == etype]
+    if layer is not None:
+        candidates = [e for e in candidates if e.layer.upper() == layer.upper()]
+
+    r_sq = radius * radius
+    hits = [
+        e
+        for e in candidates
+        if (e.insert_point.x - x) ** 2 + (e.insert_point.y - y) ** 2 <= r_sq  # type: ignore[union-attr]
+    ]
+    hits.sort(key=lambda e: math.hypot(e.insert_point.x - x, e.insert_point.y - y))  # type: ignore[union-attr]
+    return hits
+
+
+def _make_entity(
+    handle: str,
+    x: float,
+    y: float,
+    layer: str = "TEST",
+    entity_type: EntityType = EntityType.LINE,
+    text: str | None = None,
+) -> EntityRef:
+    """Minimal EntityRef factory for unit-level tests."""
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        insert_point=Point2D(x=x, y=y),
+        text_content=text,
+    )
+
+
+def _make_context(entities: list[EntityRef], file_path: str = "test.dxf") -> DrawingContext:
+    return DrawingContext(file_path=file_path, entities=entities)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def known_context() -> DrawingContext:
+    """Small drawing with entities at predictable positions.
+
+    Layout (x, y):
+      A  (0, 0)   LINE   LAYER_A
+      B  (3, 4)   TEXT   LAYER_B    — dist from origin = 5.0
+      C  (10, 0)  LINE   LAYER_A    — dist from origin = 10.0
+      D  (10, 10) TEXT   LAYER_B    — dist from origin ≈ 14.14
+      E  (0, 5)   INSERT LAYER_A    — dist from origin = 5.0
+    """
+    return _make_context(
+        [
+            _make_entity("A", 0.0, 0.0, layer="LAYER_A", entity_type=EntityType.LINE),
+            _make_entity("B", 3.0, 4.0, layer="LAYER_B", entity_type=EntityType.TEXT, text="hello"),
+            _make_entity("C", 10.0, 0.0, layer="LAYER_A", entity_type=EntityType.LINE),
+            _make_entity(
+                "D", 10.0, 10.0, layer="LAYER_B", entity_type=EntityType.TEXT, text="world"
+            ),
+            _make_entity("E", 0.0, 5.0, layer="LAYER_A", entity_type=EntityType.INSERT),
+        ]
+    )
+
+
+@pytest.fixture
+def known_index(known_context: DrawingContext) -> EntityIndex:
+    return EntityIndex(known_context)
+
+
+@pytest.fixture
+def empty_context() -> DrawingContext:
+    return _make_context([])
+
+
+@pytest.fixture
+def empty_index(empty_context: DrawingContext) -> EntityIndex:
+    return EntityIndex(empty_context)
+
+
+@pytest.fixture
+def structural_context(tmp_path: Path) -> DrawingContext:
+    """200+ entity structural drawing loaded into a DrawingContext."""
+    dxf_path = create_structural_drawing(tmp_path)
+    return load_dxf(dxf_path)
+
+
+@pytest.fixture
+def dense_context_1000(tmp_path: Path) -> DrawingContext:
+    """1000-entity dense drawing loaded into a DrawingContext."""
+    dxf_path = create_dense_drawing(tmp_path, count=1000)
+    return load_dxf(dxf_path)
+
+
+@pytest.fixture
+def overlapping_context(tmp_path: Path) -> DrawingContext:
+    """Drawing with multiple entities sharing identical coordinates."""
+    dxf_path = create_overlapping_drawing(tmp_path)
+    return load_dxf(dxf_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. nearest() — R-tree unfiltered path
+# ---------------------------------------------------------------------------
+
+
+class TestNearestUnfiltered:
+    """nearest() with no filters uses the R-tree fast path."""
+
+    def test_returns_closest_entity(self, known_index: EntityIndex) -> None:
+        """Query point at origin returns entity A (handle 'A') at (0,0)."""
+        result = known_index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.handle == "A"
+
+    def test_off_grid_query_returns_nearest(self, known_index: EntityIndex) -> None:
+        """Query close to (3,4) returns entity B."""
+        result = known_index.nearest(3.1, 4.1)
+        assert result is not None
+        assert result.handle == "B"
+
+    def test_equidistant_returns_one_result(self, known_index: EntityIndex) -> None:
+        """Query equidistant from two entities returns exactly one EntityRef."""
+        # B is at (3,4) dist=5; E is at (0,5) dist=5 — both distance 5 from origin
+        # R-tree breaks ties deterministically; we just assert we get one valid result
+        result = known_index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.insert_point is not None
+
+    def test_empty_context_returns_none(self, empty_index: EntityIndex) -> None:
+        """nearest() on empty drawing returns None."""
+        assert empty_index.nearest(0.0, 0.0) is None
+
+    def test_overlapping_entities_returns_one(self, overlapping_context: DrawingContext) -> None:
+        """When multiple entities share the same coordinates, one is returned."""
+        index = EntityIndex(overlapping_context)
+        result = index.nearest(10.0, 10.0)
+        assert result is not None
+        # Result must be one of the entities actually at (10, 10)
+        assert result.insert_point is not None
+        dist = math.hypot(result.insert_point.x - 10.0, result.insert_point.y - 10.0)
+        assert dist < 1e-6
+
+    def test_no_insert_point_entities_not_returned(self) -> None:
+        """Entities without insert_point are not indexed and cannot be nearest."""
+        e_no_pos = EntityRef(
+            handle="NP",
+            entity_type=EntityType.LINE,
+            layer="L",
+            insert_point=None,
+        )
+        e_with_pos = _make_entity("WP", 5.0, 5.0)
+        ctx = _make_context([e_no_pos, e_with_pos])
+        index = EntityIndex(ctx)
+        result = index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.handle == "WP"
+
+    def test_single_entity_always_nearest(self) -> None:
+        """Drawing with one entity — nearest always returns it regardless of distance."""
+        ctx = _make_context([_make_entity("SOLO", 1000.0, 1000.0)])
+        index = EntityIndex(ctx)
+        result = index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.handle == "SOLO"
+
+    def test_nearest_on_structural_drawing(self, structural_context: DrawingContext) -> None:
+        """nearest() on 200+ entity drawing returns a valid result."""
+        index = EntityIndex(structural_context)
+        result = index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.insert_point is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. nearest() — filtered (linear-scan) path
+# ---------------------------------------------------------------------------
+
+
+class TestNearestFiltered:
+    """nearest() with layer or type filter falls back to filtered linear scan."""
+
+    def test_layer_filter_returns_only_that_layer(self, known_index: EntityIndex) -> None:
+        """nearest() with layer='LAYER_B' returns an entity on LAYER_B."""
+        result = known_index.nearest(0.0, 0.0, layer="LAYER_B")
+        assert result is not None
+        assert result.layer.upper() == "LAYER_B"
+
+    def test_layer_filter_closest_on_layer(self, known_index: EntityIndex) -> None:
+        """nearest() picks the closest LAYER_B entity to (0,0).
+
+        B is at (3,4) dist=5; D is at (10,10) dist≈14.14 — B must win.
+        """
+        result = known_index.nearest(0.0, 0.0, layer="LAYER_B")
+        assert result is not None
+        assert result.handle == "B"
+
+    def test_type_filter_returns_only_that_type(self, known_index: EntityIndex) -> None:
+        """nearest() with entity_type='TEXT' returns a TEXT entity."""
+        result = known_index.nearest(0.0, 0.0, entity_type="TEXT")
+        assert result is not None
+        assert result.entity_type == EntityType.TEXT
+
+    def test_type_filter_closest_text(self, known_index: EntityIndex) -> None:
+        """nearest() TEXT to origin picks B at (3,4) over D at (10,10)."""
+        result = known_index.nearest(0.0, 0.0, entity_type="TEXT")
+        assert result is not None
+        assert result.handle == "B"
+
+    def test_combined_layer_and_type_filter(self, known_index: EntityIndex) -> None:
+        """nearest() with both layer and type filters applies intersection."""
+        # Only LINE on LAYER_A: A at (0,0) and C at (10,0)
+        result = known_index.nearest(9.0, 0.0, layer="LAYER_A", entity_type="LINE")
+        assert result is not None
+        assert result.handle == "C"
+        assert result.entity_type == EntityType.LINE
+        assert result.layer == "LAYER_A"
+
+    def test_layer_with_no_match_returns_none(self, known_index: EntityIndex) -> None:
+        """nearest() with layer that has no entities returns None."""
+        result = known_index.nearest(0.0, 0.0, layer="NONEXISTENT")
+        assert result is None
+
+    def test_type_with_no_match_returns_none(self, known_index: EntityIndex) -> None:
+        """nearest() with type that has no entities returns None."""
+        result = known_index.nearest(0.0, 0.0, entity_type="MTEXT")
+        assert result is None
+
+    def test_invalid_type_filter_returns_none(self, known_index: EntityIndex) -> None:
+        """nearest() with invalid entity_type string returns None."""
+        result = known_index.nearest(0.0, 0.0, entity_type="VIEWPORT")
+        assert result is None
+
+    def test_layer_filter_case_insensitive(self, known_index: EntityIndex) -> None:
+        """Layer filter is case-insensitive."""
+        upper = known_index.nearest(0.0, 0.0, layer="LAYER_B")
+        lower = known_index.nearest(0.0, 0.0, layer="layer_b")
+        assert upper is not None
+        assert lower is not None
+        assert upper.handle == lower.handle
+
+    def test_filtered_nearest_on_structural_drawing(
+        self, structural_context: DrawingContext
+    ) -> None:
+        """Filtered nearest() works on 200+ entity drawing."""
+        index = EntityIndex(structural_context)
+        result = index.nearest(0.0, 0.0, layer="NOTES")
+        assert result is not None
+        assert result.layer.upper() == "NOTES"
+
+
+# ---------------------------------------------------------------------------
+# 3. find_in_radius() tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindInRadius:
+    """find_in_radius() uses R-tree bbox + exact circular distance filter."""
+
+    def test_returns_entities_within_radius(self, known_index: EntityIndex) -> None:
+        """Entities within radius=6 of origin: A(0,0), B(3,4), E(0,5)."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=6.0)
+        handles = {e.handle for e in results}
+        assert "A" in handles  # dist=0
+        assert "B" in handles  # dist=5
+        assert "E" in handles  # dist=5
+        assert "C" not in handles  # dist=10 > 6
+        assert "D" not in handles  # dist≈14.14 > 6
+
+    def test_excludes_entities_outside_radius(self, known_index: EntityIndex) -> None:
+        """Tight radius=1 from origin only catches A at (0,0)."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=1.0)
+        assert len(results) == 1
+        assert results[0].handle == "A"
+
+    def test_circular_not_square(self, known_index: EntityIndex) -> None:
+        """Radius check is circular, not the R-tree bounding square.
+
+        Query: center=(0,0), radius=4.9
+        B is at (3,4): dist=5.0 > 4.9 — must NOT be included.
+        C is at (10,0): dist=10 > 4.9 — must NOT be included.
+        """
+        results = known_index.find_in_radius(0.0, 0.0, radius=4.9)
+        handles = {e.handle for e in results}
+        assert "B" not in handles  # dist=5.0 exceeds radius 4.9
+        assert "A" in handles  # dist=0 always inside
+
+    def test_results_sorted_by_distance(self, known_index: EntityIndex) -> None:
+        """Results are sorted nearest-first by exact Euclidean distance."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=15.0)
+        assert len(results) >= 2
+        dists = [_dist(e, 0.0, 0.0) for e in results]
+        assert dists == sorted(dists)
+
+    def test_empty_result_when_no_entities_in_radius(self, known_index: EntityIndex) -> None:
+        """Query point far from all entities returns empty list."""
+        results = known_index.find_in_radius(9999.0, 9999.0, radius=1.0)
+        assert results == []
+
+    def test_large_radius_returns_all_positioned_entities(
+        self, known_index: EntityIndex, known_context: DrawingContext
+    ) -> None:
+        """Radius large enough to encompass the drawing returns all entities with positions."""
+        positioned_count = sum(1 for e in known_context.entities if e.insert_point is not None)
+        results = known_index.find_in_radius(0.0, 0.0, radius=100.0)
+        assert len(results) == positioned_count
+
+    def test_radius_zero_returns_only_exact_match(self, known_index: EntityIndex) -> None:
+        """Radius=0 only returns entities at exact coordinates."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=0.0)
+        assert all(
+            e.insert_point is not None and e.insert_point.x == 0.0 and e.insert_point.y == 0.0
+            for e in results
+        )
+
+    def test_empty_context_returns_empty_list(self, empty_index: EntityIndex) -> None:
+        """find_in_radius() on empty drawing returns empty list."""
+        assert empty_index.find_in_radius(0.0, 0.0, radius=100.0) == []
+
+    def test_layer_filter(self, known_index: EntityIndex) -> None:
+        """Layer filter restricts results to specified layer."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=15.0, layer="LAYER_B")
+        assert all(e.layer.upper() == "LAYER_B" for e in results)
+        handles = {e.handle for e in results}
+        assert "B" in handles
+        assert "D" in handles
+        assert "A" not in handles  # LAYER_A
+
+    def test_type_filter(self, known_index: EntityIndex) -> None:
+        """Type filter restricts results to specified entity type."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=15.0, entity_type="LINE")
+        assert all(e.entity_type == EntityType.LINE for e in results)
+        handles = {e.handle for e in results}
+        assert "A" in handles
+        assert "C" in handles
+        assert "B" not in handles  # TEXT
+
+    def test_combined_layer_and_type_filter(self, known_index: EntityIndex) -> None:
+        """Combined layer+type filter returns intersection."""
+        # LAYER_A + INSERT: only E at (0,5)
+        results = known_index.find_in_radius(
+            0.0, 0.0, radius=15.0, layer="LAYER_A", entity_type="INSERT"
+        )
+        assert len(results) == 1
+        assert results[0].handle == "E"
+
+    def test_invalid_entity_type_returns_empty(self, known_index: EntityIndex) -> None:
+        """Invalid entity_type string returns empty list."""
+        results = known_index.find_in_radius(0.0, 0.0, radius=100.0, entity_type="VIEWPORT")
+        assert results == []
+
+    def test_layer_filter_case_insensitive(self, known_index: EntityIndex) -> None:
+        """Layer filter in find_in_radius is case-insensitive."""
+        upper = known_index.find_in_radius(0.0, 0.0, radius=15.0, layer="LAYER_B")
+        lower = known_index.find_in_radius(0.0, 0.0, radius=15.0, layer="layer_b")
+        assert {e.handle for e in upper} == {e.handle for e in lower}
+
+    def test_overlapping_drawing_all_at_same_point_returned(
+        self, overlapping_context: DrawingContext
+    ) -> None:
+        """Entities sharing identical coordinates are all returned within a small radius."""
+        index = EntityIndex(overlapping_context)
+        # Multiple entities at (10, 10) — tight radius should catch all of them
+        results = index.find_in_radius(10.0, 10.0, radius=0.5)
+        assert len(results) >= 2
+
+
+# ---------------------------------------------------------------------------
+# 4. Consistency tests — R-tree vs brute-force linear scan
+# ---------------------------------------------------------------------------
+
+
+class TestRtreeConsistency:
+    """R-tree results must match the brute-force reference implementation."""
+
+    @pytest.mark.parametrize(
+        "qx, qy",
+        [
+            (0.0, 0.0),
+            (5.0, 2.5),
+            (3.0, 4.0),
+            (10.0, 0.0),
+            (10.0, 10.0),
+            (50.0, 50.0),  # far from all entities
+        ],
+    )
+    def test_nearest_matches_brute_force(
+        self, known_index: EntityIndex, known_context: DrawingContext, qx: float, qy: float
+    ) -> None:
+        """nearest() result matches O(n) brute-force for multiple query points."""
+        rtree_result = known_index.nearest(qx, qy)
+        bf_result = _brute_force_nearest(known_context, qx, qy)
+
+        if bf_result is None:
+            assert rtree_result is None
+        else:
+            assert rtree_result is not None
+            # Both must be equidistant from the query point (handles ties)
+            rtree_dist = _dist(rtree_result, qx, qy)
+            bf_dist = _dist(bf_result, qx, qy)
+            assert abs(rtree_dist - bf_dist) < 1e-9
+
+    @pytest.mark.parametrize(
+        "qx, qy, radius",
+        [
+            (0.0, 0.0, 6.0),
+            (0.0, 0.0, 4.9),
+            (5.0, 2.5, 3.0),
+            (0.0, 0.0, 100.0),
+            (0.0, 0.0, 0.0),
+            (9999.0, 9999.0, 1.0),
+        ],
+    )
+    def test_find_in_radius_matches_brute_force(
+        self,
+        known_index: EntityIndex,
+        known_context: DrawingContext,
+        qx: float,
+        qy: float,
+        radius: float,
+    ) -> None:
+        """find_in_radius() result set matches O(n) brute-force."""
+        rtree_results = known_index.find_in_radius(qx, qy, radius)
+        bf_results = _brute_force_in_radius(known_context, qx, qy, radius)
+
+        assert {e.handle for e in rtree_results} == {e.handle for e in bf_results}
+
+    def test_nearest_consistency_on_dense_drawing(self, dense_context_1000: DrawingContext) -> None:
+        """R-tree nearest() matches brute-force across multiple queries on 1000-entity drawing."""
+        index = EntityIndex(dense_context_1000)
+        query_points = [(0.0, 0.0), (25.0, 25.0), (100.0, 50.0), (500.0, 500.0)]
+
+        for qx, qy in query_points:
+            rtree_result = index.nearest(qx, qy)
+            bf_result = _brute_force_nearest(dense_context_1000, qx, qy)
+
+            assert rtree_result is not None, f"R-tree returned None at ({qx},{qy})"
+            assert bf_result is not None, f"Brute-force returned None at ({qx},{qy})"
+            rtree_dist = _dist(rtree_result, qx, qy)
+            bf_dist = _dist(bf_result, qx, qy)
+            assert abs(rtree_dist - bf_dist) < 1e-9, (
+                f"Distance mismatch at ({qx},{qy}): rtree={rtree_dist} bf={bf_dist}"
+            )
+
+    def test_radius_consistency_on_dense_drawing(self, dense_context_1000: DrawingContext) -> None:
+        """R-tree find_in_radius() result sets match brute-force on 1000-entity drawing."""
+        index = EntityIndex(dense_context_1000)
+        # Grid spacing is 5.0, so radius=6 will catch entities in immediate neighbourhood
+        test_cases = [
+            (0.0, 0.0, 6.0),
+            (25.0, 25.0, 8.0),
+            (0.0, 0.0, 1000.0),  # catch everything
+        ]
+
+        for qx, qy, radius in test_cases:
+            rtree_handles = {e.handle for e in index.find_in_radius(qx, qy, radius)}
+            bf_handles = {
+                e.handle for e in _brute_force_in_radius(dense_context_1000, qx, qy, radius)
+            }
+            assert rtree_handles == bf_handles, (
+                f"Handle mismatch at ({qx},{qy}) r={radius}: "
+                f"rtree={len(rtree_handles)} bf={len(bf_handles)}"
+            )
+
+    def test_filtered_nearest_matches_brute_force_on_structural(
+        self, structural_context: DrawingContext
+    ) -> None:
+        """Filtered nearest() on 200+ entity drawing matches brute-force."""
+        index = EntityIndex(structural_context)
+        # Layer filter
+        qx, qy = 15.0, 15.0
+        rtree_result = index.nearest(qx, qy, layer="NOTES")
+        bf_result = _brute_force_nearest(structural_context, qx, qy, layer="NOTES")
+        if bf_result is None:
+            assert rtree_result is None
+        else:
+            assert rtree_result is not None
+            assert abs(_dist(rtree_result, qx, qy) - _dist(bf_result, qx, qy)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 5. ENTITY_CAP tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityCap:
+    """ENTITY_CAP was raised from 500 to 5000."""
+
+    def test_entity_cap_value(self) -> None:
+        """ENTITY_CAP is exactly 5000."""
+        assert ENTITY_CAP == 5000
+
+    def test_no_truncation_below_cap(self, dense_context_1000: DrawingContext) -> None:
+        """build_planner_context does not truncate when entity count < 5000."""
+        ctx = build_planner_context(dense_context_1000)
+        assert "entities_truncated" not in ctx
+        # entity list length must equal the actual entity count
+        assert len(ctx["entities"]) == dense_context_1000.entity_count
+
+    def test_no_truncation_at_exactly_cap(self) -> None:
+        """build_planner_context does not truncate when entity count == ENTITY_CAP."""
+        entities = [_make_entity(str(i), float(i), 0.0) for i in range(ENTITY_CAP)]
+        ctx = _make_context(entities)
+        result = build_planner_context(ctx)
+        assert "entities_truncated" not in result
+        assert len(result["entities"]) == ENTITY_CAP
+
+    def test_truncation_above_cap(self) -> None:
+        """build_planner_context truncates entity list when count > 5000."""
+        overflow = ENTITY_CAP + 500
+        entities = [_make_entity(str(i), float(i), 0.0) for i in range(overflow)]
+        ctx = _make_context(entities)
+        result = build_planner_context(ctx)
+        assert result.get("entities_truncated") is True
+        assert len(result["entities"]) == ENTITY_CAP
+        assert result["total_entity_count"] == overflow
+
+    def test_entity_count_field_reflects_full_count_when_truncated(self) -> None:
+        """entity_count in context reflects full drawing count, not the capped list."""
+        overflow = ENTITY_CAP + 1
+        entities = [_make_entity(str(i), float(i), 0.0) for i in range(overflow)]
+        ctx = _make_context(entities)
+        result = build_planner_context(ctx)
+        # entity_count comes from DrawingContext.entity_count — always the true count
+        assert result["entity_count"] == overflow
+
+    def test_old_cap_500_would_have_truncated_1000(
+        self, dense_context_1000: DrawingContext
+    ) -> None:
+        """Regression: 1000-entity drawing no longer truncated (was truncated at old cap=500)."""
+        ctx = build_planner_context(dense_context_1000)
+        # With the old cap of 500, this would have set entities_truncated=True.
+        # With the new cap of 5000 it must not.
+        assert ctx.get("entities_truncated") is not True
+        assert len(ctx["entities"]) == dense_context_1000.entity_count
+
+
+# ---------------------------------------------------------------------------
+# 6. Performance smoke tests — correctness under load, not timing
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceSmoke:
+    """Verify that large-drawing operations complete without error or timeout.
+
+    These are correctness-under-load checks, not micro-benchmarks.
+    They assert that results are plausible rather than measuring wall time.
+    """
+
+    def test_entity_index_construction_5000(self, tmp_path: Path) -> None:
+        """EntityIndex construction with 5000 entities completes without error."""
+        dxf_path = create_dense_drawing(tmp_path, count=5000, filename="dense_5000.dxf")
+        context = load_dxf(dxf_path)
+        index = EntityIndex(context)
+        assert index.count == context.entity_count
+        assert index.count >= 5000
+
+    def test_nearest_on_5000_entity_drawing(self, tmp_path: Path) -> None:
+        """nearest() on 5000-entity drawing returns a valid result."""
+        dxf_path = create_dense_drawing(tmp_path, count=5000, filename="dense_5000_near.dxf")
+        context = load_dxf(dxf_path)
+        index = EntityIndex(context)
+        result = index.nearest(0.0, 0.0)
+        assert result is not None
+        assert result.insert_point is not None
+
+    def test_find_in_radius_on_5000_entity_drawing(self, tmp_path: Path) -> None:
+        """find_in_radius() on 5000-entity drawing returns non-empty results."""
+        dxf_path = create_dense_drawing(tmp_path, count=5000, filename="dense_5000_rad.dxf")
+        context = load_dxf(dxf_path)
+        index = EntityIndex(context)
+        # Grid spacing is 5.0 — radius=8 should hit several neighbours
+        results = index.find_in_radius(25.0, 25.0, radius=8.0)
+        assert len(results) > 0
+        # All returned entities must actually be within the radius
+        for entity in results:
+            assert entity.insert_point is not None
+            dist = math.hypot(entity.insert_point.x - 25.0, entity.insert_point.y - 25.0)
+            assert dist <= 8.0 + 1e-9
+
+    def test_repeated_nearest_queries_5000(self, tmp_path: Path) -> None:
+        """100 nearest() queries on 5000-entity drawing all return valid results."""
+        dxf_path = create_dense_drawing(tmp_path, count=5000, filename="dense_5000_rep.dxf")
+        context = load_dxf(dxf_path)
+        index = EntityIndex(context)
+        for i in range(100):
+            qx = float(i * 3)
+            qy = float(i * 2)
+            result = index.nearest(qx, qy)
+            assert result is not None, f"nearest() returned None for query ({qx},{qy})"
+
+    def test_build_planner_context_with_1000_entities_no_error(
+        self, dense_context_1000: DrawingContext
+    ) -> None:
+        """build_planner_context with 1000 entities completes and is not truncated."""
+        result = build_planner_context(dense_context_1000)
+        assert "entities" in result
+        assert len(result["entities"]) == dense_context_1000.entity_count
+
+    def test_entity_index_filter_on_5000_drawing(self, tmp_path: Path) -> None:
+        """filter() on 5000-entity index returns plausible subset without error."""
+        dxf_path = create_dense_drawing(tmp_path, count=5000, filename="dense_5000_filt.dxf")
+        context = load_dxf(dxf_path)
+        index = EntityIndex(context)
+        # dense_drawing uses layers: LAYER_A, LAYER_B, LAYER_C, STRUCTURAL, NOTES
+        layer_a = index.filter(layer="LAYER_A")
+        assert len(layer_a) > 0
+        assert all(e.layer.upper() == "LAYER_A" for e in layer_a)

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -59,7 +59,7 @@ class TestEditOperation:
 
     def test_invalid_op_type(self):
         with pytest.raises(ValidationError):
-            EditOperation(op_type="scale_entity", target_handle="A1")
+            EditOperation(op_type="explode_entity", target_handle="A1")
 
 
 class TestChangeSet:

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -59,7 +59,25 @@ class TestToolDefinitions:
 
     def test_expected_edit_tools(self):
         names = {t["name"] for t in EDIT_TOOLS}
-        assert names == {"move_entity", "edit_text", "delete_entity", "add_block"}
+        expected = {
+            # V1
+            "move_entity",
+            "edit_text",
+            "delete_entity",
+            "add_block",
+            # V2 transforms
+            "rotate_entity",
+            "copy_entity",
+            "scale_entity",
+            "mirror_entity",
+            # V2 creation
+            "add_line",
+            "add_polyline",
+            "add_circle",
+            "add_arc",
+            "add_text",
+        }
+        assert names == expected
 
     def test_move_entity_params(self):
         tool = get_tool_by_name("move_entity")

--- a/tests/unit/test_v2_creation.py
+++ b/tests/unit/test_v2_creation.py
@@ -1227,8 +1227,8 @@ class TestAddTextToolExecutor:
     def test_result_contains_text_and_position(self, executor):
         result = executor.execute("add_text", {"text": "CHECK", "x": 11, "y": 22})
         assert result["text"] == "CHECK"
-        assert result["x"] == 11
-        assert result["y"] == 22
+        assert result["insert"]["x"] == 11
+        assert result["insert"]["y"] == 22
 
     def test_editable_layer_queued(self, executor):
         result = executor.execute(

--- a/tests/unit/test_v2_creation.py
+++ b/tests/unit/test_v2_creation.py
@@ -1,0 +1,1344 @@
+"""Tests for V2 entity creation operations: add_line, add_polyline, add_circle, add_arc, add_text.
+
+Covers:
+- Validation (valid params, missing required params, protected-layer blocks)
+- Engine apply (success=True, returned handle, persisted DXF attributes)
+- Preview model descriptions
+- Revision note text
+- Tool executor dispatch and protected-layer gating
+"""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.preview_model import PreviewModel
+from cad_dxf_agent.core.revision_notes import generate_note_text
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.llm.tool_executor import ToolExecutor
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.changes_schema import ValidationResult
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig
+from cad_dxf_agent.models.ops_schema import AppliedChange, ChangeSet, EditOperation, OpType
+from tests.helpers.changeset_factory import (
+    make_add_arc,
+    make_add_circle,
+    make_add_line,
+    make_add_polyline,
+    make_add_text,
+)
+
+# ---------------------------------------------------------------------------
+# Shared tool-executor fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def drawing_context() -> DrawingContext:
+    """Minimal DrawingContext for tool-executor tests."""
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="A1",
+                entity_type=EntityType.LINE,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=0, y=0),
+            ),
+        ],
+        layers=[
+            LayerRule(name="STRUCTURAL", protected=False),
+            LayerRule(name="NOTES", protected=False),
+            LayerRule(name="TITLE", protected=True),
+        ],
+        blocks=[],
+    )
+
+
+@pytest.fixture
+def executor(drawing_context: DrawingContext) -> ToolExecutor:
+    """ToolExecutor with the standard protected-layer set."""
+    return ToolExecutor(
+        drawing_context,
+        protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_and_save(sample_dxf, tmp_path, changeset, work_name="work.dxf", out_name="out.dxf"):
+    """Copy the sample DXF, apply the changeset, save, and return (engine, output_path)."""
+    work = copy_dxf_for_editing(sample_dxf, tmp_path / work_name)
+    engine = EditEngine(work)
+    results = engine.apply_changeset(changeset)
+    output = tmp_path / out_name
+    engine.save(output)
+    return engine, results, output
+
+
+def _count_type(dxf_path, dxf_type: str) -> int:
+    """Count entities of a given DXF type in model space."""
+    doc = ezdxf.readfile(str(dxf_path))
+    return sum(1 for e in doc.modelspace() if e.dxftype() == dxf_type)
+
+
+def _get_entities_of_type(dxf_path, dxf_type: str):
+    """Return all entities of a given DXF type from model space."""
+    doc = ezdxf.readfile(str(dxf_path))
+    return [e for e in doc.modelspace() if e.dxftype() == dxf_type]
+
+
+def _make_applied(op_type: OpType, params: dict, handle: str = "H1") -> AppliedChange:
+    """Build a successful AppliedChange for revision-note tests."""
+    return AppliedChange(
+        operation=EditOperation(op_type=op_type, params=params),
+        success=True,
+        entity_handle=handle,
+    )
+
+
+# ===========================================================================
+# add_line
+# ===========================================================================
+
+
+class TestAddLineValidation:
+    def test_valid_params_pass(self, sample_context, rule_config):
+        cs = make_add_line(0, 0, 100, 0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_missing_start_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_LINE,
+                    params={"end": {"x": 100, "y": 0}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("start" in b.message.lower() for b in result.blockers)
+
+    def test_missing_end_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_LINE,
+                    params={"start": {"x": 0, "y": 0}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("end" in b.message.lower() for b in result.blockers)
+
+    def test_start_missing_x_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_LINE,
+                    params={"start": {"y": 0}, "end": {"x": 100, "y": 0}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_end_missing_y_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_LINE,
+                    params={"start": {"x": 0, "y": 0}, "end": {"x": 100}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_protected_layer_blocked(self, sample_context, rule_config):
+        cs = make_add_line(0, 0, 100, 0, layer="TITLE")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_non_protected_layer_valid(self, sample_context, rule_config):
+        cs = make_add_line(0, 0, 100, 0, layer="STRUCTURAL")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_empty_params_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[EditOperation(op_type=OpType.ADD_LINE, params={})],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+
+class TestAddLineEngine:
+    def test_apply_returns_success_and_handle(self, sample_dxf, tmp_path):
+        cs = make_add_line(0, 0, 100, 50)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert results[0].entity_handle
+
+    def test_apply_creates_line_in_dxf(self, sample_dxf, tmp_path):
+        before = _count_type(sample_dxf, "LINE")
+        cs = make_add_line(10, 20, 80, 90)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert _count_type(output, "LINE") == before + 1
+
+    def test_apply_line_start_end_coords(self, sample_dxf, tmp_path):
+        cs = make_add_line(5.0, 7.0, 55.0, 77.0)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        lines = _get_entities_of_type(output, "LINE")
+        # The last LINE added is the new one — check its endpoints
+        found = any(
+            abs(ln.dxf.start.x - 5.0) < 0.01
+            and abs(ln.dxf.start.y - 7.0) < 0.01
+            and abs(ln.dxf.end.x - 55.0) < 0.01
+            and abs(ln.dxf.end.y - 77.0) < 0.01
+            for ln in lines
+        )
+        assert found, "New line with expected start/end not found in output DXF"
+
+    def test_apply_line_layer_assignment(self, sample_dxf, tmp_path):
+        cs = make_add_line(0, 0, 50, 0, layer="NOTES")
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        lines = _get_entities_of_type(output, "LINE")
+        assert any(ln.dxf.layer == "NOTES" for ln in lines)
+
+    def test_apply_diagonal_line(self, sample_dxf, tmp_path):
+        cs = make_add_line(-10, -10, 110, 110)
+        _, results, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        lines = _get_entities_of_type(output, "LINE")
+        assert any(
+            abs(ln.dxf.start.x - (-10)) < 0.01 and abs(ln.dxf.end.x - 110) < 0.01 for ln in lines
+        )
+
+    def test_apply_zero_length_line(self, sample_dxf, tmp_path):
+        """A zero-length line is geometrically degenerate but should not crash."""
+        cs = make_add_line(25.0, 25.0, 25.0, 25.0)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+
+
+class TestAddLinePreview:
+    def test_description_mentions_add_line(self, sample_context):
+        cs = make_add_line(0, 0, 100, 0)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "Add line" in desc
+
+    def test_description_includes_start_coords(self, sample_context):
+        cs = make_add_line(10, 20, 90, 80)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "10" in desc and "20" in desc
+
+    def test_description_includes_end_coords(self, sample_context):
+        cs = make_add_line(0, 0, 42, 99)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "42" in desc and "99" in desc
+
+
+class TestAddLineRevisionNote:
+    def test_note_contains_added_line(self):
+        config = RevisionNoteConfig(revision_number=1)
+        change = _make_applied(
+            OpType.ADD_LINE,
+            {"start": {"x": 0, "y": 0}, "end": {"x": 100, "y": 0}},
+        )
+        note = generate_note_text([change], config)
+        assert note.startswith("REV 1")
+        assert "Added line" in note
+
+    def test_note_includes_coords(self):
+        config = RevisionNoteConfig(revision_number=2)
+        change = _make_applied(
+            OpType.ADD_LINE,
+            {"start": {"x": 5, "y": 10}, "end": {"x": 50, "y": 100}},
+        )
+        note = generate_note_text([change], config)
+        assert "5" in note and "10" in note
+
+
+class TestAddLineToolExecutor:
+    def test_queues_add_line_operation(self, executor):
+        result = executor.execute(
+            "add_line", {"start_x": 0, "start_y": 0, "end_x": 100, "end_y": 0}
+        )
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ADD_LINE
+        assert op.params["start"] == {"x": 0, "y": 0}
+        assert op.params["end"] == {"x": 100, "y": 0}
+
+    def test_protected_layer_blocked(self, executor):
+        result = executor.execute(
+            "add_line",
+            {"start_x": 0, "start_y": 0, "end_x": 100, "end_y": 0, "layer": "TITLE"},
+        )
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_editable_layer_queued(self, executor):
+        result = executor.execute(
+            "add_line",
+            {"start_x": 0, "start_y": 0, "end_x": 100, "end_y": 0, "layer": "STRUCTURAL"},
+        )
+        assert result["status"] == "queued"
+        assert executor.operations[0].params["layer"] == "STRUCTURAL"
+
+    def test_result_contains_start_end(self, executor):
+        result = executor.execute(
+            "add_line", {"start_x": 3, "start_y": 4, "end_x": 30, "end_y": 40}
+        )
+        assert result["start"] == {"x": 3, "y": 4}
+        assert result["end"] == {"x": 30, "y": 40}
+
+
+# ===========================================================================
+# add_polyline
+# ===========================================================================
+
+
+class TestAddPolylineValidation:
+    def test_valid_default_params_pass(self, sample_context, rule_config):
+        cs = make_add_polyline()
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_missing_points_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_POLYLINE,
+                    params={"closed": False},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("points" in b.message.lower() for b in result.blockers)
+
+    def test_single_point_blocked(self, sample_context, rule_config):
+        cs = make_add_polyline(points=[{"x": 0, "y": 0}])
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("at least 2" in b.message.lower() for b in result.blockers)
+
+    def test_empty_points_list_blocked(self, sample_context, rule_config):
+        cs = make_add_polyline(points=[])
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_point_missing_x_blocked(self, sample_context, rule_config):
+        cs = make_add_polyline(points=[{"y": 0}, {"x": 50, "y": 50}])
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("x" in b.message.lower() or "y" in b.message.lower() for b in result.blockers)
+
+    def test_two_points_valid(self, sample_context, rule_config):
+        cs = make_add_polyline(points=[{"x": 0, "y": 0}, {"x": 100, "y": 0}])
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_closed_polyline_valid(self, sample_context, rule_config):
+        cs = make_add_polyline(closed=True)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_protected_layer_blocked(self, sample_context, rule_config):
+        cs = make_add_polyline(layer="TITLEBLOCK")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_non_protected_layer_valid(self, sample_context, rule_config):
+        cs = make_add_polyline(layer="STRUCTURAL")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestAddPolylineEngine:
+    def test_apply_returns_success_and_handle(self, sample_dxf, tmp_path):
+        cs = make_add_polyline()
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert results[0].entity_handle
+
+    def test_apply_creates_lwpolyline_in_dxf(self, sample_dxf, tmp_path):
+        before = _count_type(sample_dxf, "LWPOLYLINE")
+        cs = make_add_polyline()
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert _count_type(output, "LWPOLYLINE") == before + 1
+
+    def test_apply_correct_point_count(self, sample_dxf, tmp_path):
+        pts = [{"x": i * 10, "y": 0} for i in range(6)]
+        cs = make_add_polyline(points=pts)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        polys = _get_entities_of_type(output, "LWPOLYLINE")
+        # Find the newly-added one (6 vertices)
+        assert any(len(list(p.vertices())) == 6 for p in polys)
+
+    def test_apply_closed_polyline_flag(self, sample_dxf, tmp_path):
+        cs = make_add_polyline(closed=True)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        polys = _get_entities_of_type(output, "LWPOLYLINE")
+        assert any(p.closed for p in polys)
+
+    def test_apply_open_polyline_flag(self, sample_dxf, tmp_path):
+        cs = make_add_polyline(closed=False)
+        _, results, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+
+    def test_apply_layer_assignment(self, sample_dxf, tmp_path):
+        cs = make_add_polyline(layer="NOTES")
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        polys = _get_entities_of_type(output, "LWPOLYLINE")
+        assert any(p.dxf.layer == "NOTES" for p in polys)
+
+    def test_apply_two_point_polyline(self, sample_dxf, tmp_path):
+        cs = make_add_polyline(points=[{"x": 0, "y": 0}, {"x": 100, "y": 100}])
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+
+
+class TestAddPolylinePreview:
+    def test_description_mentions_polyline(self, sample_context):
+        cs = make_add_polyline()
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "polyline" in preview.items[0].description.lower()
+
+    def test_description_includes_point_count(self, sample_context):
+        pts = [{"x": i, "y": 0} for i in range(5)]
+        cs = make_add_polyline(points=pts)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "5" in preview.items[0].description
+
+    def test_description_mentions_closed_when_true(self, sample_context):
+        cs = make_add_polyline(closed=True)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "closed" in preview.items[0].description.lower()
+
+    def test_description_no_closed_when_open(self, sample_context):
+        cs = make_add_polyline(closed=False)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        # Should not claim it's closed
+        desc = preview.items[0].description
+        assert "closed" not in desc.lower() or "Add polyline" in desc
+
+
+class TestAddPolylineRevisionNote:
+    def test_note_contains_added_polyline(self):
+        config = RevisionNoteConfig(revision_number=3)
+        change = _make_applied(
+            OpType.ADD_POLYLINE,
+            {"points": [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 50, "y": 50}], "closed": False},
+        )
+        note = generate_note_text([change], config)
+        assert note.startswith("REV 3")
+        assert "polyline" in note.lower()
+
+    def test_note_includes_point_count(self):
+        config = RevisionNoteConfig(revision_number=1)
+        pts = [{"x": i, "y": 0} for i in range(4)]
+        change = _make_applied(OpType.ADD_POLYLINE, {"points": pts, "closed": False})
+        note = generate_note_text([change], config)
+        assert "4" in note
+
+    def test_note_mentions_closed(self):
+        config = RevisionNoteConfig(revision_number=1)
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 25, "y": 50}]
+        change = _make_applied(OpType.ADD_POLYLINE, {"points": pts, "closed": True})
+        note = generate_note_text([change], config)
+        assert "closed" in note.lower()
+
+
+class TestAddPolylineToolExecutor:
+    def test_queues_add_polyline_operation(self, executor):
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 50, "y": 50}, {"x": 0, "y": 50}]
+        result = executor.execute("add_polyline", {"points": pts, "closed": False})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ADD_POLYLINE
+        assert op.params["points"] == pts
+        assert op.params["closed"] is False
+
+    def test_queues_closed_polyline(self, executor):
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 25, "y": 50}]
+        result = executor.execute("add_polyline", {"points": pts, "closed": True})
+        assert result["status"] == "queued"
+        assert executor.operations[0].params["closed"] is True
+
+    def test_protected_layer_blocked(self, executor):
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}]
+        result = executor.execute("add_polyline", {"points": pts, "layer": "SEAL"})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_result_includes_point_count(self, executor):
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 25, "y": 50}]
+        result = executor.execute("add_polyline", {"points": pts})
+        assert result["point_count"] == 3
+
+
+# ===========================================================================
+# add_circle
+# ===========================================================================
+
+
+class TestAddCircleValidation:
+    def test_valid_params_pass(self, sample_context, rule_config):
+        cs = make_add_circle(50, 50, 10)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_missing_center_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_CIRCLE,
+                    params={"radius": 10},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("center" in b.message.lower() for b in result.blockers)
+
+    def test_missing_radius_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_CIRCLE,
+                    params={"center": {"x": 50, "y": 50}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("radius" in b.message.lower() for b in result.blockers)
+
+    def test_zero_radius_blocked(self, sample_context, rule_config):
+        cs = make_add_circle(50, 50, radius=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("positive" in b.message.lower() for b in result.blockers)
+
+    def test_negative_radius_blocked(self, sample_context, rule_config):
+        cs = make_add_circle(50, 50, radius=-5)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("positive" in b.message.lower() for b in result.blockers)
+
+    def test_center_missing_x_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_CIRCLE,
+                    params={"center": {"y": 50}, "radius": 10},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_protected_layer_blocked(self, sample_context, rule_config):
+        cs = make_add_circle(50, 50, 10, layer="REVISION")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_editable_layer_valid(self, sample_context, rule_config):
+        cs = make_add_circle(50, 50, 10, layer="NOTES")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_fractional_radius_valid(self, sample_context, rule_config):
+        cs = make_add_circle(0, 0, radius=0.001)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestAddCircleEngine:
+    def test_apply_returns_success_and_handle(self, sample_dxf, tmp_path):
+        cs = make_add_circle(50, 50, 10)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert results[0].entity_handle
+
+    def test_apply_creates_circle_in_dxf(self, sample_dxf, tmp_path):
+        before = _count_type(sample_dxf, "CIRCLE")
+        cs = make_add_circle(30, 30, 15)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert _count_type(output, "CIRCLE") == before + 1
+
+    def test_apply_correct_center(self, sample_dxf, tmp_path):
+        cs = make_add_circle(cx=77.0, cy=33.0, radius=5)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        circles = _get_entities_of_type(output, "CIRCLE")
+        assert any(
+            abs(c.dxf.center.x - 77.0) < 0.01 and abs(c.dxf.center.y - 33.0) < 0.01 for c in circles
+        )
+
+    def test_apply_correct_radius(self, sample_dxf, tmp_path):
+        cs = make_add_circle(50, 50, radius=12.5)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        circles = _get_entities_of_type(output, "CIRCLE")
+        assert any(abs(c.dxf.radius - 12.5) < 0.001 for c in circles)
+
+    def test_apply_layer_assignment(self, sample_dxf, tmp_path):
+        cs = make_add_circle(50, 50, 10, layer="STRUCTURAL")
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        circles = _get_entities_of_type(output, "CIRCLE")
+        assert any(c.dxf.layer == "STRUCTURAL" for c in circles)
+
+    def test_apply_large_radius(self, sample_dxf, tmp_path):
+        cs = make_add_circle(0, 0, radius=10000)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+
+
+class TestAddCirclePreview:
+    def test_description_mentions_add_circle(self, sample_context):
+        cs = make_add_circle(50, 50, 10)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "Add circle" in preview.items[0].description
+
+    def test_description_includes_center(self, sample_context):
+        cs = make_add_circle(cx=30, cy=70, radius=5)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "30" in desc and "70" in desc
+
+    def test_description_includes_radius(self, sample_context):
+        cs = make_add_circle(50, 50, radius=25)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "25" in preview.items[0].description
+
+
+class TestAddCircleRevisionNote:
+    def test_note_contains_added_circle(self):
+        config = RevisionNoteConfig(revision_number=4)
+        change = _make_applied(
+            OpType.ADD_CIRCLE,
+            {"center": {"x": 50, "y": 50}, "radius": 10},
+        )
+        note = generate_note_text([change], config)
+        assert note.startswith("REV 4")
+        assert "circle" in note.lower()
+
+    def test_note_includes_center_coords(self):
+        config = RevisionNoteConfig(revision_number=1)
+        change = _make_applied(
+            OpType.ADD_CIRCLE,
+            {"center": {"x": 20, "y": 40}, "radius": 5},
+        )
+        note = generate_note_text([change], config)
+        assert "20" in note and "40" in note
+
+    def test_note_includes_radius(self):
+        config = RevisionNoteConfig(revision_number=1)
+        change = _make_applied(
+            OpType.ADD_CIRCLE,
+            {"center": {"x": 0, "y": 0}, "radius": 99},
+        )
+        note = generate_note_text([change], config)
+        assert "99" in note
+
+
+class TestAddCircleToolExecutor:
+    def test_queues_add_circle_operation(self, executor):
+        result = executor.execute("add_circle", {"center_x": 50, "center_y": 50, "radius": 10})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ADD_CIRCLE
+        assert op.params["center"] == {"x": 50, "y": 50}
+        assert op.params["radius"] == 10
+
+    def test_protected_layer_blocked(self, executor):
+        result = executor.execute(
+            "add_circle",
+            {"center_x": 50, "center_y": 50, "radius": 10, "layer": "TITLE"},
+        )
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_result_contains_center_and_radius(self, executor):
+        result = executor.execute("add_circle", {"center_x": 30, "center_y": 60, "radius": 7})
+        assert result["center"] == {"x": 30, "y": 60}
+        assert result["radius"] == 7
+
+    def test_editable_layer_queued(self, executor):
+        result = executor.execute(
+            "add_circle", {"center_x": 0, "center_y": 0, "radius": 5, "layer": "NOTES"}
+        )
+        assert result["status"] == "queued"
+        assert executor.operations[0].params["layer"] == "NOTES"
+
+
+# ===========================================================================
+# add_arc
+# ===========================================================================
+
+
+class TestAddArcValidation:
+    def test_valid_params_pass(self, sample_context, rule_config):
+        cs = make_add_arc(50, 50, 10, start_angle=0, end_angle=90)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_missing_center_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_ARC,
+                    params={"radius": 10, "start_angle": 0, "end_angle": 90},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("center" in b.message.lower() for b in result.blockers)
+
+    def test_missing_radius_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_ARC,
+                    params={"center": {"x": 50, "y": 50}, "start_angle": 0, "end_angle": 90},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("radius" in b.message.lower() for b in result.blockers)
+
+    def test_zero_radius_blocked(self, sample_context, rule_config):
+        cs = make_add_arc(50, 50, radius=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_negative_radius_blocked(self, sample_context, rule_config):
+        cs = make_add_arc(50, 50, radius=-1)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_missing_start_angle_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_ARC,
+                    params={"center": {"x": 50, "y": 50}, "radius": 10, "end_angle": 90},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("start_angle" in b.message.lower() for b in result.blockers)
+
+    def test_missing_end_angle_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_ARC,
+                    params={"center": {"x": 50, "y": 50}, "radius": 10, "start_angle": 0},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("end_angle" in b.message.lower() for b in result.blockers)
+
+    def test_protected_layer_blocked(self, sample_context, rule_config):
+        cs = make_add_arc(50, 50, 10, layer="SEAL")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_full_circle_angles_valid(self, sample_context, rule_config):
+        cs = make_add_arc(0, 0, 10, start_angle=0, end_angle=360)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_reversed_angles_valid(self, sample_context, rule_config):
+        """DXF arcs support start > end (wraps around); validator should not block this."""
+        cs = make_add_arc(0, 0, 10, start_angle=270, end_angle=90)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestAddArcEngine:
+    def test_apply_returns_success_and_handle(self, sample_dxf, tmp_path):
+        cs = make_add_arc(50, 50, 10, start_angle=0, end_angle=90)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert results[0].entity_handle
+
+    def test_apply_creates_arc_in_dxf(self, sample_dxf, tmp_path):
+        before = _count_type(sample_dxf, "ARC")
+        cs = make_add_arc(25, 25, 8)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert _count_type(output, "ARC") == before + 1
+
+    def test_apply_correct_center(self, sample_dxf, tmp_path):
+        cs = make_add_arc(cx=42.0, cy=13.0, radius=5, start_angle=30, end_angle=120)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        arcs = _get_entities_of_type(output, "ARC")
+        assert any(
+            abs(a.dxf.center.x - 42.0) < 0.01 and abs(a.dxf.center.y - 13.0) < 0.01 for a in arcs
+        )
+
+    def test_apply_correct_radius(self, sample_dxf, tmp_path):
+        cs = make_add_arc(50, 50, radius=17.5, start_angle=0, end_angle=180)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        arcs = _get_entities_of_type(output, "ARC")
+        assert any(abs(a.dxf.radius - 17.5) < 0.001 for a in arcs)
+
+    def test_apply_correct_angles(self, sample_dxf, tmp_path):
+        cs = make_add_arc(0, 0, 10, start_angle=45.0, end_angle=135.0)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        arcs = _get_entities_of_type(output, "ARC")
+        assert any(
+            abs(a.dxf.start_angle - 45.0) < 0.01 and abs(a.dxf.end_angle - 135.0) < 0.01
+            for a in arcs
+        )
+
+    def test_apply_layer_assignment(self, sample_dxf, tmp_path):
+        cs = make_add_arc(50, 50, 10, layer="NOTES")
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        arcs = _get_entities_of_type(output, "ARC")
+        assert any(a.dxf.layer == "NOTES" for a in arcs)
+
+    def test_apply_semicircle(self, sample_dxf, tmp_path):
+        cs = make_add_arc(0, 0, 20, start_angle=0, end_angle=180)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+
+
+class TestAddArcPreview:
+    def test_description_mentions_add_arc(self, sample_context):
+        cs = make_add_arc(50, 50, 10)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "Add arc" in preview.items[0].description
+
+    def test_description_includes_center(self, sample_context):
+        cs = make_add_arc(cx=11, cy=22, radius=5)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "11" in desc and "22" in desc
+
+    def test_description_includes_radius(self, sample_context):
+        cs = make_add_arc(0, 0, radius=33)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "33" in preview.items[0].description
+
+    def test_description_includes_angles(self, sample_context):
+        cs = make_add_arc(0, 0, 10, start_angle=15, end_angle=75)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "15" in desc and "75" in desc
+
+
+class TestAddArcRevisionNote:
+    def test_note_contains_added_arc(self):
+        config = RevisionNoteConfig(revision_number=5)
+        change = _make_applied(
+            OpType.ADD_ARC,
+            {"center": {"x": 50, "y": 50}, "radius": 10, "start_angle": 0, "end_angle": 90},
+        )
+        note = generate_note_text([change], config)
+        assert note.startswith("REV 5")
+        assert "arc" in note.lower()
+
+    def test_note_includes_center_coords(self):
+        config = RevisionNoteConfig(revision_number=1)
+        change = _make_applied(
+            OpType.ADD_ARC,
+            {"center": {"x": 15, "y": 25}, "radius": 8, "start_angle": 0, "end_angle": 180},
+        )
+        note = generate_note_text([change], config)
+        assert "15" in note and "25" in note
+
+
+class TestAddArcToolExecutor:
+    def test_queues_add_arc_operation(self, executor):
+        result = executor.execute(
+            "add_arc",
+            {"center_x": 50, "center_y": 50, "radius": 10, "start_angle": 0, "end_angle": 90},
+        )
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ADD_ARC
+        assert op.params["center"] == {"x": 50, "y": 50}
+        assert op.params["radius"] == 10
+        assert op.params["start_angle"] == 0
+        assert op.params["end_angle"] == 90
+
+    def test_protected_layer_blocked(self, executor):
+        result = executor.execute(
+            "add_arc",
+            {
+                "center_x": 50,
+                "center_y": 50,
+                "radius": 10,
+                "start_angle": 0,
+                "end_angle": 90,
+                "layer": "REVISION",
+            },
+        )
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_result_contains_center_and_radius(self, executor):
+        result = executor.execute(
+            "add_arc",
+            {"center_x": 10, "center_y": 20, "radius": 5, "start_angle": 45, "end_angle": 135},
+        )
+        assert result["center"] == {"x": 10, "y": 20}
+        assert result["radius"] == 5
+
+    def test_editable_layer_queued(self, executor):
+        result = executor.execute(
+            "add_arc",
+            {
+                "center_x": 0,
+                "center_y": 0,
+                "radius": 5,
+                "start_angle": 0,
+                "end_angle": 90,
+                "layer": "STRUCTURAL",
+            },
+        )
+        assert result["status"] == "queued"
+        assert executor.operations[0].params["layer"] == "STRUCTURAL"
+
+
+# ===========================================================================
+# add_text
+# ===========================================================================
+
+
+class TestAddTextValidation:
+    def test_valid_params_pass(self, sample_context, rule_config):
+        cs = make_add_text("NEW ANNOTATION", 10, 10)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_missing_text_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={"insert": {"x": 10, "y": 10}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("text" in b.message.lower() for b in result.blockers)
+
+    def test_non_string_text_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={"text": 42, "insert": {"x": 10, "y": 10}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("string" in b.message.lower() for b in result.blockers)
+
+    def test_missing_insert_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={"text": "hello"},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("insert" in b.message.lower() for b in result.blockers)
+
+    def test_insert_missing_x_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={"text": "hello", "insert": {"y": 10}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_insert_missing_y_blocked(self, sample_context, rule_config):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={"text": "hello", "insert": {"x": 10}},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_protected_layer_blocked(self, sample_context, rule_config):
+        cs = make_add_text("BLOCKED TEXT", 0, 0, layer="TITLE")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_editable_layer_valid(self, sample_context, rule_config):
+        cs = make_add_text("OK TEXT", 10, 10, layer="NOTES")
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_empty_string_text_valid(self, sample_context, rule_config):
+        """Empty string is still a string — validator should allow it."""
+        cs = make_add_text("", 0, 0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestAddTextEngine:
+    def test_apply_returns_success_and_handle(self, sample_dxf, tmp_path):
+        cs = make_add_text("HELLO", 10, 10)
+        _, results, _ = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert results[0].entity_handle
+
+    def test_apply_creates_text_entity(self, sample_dxf, tmp_path):
+        before = _count_type(sample_dxf, "TEXT")
+        cs = make_add_text("NEW TEXT", 5, 5)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert _count_type(output, "TEXT") == before + 1
+
+    def test_apply_text_content_preserved(self, sample_dxf, tmp_path):
+        cs = make_add_text("SPECIFIC LABEL", 10, 10)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        texts = _get_entities_of_type(output, "TEXT")
+        assert any(t.dxf.text == "SPECIFIC LABEL" for t in texts)
+
+    def test_apply_text_insert_position(self, sample_dxf, tmp_path):
+        cs = make_add_text("POS CHECK", 55.0, 77.0)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        texts = _get_entities_of_type(output, "TEXT")
+        assert any(
+            abs(t.dxf.insert.x - 55.0) < 0.01 and abs(t.dxf.insert.y - 77.0) < 0.01 for t in texts
+        )
+
+    def test_apply_text_height(self, sample_dxf, tmp_path):
+        cs = make_add_text("BIG TEXT", 0, 0, height=5.0)
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        texts = _get_entities_of_type(output, "TEXT")
+        assert any(abs(t.dxf.height - 5.0) < 0.001 for t in texts)
+
+    def test_apply_text_layer_assignment(self, sample_dxf, tmp_path):
+        cs = make_add_text("LAYERED", 10, 10, layer="NOTES")
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        texts = _get_entities_of_type(output, "TEXT")
+        assert any(t.dxf.layer == "NOTES" and t.dxf.text == "LAYERED" for t in texts)
+
+    def test_apply_mtext_type_creates_mtext(self, sample_dxf, tmp_path):
+        """text_type=MTEXT creates an MTEXT entity, not TEXT."""
+        before = _count_type(sample_dxf, "MTEXT")
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={
+                        "text": "MTEXT CONTENT",
+                        "insert": {"x": 20, "y": 20},
+                        "height": 3.0,
+                        "text_type": "MTEXT",
+                    },
+                )
+            ],
+        )
+        _, results, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        assert _count_type(output, "MTEXT") == before + 1
+
+    def test_apply_mtext_content_preserved(self, sample_dxf, tmp_path):
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ADD_TEXT,
+                    params={
+                        "text": "RICH TEXT HERE",
+                        "insert": {"x": 0, "y": 0},
+                        "height": 2.5,
+                        "text_type": "MTEXT",
+                    },
+                )
+            ],
+        )
+        _, _, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        mtexts = _get_entities_of_type(output, "MTEXT")
+        assert any("RICH TEXT HERE" in m.text for m in mtexts)
+
+    def test_apply_text_type_default_is_text(self, sample_dxf, tmp_path):
+        """When text_type is omitted, a TEXT entity is created (not MTEXT)."""
+        cs = make_add_text("DEFAULT TYPE", 10, 10)
+        _, results, output = _apply_and_save(sample_dxf, tmp_path, cs)
+        assert results[0].success
+        texts = _get_entities_of_type(output, "TEXT")
+        assert any(t.dxf.text == "DEFAULT TYPE" for t in texts)
+
+
+class TestAddTextPreview:
+    def test_description_mentions_add_text(self, sample_context):
+        cs = make_add_text("HELLO", 10, 10)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "Add text" in preview.items[0].description
+
+    def test_description_includes_text_content(self, sample_context):
+        cs = make_add_text("MY LABEL", 0, 0)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        assert "MY LABEL" in preview.items[0].description
+
+    def test_description_includes_insert_coords(self, sample_context):
+        cs = make_add_text("X", 30, 70)
+        preview = PreviewModel(cs, sample_context, ValidationResult())
+        desc = preview.items[0].description
+        assert "30" in desc and "70" in desc
+
+
+class TestAddTextRevisionNote:
+    def test_note_contains_added_text(self):
+        config = RevisionNoteConfig(revision_number=6)
+        change = _make_applied(
+            OpType.ADD_TEXT,
+            {"text": "NEW LABEL", "insert": {"x": 10, "y": 10}, "height": 2.5},
+        )
+        note = generate_note_text([change], config)
+        assert note.startswith("REV 6")
+        assert "Added text" in note
+
+    def test_note_includes_text_content(self):
+        config = RevisionNoteConfig(revision_number=1)
+        change = _make_applied(
+            OpType.ADD_TEXT,
+            {"text": "FOOTING NOTE", "insert": {"x": 0, "y": 0}, "height": 2.5},
+        )
+        note = generate_note_text([change], config)
+        assert "FOOTING NOTE" in note
+
+    def test_note_truncates_long_text(self):
+        config = RevisionNoteConfig(revision_number=1)
+        long_text = "A" * 50
+        change = _make_applied(
+            OpType.ADD_TEXT,
+            {"text": long_text, "insert": {"x": 0, "y": 0}, "height": 2.5},
+        )
+        note = generate_note_text([change], config)
+        # Note should be generated without crashing; long content truncated
+        assert "REV 1" in note
+        assert "Added text" in note
+
+
+class TestAddTextToolExecutor:
+    def test_queues_add_text_operation(self, executor):
+        result = executor.execute("add_text", {"text": "ANNOTATION", "x": 10, "y": 20})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ADD_TEXT
+        assert op.params["text"] == "ANNOTATION"
+        assert op.params["insert"] == {"x": 10, "y": 20}
+
+    def test_protected_layer_blocked(self, executor):
+        result = executor.execute(
+            "add_text",
+            {"text": "BLOCKED", "x": 10, "y": 10, "layer": "TITLEBLOCK"},
+        )
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_mtext_type_queued(self, executor):
+        result = executor.execute(
+            "add_text",
+            {"text": "RICH", "x": 0, "y": 0, "text_type": "MTEXT"},
+        )
+        assert result["status"] == "queued"
+        op = executor.operations[0]
+        assert op.params["text_type"] == "MTEXT"
+
+    def test_default_text_type_is_text(self, executor):
+        executor.execute("add_text", {"text": "PLAIN", "x": 0, "y": 0})
+        assert executor.operations[0].params["text_type"] == "TEXT"
+
+    def test_height_param_stored(self, executor):
+        executor.execute("add_text", {"text": "BIG", "x": 0, "y": 0, "height": 7.5})
+        assert executor.operations[0].params["height"] == 7.5
+
+    def test_default_height_applied(self, executor):
+        executor.execute("add_text", {"text": "DEFAULT H", "x": 0, "y": 0})
+        assert executor.operations[0].params["height"] == 2.5
+
+    def test_result_contains_text_and_position(self, executor):
+        result = executor.execute("add_text", {"text": "CHECK", "x": 11, "y": 22})
+        assert result["text"] == "CHECK"
+        assert result["x"] == 11
+        assert result["y"] == 22
+
+    def test_editable_layer_queued(self, executor):
+        result = executor.execute(
+            "add_text", {"text": "NOTES LAYER", "x": 0, "y": 0, "layer": "NOTES"}
+        )
+        assert result["status"] == "queued"
+        assert executor.operations[0].params["layer"] == "NOTES"
+
+
+# ===========================================================================
+# Cross-op / multi-operation tests
+# ===========================================================================
+
+
+class TestMultipleCreationOps:
+    """Verify multiple creation ops in one changeset all validate and apply correctly."""
+
+    def test_mixed_creation_ops_all_valid(self, sample_context, rule_config):
+        from cad_dxf_agent.models.ops_schema import EditOperation
+        from tests.helpers.changeset_factory import make_multi_op
+
+        cs = make_multi_op(
+            EditOperation(
+                op_type=OpType.ADD_LINE,
+                params={"start": {"x": 0, "y": 0}, "end": {"x": 100, "y": 0}},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_CIRCLE,
+                params={"center": {"x": 50, "y": 50}, "radius": 10},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_TEXT,
+                params={"text": "MULTI", "insert": {"x": 0, "y": 0}},
+            ),
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+
+    def test_mixed_ops_accumulate_in_executor(self, executor):
+        executor.execute("add_line", {"start_x": 0, "start_y": 0, "end_x": 50, "end_y": 0})
+        executor.execute("add_circle", {"center_x": 25, "center_y": 25, "radius": 5})
+        executor.execute(
+            "add_arc",
+            {"center_x": 0, "center_y": 0, "radius": 10, "start_angle": 0, "end_angle": 180},
+        )
+        pts = [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 25, "y": 50}]
+        executor.execute("add_polyline", {"points": pts})
+        executor.execute("add_text", {"text": "LABEL", "x": 0, "y": 0})
+        assert len(executor.operations) == 5
+
+    def test_protected_layer_in_multi_op_blocks_only_that_op(self, sample_context, rule_config):
+        from tests.helpers.changeset_factory import make_multi_op
+
+        cs = make_multi_op(
+            EditOperation(
+                op_type=OpType.ADD_LINE,
+                params={"start": {"x": 0, "y": 0}, "end": {"x": 100, "y": 0}, "layer": "TITLE"},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_CIRCLE,
+                params={"center": {"x": 50, "y": 50}, "radius": 5},
+            ),
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert len(result.blockers) == 1
+        assert "protected layer" in result.blockers[0].message.lower()
+
+    def test_all_five_creation_ops_apply_to_dxf(self, sample_dxf, tmp_path):
+        from tests.helpers.changeset_factory import make_multi_op
+
+        line_before = _count_type(sample_dxf, "LINE")
+        circle_before = _count_type(sample_dxf, "CIRCLE")
+        arc_before = _count_type(sample_dxf, "ARC")
+        poly_before = _count_type(sample_dxf, "LWPOLYLINE")
+        text_before = _count_type(sample_dxf, "TEXT")
+
+        cs = make_multi_op(
+            EditOperation(
+                op_type=OpType.ADD_LINE,
+                params={"start": {"x": 0, "y": 0}, "end": {"x": 10, "y": 0}},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_CIRCLE,
+                params={"center": {"x": 50, "y": 50}, "radius": 5},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_ARC,
+                params={
+                    "center": {"x": 0, "y": 0},
+                    "radius": 10,
+                    "start_angle": 0,
+                    "end_angle": 90,
+                },
+            ),
+            EditOperation(
+                op_type=OpType.ADD_POLYLINE,
+                params={"points": [{"x": 0, "y": 0}, {"x": 50, "y": 0}, {"x": 25, "y": 50}]},
+            ),
+            EditOperation(
+                op_type=OpType.ADD_TEXT,
+                params={"text": "ALL OPS", "insert": {"x": 0, "y": 0}},
+            ),
+        )
+        _, results, output = _apply_and_save(sample_dxf, tmp_path, cs)
+
+        assert all(r.success for r in results)
+        assert _count_type(output, "LINE") == line_before + 1
+        assert _count_type(output, "CIRCLE") == circle_before + 1
+        assert _count_type(output, "ARC") == arc_before + 1
+        assert _count_type(output, "LWPOLYLINE") == poly_before + 1
+        assert _count_type(output, "TEXT") == text_before + 1

--- a/tests/unit/test_v2_transforms.py
+++ b/tests/unit/test_v2_transforms.py
@@ -1,0 +1,1625 @@
+"""Comprehensive tests for V2 transform operations: rotate, copy, scale, mirror.
+
+Covers four test categories for each operation:
+  - Validation (params, types, protected layers, edge cases)
+  - Engine apply (success path, entity-not-found, geometric verification)
+  - Preview model (description strings)
+  - Revision notes (summary text)
+  - Tool executor (operation queuing, error paths)
+"""
+
+from __future__ import annotations
+
+import ezdxf
+import pytest
+
+from cad_dxf_agent.core.edit_engine import EditEngine
+from cad_dxf_agent.core.preview_model import PreviewModel
+from cad_dxf_agent.core.revision_notes import generate_note_text
+from cad_dxf_agent.core.validators import validate_changeset
+from cad_dxf_agent.llm.tool_executor import ToolExecutor
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.changes_schema import ValidationResult
+from cad_dxf_agent.models.config_schema import RevisionNoteConfig, RuleConfig
+from cad_dxf_agent.models.ops_schema import AppliedChange, ChangeSet, EditOperation, OpType
+from tests.helpers.changeset_factory import make_copy, make_mirror, make_rotate, make_scale
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_handle(context: DrawingContext, entity_type_str: str) -> str | None:
+    """Return the first handle of the given entity type from a DrawingContext."""
+    for e in context.entities:
+        if e.entity_type.value == entity_type_str:
+            return e.handle
+    return None
+
+
+def _get_editable_handle(context: DrawingContext, rule_config: RuleConfig) -> str:
+    """Return the handle of the first entity on a non-protected layer."""
+    protected_upper = {p.upper() for p in rule_config.protected_layers}
+    for e in context.entities:
+        if e.layer.upper() not in protected_upper:
+            return e.handle
+    pytest.fail("No editable entity found in context")
+
+
+def _get_protected_handle(context: DrawingContext) -> str:
+    """Return the handle of the first entity on the TITLE layer."""
+    for e in context.entities:
+        if e.layer.upper() == "TITLE":
+            return e.handle
+    pytest.fail("No TITLE-layer entity found in context")
+
+
+def _copy_for_editing(source_path, tmp_path, name: str = "work.dxf"):
+    """Copy sample DXF to a working path and return the path."""
+    from cad_dxf_agent.core.dxf_writer import copy_dxf_for_editing
+
+    return copy_dxf_for_editing(source_path, tmp_path / name)
+
+
+def _get_first_handle_in_file(dxf_path, dxf_type: str) -> str | None:
+    """Read a DXF file and return the handle of the first entity of the given type."""
+    doc = ezdxf.readfile(str(dxf_path))
+    for e in doc.modelspace():
+        if e.dxftype() == dxf_type:
+            return e.dxf.handle
+    return None
+
+
+def _get_line_start(dxf_path, handle: str) -> tuple[float, float]:
+    """Return (x, y) of a LINE entity's start point."""
+    doc = ezdxf.readfile(str(dxf_path))
+    entity = doc.entitydb.get(handle)
+    assert entity is not None and entity.dxftype() == "LINE"
+    return entity.dxf.start.x, entity.dxf.start.y
+
+
+# ---------------------------------------------------------------------------
+# Minimal ToolExecutor fixture (mirrors test_tool_executor.py pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_context() -> DrawingContext:
+    """Minimal DrawingContext with a LINE, TEXT, and a TITLE-protected TEXT."""
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=[
+            EntityRef(
+                handle="H1",
+                entity_type=EntityType.LINE,
+                layer="STRUCTURAL",
+                insert_point=Point2D(x=0, y=0),
+            ),
+            EntityRef(
+                handle="H2",
+                entity_type=EntityType.TEXT,
+                layer="NOTES",
+                insert_point=Point2D(x=10, y=10),
+                text_content="Label",
+            ),
+            EntityRef(
+                handle="H3",
+                entity_type=EntityType.TEXT,
+                layer="TITLE",
+                insert_point=Point2D(x=0, y=-20),
+                text_content="PROJECT TITLE",
+            ),
+        ],
+        layers=[
+            LayerRule(name="STRUCTURAL", protected=False),
+            LayerRule(name="NOTES", protected=False),
+            LayerRule(name="TITLE", protected=True),
+        ],
+        blocks=[],
+    )
+
+
+@pytest.fixture
+def executor(simple_context: DrawingContext) -> ToolExecutor:
+    return ToolExecutor(
+        simple_context, protected_layers=["TITLE", "TITLEBLOCK", "SEAL", "REVISION"]
+    )
+
+
+# ===========================================================================
+# ROTATE_ENTITY
+# ===========================================================================
+
+
+class TestRotateValidation:
+    def test_valid_rotate_passes(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_rotate(handle, angle=90.0, cx=0, cy=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+
+    def test_rotate_missing_angle_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle=handle,
+                    params={},  # angle is required
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("angle" in b.message.lower() for b in result.blockers)
+
+    def test_rotate_nan_angle_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle=handle,
+                    params={"angle": float("nan")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any(
+            "nan" in b.message.lower() or "inf" in b.message.lower() for b in result.blockers
+        )
+
+    def test_rotate_inf_angle_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle=handle,
+                    params={"angle": float("inf")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_rotate_protected_layer_blocked(self, sample_context, rule_config):
+        handle = _get_protected_handle(sample_context)
+        cs = make_rotate(handle, angle=45.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_rotate_nonexistent_handle_blocked(self, sample_context, rule_config):
+        cs = make_rotate("NONEXISTENT_HANDLE_XYZ", angle=90.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("not found" in b.message.lower() for b in result.blockers)
+
+    def test_rotate_zero_angle_valid(self, sample_context, rule_config):
+        """Zero-degree rotation is a no-op but still valid."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_rotate(handle, angle=0.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_rotate_full_circle_valid(self, sample_context, rule_config):
+        """360-degree rotation is valid."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_rotate(handle, angle=360.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_rotate_negative_angle_valid(self, sample_context, rule_config):
+        """Negative angles (clockwise) are permitted."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_rotate(handle, angle=-90.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestRotateEngine:
+    def test_rotate_line_returns_success(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = make_rotate(handle, angle=90.0, cx=0, cy=0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+        assert results[0].entity_handle == handle
+
+    def test_rotate_description_contains_handle(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = make_rotate(handle, angle=45.0)
+        results = engine.apply_changeset(cs)
+
+        assert handle in results[0].description
+
+    def test_rotate_90deg_moves_line_start(self, sample_dxf, tmp_path):
+        """Rotating a horizontal line 90° around origin should move start from (0,0) to (0,0)
+        but the end should go from (100,0) to ~(0,100)."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+        assert handle is not None
+
+        # Record original end point
+        doc_before = ezdxf.readfile(str(work))
+        line_before = doc_before.entitydb.get(handle)
+        end_x_before = line_before.dxf.end.x
+        end_y_before = line_before.dxf.end.y
+
+        engine = EditEngine(work)
+        cs = make_rotate(handle, angle=90.0, cx=0, cy=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "rotated.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        line_after = doc_after.entitydb.get(handle)
+
+        # After 90° CCW rotation around origin: (x,y) → (-y, x)
+        expected_end_x = -end_y_before
+        expected_end_y = end_x_before
+        assert abs(line_after.dxf.end.x - expected_end_x) < 0.01
+        assert abs(line_after.dxf.end.y - expected_end_y) < 0.01
+
+    def test_rotate_around_nonzero_center(self, sample_dxf, tmp_path):
+        """180° rotation around a non-origin center produces predictable coordinates."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        line_before = doc_before.entitydb.get(handle)
+        start_x = line_before.dxf.start.x
+        start_y = line_before.dxf.start.y
+
+        # Rotate 180° around (50, 0): point (x,y) → (100-x, -y)
+        engine = EditEngine(work)
+        cs = make_rotate(handle, angle=180.0, cx=50, cy=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "rotated_center.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        line_after = doc_after.entitydb.get(handle)
+
+        expected_x = 2 * 50 - start_x
+        expected_y = 2 * 0 - start_y
+        assert abs(line_after.dxf.start.x - expected_x) < 0.01
+        assert abs(line_after.dxf.start.y - expected_y) < 0.01
+
+    def test_rotate_entity_not_found_returns_failure(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        engine = EditEngine(work)
+        cs = make_rotate("DOES_NOT_EXIST_999", angle=90.0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is False
+        assert "not found" in results[0].description.lower()
+
+    def test_rotate_multiple_entity_types(self, sample_dxf, tmp_path):
+        """rotate_entity succeeds on LWPOLYLINE as well as LINE."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LWPOLYLINE")
+        assert handle is not None, "Fixture must include an LWPOLYLINE"
+
+        engine = EditEngine(work)
+        cs = make_rotate(handle, angle=45.0, cx=25, cy=25)
+        results = engine.apply_changeset(cs)
+        assert results[0].success is True
+
+
+class TestRotatePreview:
+    def test_preview_description_contains_angle(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_rotate(handle, angle=90.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Rotate" in desc
+        assert "90" in desc
+
+    def test_preview_description_includes_entity_label(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_rotate(handle, angle=45.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        # Should include entity type and layer in brackets
+        assert "LINE" in desc or "STRUCTURAL" in desc
+
+    def test_preview_rotate_no_entity_found(self, sample_context):
+        """Preview still renders a description even when the handle does not resolve."""
+        cs = make_rotate("GHOST_HANDLE", angle=30.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Rotate" in desc
+        assert "30" in desc
+
+
+class TestRotateRevisionNotes:
+    def test_rotate_note_contains_angle(self):
+        config = RevisionNoteConfig(revision_number=2)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle="A1",
+                    params={"angle": 90.0, "cx": 0, "cy": 0},
+                ),
+                success=True,
+                entity_handle="A1",
+                description="Rotated A1 by 90°",
+            )
+        ]
+        note = generate_note_text(changes, config)
+
+        assert note.startswith("REV 2")
+        assert "90" in note
+        assert "Rotated" in note
+
+    def test_rotate_note_prefix_and_angle(self):
+        config = RevisionNoteConfig(revision_number=7, prefix="REV")
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle="B2",
+                    params={"angle": 45.0},
+                ),
+                success=True,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "REV 7" in note
+        assert "45" in note
+
+    def test_rotate_failed_change_excluded_from_note(self):
+        config = RevisionNoteConfig(revision_number=1)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle="X1",
+                    params={"angle": 90.0},
+                ),
+                success=False,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "No successful" in note
+
+
+class TestRotateToolExecutor:
+    def test_rotate_queues_operation(self, executor):
+        result = executor.execute("rotate_entity", {"handle": "H1", "angle": 90.0})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.ROTATE_ENTITY
+        assert op.target_handle == "H1"
+        assert op.params["angle"] == 90.0
+
+    def test_rotate_includes_center_params(self, executor):
+        executor.execute("rotate_entity", {"handle": "H1", "angle": 45.0, "cx": 10, "cy": 20})
+        op = executor.operations[0]
+        assert op.params["cx"] == 10
+        assert op.params["cy"] == 20
+
+    def test_rotate_defaults_cx_cy_to_zero(self, executor):
+        executor.execute("rotate_entity", {"handle": "H1", "angle": 30.0})
+        op = executor.operations[0]
+        assert op.params["cx"] == 0
+        assert op.params["cy"] == 0
+
+    def test_rotate_protected_layer_returns_error(self, executor):
+        result = executor.execute("rotate_entity", {"handle": "H3", "angle": 90.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_rotate_entity_not_found_returns_error(self, executor):
+        result = executor.execute("rotate_entity", {"handle": "NONEXISTENT", "angle": 90.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+
+# ===========================================================================
+# COPY_ENTITY
+# ===========================================================================
+
+
+class TestCopyValidation:
+    def test_valid_copy_passes(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_copy(handle, dx=30.0, dy=0.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+
+    def test_copy_missing_dx_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle=handle,
+                    params={"dy": 0.0},  # dx missing
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("dx" in b.message.lower() for b in result.blockers)
+
+    def test_copy_missing_dy_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 10.0},  # dy missing
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_copy_nan_dx_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle=handle,
+                    params={"dx": float("nan"), "dy": 0.0},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any(
+            "nan" in b.message.lower() or "inf" in b.message.lower() for b in result.blockers
+        )
+
+    def test_copy_inf_dy_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle=handle,
+                    params={"dx": 0.0, "dy": float("inf")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_copy_protected_layer_blocked(self, sample_context, rule_config):
+        handle = _get_protected_handle(sample_context)
+        cs = make_copy(handle, dx=10.0, dy=0.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_copy_nonexistent_handle_blocked(self, sample_context, rule_config):
+        cs = make_copy("DOES_NOT_EXIST_ZZZ", dx=5.0, dy=5.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_copy_zero_offset_valid(self, sample_context, rule_config):
+        """Copying with (0, 0) offset is valid (creates overlapping copy)."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_copy(handle, dx=0.0, dy=0.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestCopyEngine:
+    def test_copy_returns_success(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=30.0, dy=0.0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+
+    def test_copy_returns_new_handle_different_from_original(self, sample_dxf, tmp_path):
+        """The copy must get a fresh handle distinct from the original."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=10.0, dy=0.0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+        assert results[0].entity_handle != handle
+
+    def test_copy_creates_additional_entity_in_dxf(self, sample_dxf, tmp_path):
+        """Saving and reloading the DXF shows one more LINE than before."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+
+        doc_before = ezdxf.readfile(str(work))
+        count_before = sum(1 for e in doc_before.modelspace() if e.dxftype() == "LINE")
+
+        handle = _get_first_handle_in_file(work, "LINE")
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=50.0, dy=0.0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "copied.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        count_after = sum(1 for e in doc_after.modelspace() if e.dxftype() == "LINE")
+
+        assert count_after == count_before + 1
+
+    def test_copy_places_new_entity_at_offset_position(self, sample_dxf, tmp_path):
+        """The copied LINE's start point should be original + (dx, dy)."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        orig_start_x = doc_before.entitydb.get(handle).dxf.start.x
+        orig_start_y = doc_before.entitydb.get(handle).dxf.start.y
+
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=25.0, dy=10.0)
+        results = engine.apply_changeset(cs)
+        new_handle = results[0].entity_handle
+
+        output = tmp_path / "copy_offset.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        new_entity = doc_after.entitydb.get(new_handle)
+        assert new_entity is not None
+
+        assert abs(new_entity.dxf.start.x - (orig_start_x + 25.0)) < 0.01
+        assert abs(new_entity.dxf.start.y - (orig_start_y + 10.0)) < 0.01
+
+    def test_copy_does_not_modify_original_entity(self, sample_dxf, tmp_path):
+        """The original entity's position should be unchanged after copy."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        orig_start_x = doc_before.entitydb.get(handle).dxf.start.x
+
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=50.0, dy=0.0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "copy_orig.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        orig_entity = doc_after.entitydb.get(handle)
+
+        assert abs(orig_entity.dxf.start.x - orig_start_x) < 0.01
+
+    def test_copy_entity_not_found_returns_failure(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        engine = EditEngine(work)
+        cs = make_copy("GHOST_HANDLE_999", dx=10.0, dy=0.0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is False
+        assert "not found" in results[0].description.lower()
+
+    def test_copy_lwpolyline_succeeds(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LWPOLYLINE")
+        assert handle is not None
+
+        engine = EditEngine(work)
+        cs = make_copy(handle, dx=100.0, dy=0.0)
+        results = engine.apply_changeset(cs)
+        assert results[0].success is True
+
+
+class TestCopyPreview:
+    def test_preview_description_contains_copy_and_offset(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_copy(handle, dx=30.0, dy=15.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Copy" in desc
+        assert "30" in desc
+        assert "15" in desc
+
+    def test_preview_copy_includes_entity_label(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_copy(handle, dx=10.0, dy=0.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "LINE" in desc or "STRUCTURAL" in desc
+
+    def test_preview_copy_unknown_handle_still_renders(self, sample_context):
+        cs = make_copy("UNKNOWN_HANDLE", dx=5.0, dy=5.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Copy" in desc
+
+
+class TestCopyRevisionNotes:
+    def test_copy_note_contains_offset(self):
+        config = RevisionNoteConfig(revision_number=1)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle="A1",
+                    params={"dx": 30.0, "dy": 0.0},
+                ),
+                success=True,
+                entity_handle="NEW_HANDLE",
+            )
+        ]
+        note = generate_note_text(changes, config)
+
+        assert note.startswith("REV 1")
+        assert "Copied" in note
+        assert "30" in note
+
+    def test_copy_note_shows_both_dx_dy(self):
+        config = RevisionNoteConfig(revision_number=3)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle="B2",
+                    params={"dx": 10.0, "dy": 20.0},
+                ),
+                success=True,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "10" in note
+        assert "20" in note
+
+
+class TestCopyToolExecutor:
+    def test_copy_queues_operation(self, executor):
+        result = executor.execute("copy_entity", {"handle": "H1", "dx": 30.0, "dy": 0.0})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.COPY_ENTITY
+        assert op.target_handle == "H1"
+        assert op.params["dx"] == 30.0
+        assert op.params["dy"] == 0.0
+
+    def test_copy_returns_handle_and_offset_in_result(self, executor):
+        result = executor.execute("copy_entity", {"handle": "H1", "dx": 10.0, "dy": 5.0})
+        assert result["handle"] == "H1"
+        assert result["dx"] == 10.0
+        assert result["dy"] == 5.0
+
+    def test_copy_protected_layer_returns_error(self, executor):
+        result = executor.execute("copy_entity", {"handle": "H3", "dx": 10.0, "dy": 0.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_copy_entity_not_found_returns_error(self, executor):
+        result = executor.execute("copy_entity", {"handle": "GHOST", "dx": 5.0, "dy": 5.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+
+# ===========================================================================
+# SCALE_ENTITY
+# ===========================================================================
+
+
+class TestScaleValidation:
+    def test_valid_scale_passes(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_scale(handle, factor=2.0, cx=0, cy=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+
+    def test_scale_missing_factor_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={},  # factor missing
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("factor" in b.message.lower() for b in result.blockers)
+
+    def test_scale_zero_factor_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={"factor": 0},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("zero" in b.message.lower() for b in result.blockers)
+
+    def test_scale_negative_factor_warns(self, sample_context, rule_config):
+        """Negative scale factor is allowed but generates a warning."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={"factor": -1.0},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid  # warning, not blocker
+        assert len(result.warnings) == 1
+        assert (
+            "mirror" in result.warnings[0].message.lower()
+            or "negative" in result.warnings[0].message.lower()
+        )
+
+    def test_scale_nan_factor_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={"factor": float("nan")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_scale_inf_factor_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={"factor": float("inf")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_scale_protected_layer_blocked(self, sample_context, rule_config):
+        handle = _get_protected_handle(sample_context)
+        cs = make_scale(handle, factor=2.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_scale_nonexistent_handle_blocked(self, sample_context, rule_config):
+        cs = make_scale("NO_SUCH_ENTITY", factor=2.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_scale_factor_one_valid(self, sample_context, rule_config):
+        """Factor of 1.0 is an identity scale — still valid."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_scale(handle, factor=1.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_scale_large_factor_valid(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_scale(handle, factor=1000.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestScaleEngine:
+    def test_scale_returns_success(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = make_scale(handle, factor=2.0, cx=0, cy=0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+        assert results[0].entity_handle == handle
+
+    def test_scale_2x_doubles_line_length(self, sample_dxf, tmp_path):
+        """Scaling a line by 2x from the origin doubles all coordinates."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        line_before = doc_before.entitydb.get(handle)
+        end_x_before = line_before.dxf.end.x
+        end_y_before = line_before.dxf.end.y
+
+        engine = EditEngine(work)
+        cs = make_scale(handle, factor=2.0, cx=0, cy=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "scaled2x.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        line_after = doc_after.entitydb.get(handle)
+
+        assert abs(line_after.dxf.end.x - 2 * end_x_before) < 0.01
+        assert abs(line_after.dxf.end.y - 2 * end_y_before) < 0.01
+
+    def test_scale_around_nonzero_center(self, sample_dxf, tmp_path):
+        """Scaling 2x around (50, 0): new_x = cx + factor*(old_x - cx)."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        line_before = doc_before.entitydb.get(handle)
+        end_x_before = line_before.dxf.end.x
+
+        engine = EditEngine(work)
+        cs = make_scale(handle, factor=2.0, cx=50, cy=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "scaled_center.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        line_after = doc_after.entitydb.get(handle)
+
+        expected_end_x = 50 + 2.0 * (end_x_before - 50)
+        assert abs(line_after.dxf.end.x - expected_end_x) < 0.01
+
+    def test_scale_half_shrinks_line(self, sample_dxf, tmp_path):
+        """Scaling 0.5x from origin halves all coordinates."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        end_x_before = doc_before.entitydb.get(handle).dxf.end.x
+
+        engine = EditEngine(work)
+        cs = make_scale(handle, factor=0.5, cx=0, cy=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "scaled_half.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        end_x_after = doc_after.entitydb.get(handle).dxf.end.x
+
+        assert abs(end_x_after - 0.5 * end_x_before) < 0.01
+
+    def test_scale_entity_not_found_returns_failure(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        engine = EditEngine(work)
+        cs = make_scale("MISSING_HANDLE_XYZ", factor=2.0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is False
+        assert "not found" in results[0].description.lower()
+
+
+class TestScalePreview:
+    def test_preview_description_contains_factor(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_scale(handle, factor=3.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Scale" in desc
+        assert "3.0" in desc
+
+    def test_preview_scale_includes_entity_label(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_scale(handle, factor=2.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "LINE" in desc or "STRUCTURAL" in desc
+
+    def test_preview_scale_description_shows_x_suffix(self, sample_context):
+        """The description should include 'x' (e.g. '2.0x') for readability."""
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_scale(handle, factor=2.0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "2.0x" in desc
+
+
+class TestScaleRevisionNotes:
+    def test_scale_note_contains_factor(self):
+        config = RevisionNoteConfig(revision_number=4)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle="A1",
+                    params={"factor": 2.5, "cx": 0, "cy": 0},
+                ),
+                success=True,
+                entity_handle="A1",
+            )
+        ]
+        note = generate_note_text(changes, config)
+
+        assert note.startswith("REV 4")
+        assert "Scaled" in note
+        assert "2.5" in note
+
+    def test_scale_note_includes_x_suffix(self):
+        config = RevisionNoteConfig(revision_number=1)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle="C3",
+                    params={"factor": 3.0},
+                ),
+                success=True,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "3.0x" in note
+
+    def test_scale_failed_not_included_in_note(self):
+        config = RevisionNoteConfig(revision_number=1)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle="Z9",
+                    params={"factor": 2.0},
+                ),
+                success=False,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "No successful" in note
+
+
+class TestScaleToolExecutor:
+    def test_scale_queues_operation(self, executor):
+        result = executor.execute("scale_entity", {"handle": "H1", "factor": 2.0})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.SCALE_ENTITY
+        assert op.target_handle == "H1"
+        assert op.params["factor"] == 2.0
+
+    def test_scale_includes_center_params(self, executor):
+        executor.execute("scale_entity", {"handle": "H1", "factor": 2.0, "cx": 50, "cy": 25})
+        op = executor.operations[0]
+        assert op.params["cx"] == 50
+        assert op.params["cy"] == 25
+
+    def test_scale_defaults_cx_cy_to_zero(self, executor):
+        executor.execute("scale_entity", {"handle": "H1", "factor": 1.5})
+        op = executor.operations[0]
+        assert op.params["cx"] == 0
+        assert op.params["cy"] == 0
+
+    def test_scale_returns_factor_in_result(self, executor):
+        result = executor.execute("scale_entity", {"handle": "H1", "factor": 4.0})
+        assert result["factor"] == 4.0
+
+    def test_scale_protected_layer_returns_error(self, executor):
+        result = executor.execute("scale_entity", {"handle": "H3", "factor": 2.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_scale_entity_not_found_returns_error(self, executor):
+        result = executor.execute("scale_entity", {"handle": "GHOST", "factor": 2.0})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+
+# ===========================================================================
+# MIRROR_ENTITY
+# ===========================================================================
+
+
+class TestMirrorValidation:
+    def test_valid_mirror_x_axis_passes(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_mirror(handle, axis="x", value=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+        assert len(result.blockers) == 0
+
+    def test_valid_mirror_y_axis_passes(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_mirror(handle, axis="y", value=50)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_mirror_missing_axis_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"value": 0},  # axis missing
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("axis" in b.message.lower() for b in result.blockers)
+
+    def test_mirror_invalid_axis_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "z", "value": 0},  # only 'x' or 'y' allowed
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("axis" in b.message.lower() for b in result.blockers)
+
+    def test_mirror_diagonal_axis_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "diagonal", "value": 0},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_mirror_nan_value_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "x", "value": float("nan")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any(
+            "nan" in b.message.lower() or "inf" in b.message.lower() for b in result.blockers
+        )
+
+    def test_mirror_inf_value_blocked(self, sample_context, rule_config):
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "y", "value": float("inf")},
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_mirror_protected_layer_blocked(self, sample_context, rule_config):
+        handle = _get_protected_handle(sample_context)
+        cs = make_mirror(handle, axis="x", value=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert any("protected layer" in b.message.lower() for b in result.blockers)
+
+    def test_mirror_nonexistent_handle_blocked(self, sample_context, rule_config):
+        cs = make_mirror("NO_SUCH_ENTITY_XYZ", axis="x", value=0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+
+    def test_mirror_value_optional_defaults_valid(self, sample_context, rule_config):
+        """Omitting value (defaults to 0) is valid."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "x"},  # value omitted
+                )
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_mirror_negative_value_valid(self, sample_context, rule_config):
+        """Negative axis value (e.g. mirror line at y=-10) is valid."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = make_mirror(handle, axis="x", value=-10.0)
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+
+class TestMirrorEngine:
+    def test_mirror_x_axis_returns_success(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = make_mirror(handle, axis="x", value=0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+        assert results[0].entity_handle == handle
+
+    def test_mirror_y_axis_returns_success(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        cs = make_mirror(handle, axis="y", value=50)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is True
+
+    def test_mirror_x_axis_flips_y_coordinate(self, sample_dxf, tmp_path):
+        """Mirror across x-axis (y=0): new_y = -old_y for a line starting at y=0."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+
+        # Use the LWPOLYLINE which has points at y=0 and y=50 in conftest
+        handle = _get_first_handle_in_file(work, "LWPOLYLINE")
+        assert handle is not None
+
+        doc_before = ezdxf.readfile(str(work))
+        poly_before = doc_before.entitydb.get(handle)
+        pts_before = list(poly_before.get_points())  # list of (x, y, ...) tuples
+        # Get the point with highest y to verify flip
+        max_y_before = max(pt[1] for pt in pts_before)
+
+        engine = EditEngine(work)
+        cs = make_mirror(handle, axis="x", value=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "mirror_x.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        poly_after = doc_after.entitydb.get(handle)
+        pts_after = list(poly_after.get_points())
+        min_y_after = min(pt[1] for pt in pts_after)
+
+        # max_y_before should become -max_y_before (the minimum after flip)
+        assert abs(min_y_after - (-max_y_before)) < 0.01
+
+    def test_mirror_y_axis_flips_x_coordinate(self, sample_dxf, tmp_path):
+        """Mirror across y-axis (x=0): new_x = -old_x."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        line_before = doc_before.entitydb.get(handle)
+        end_x_before = line_before.dxf.end.x
+
+        engine = EditEngine(work)
+        cs = make_mirror(handle, axis="y", value=0)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "mirror_y.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        line_after = doc_after.entitydb.get(handle)
+
+        # Mirror across y=0: new_x = -old_x
+        assert abs(line_after.dxf.end.x - (-end_x_before)) < 0.01
+
+    def test_mirror_x_axis_nonzero_value(self, sample_dxf, tmp_path):
+        """Mirror across y=25: new_y = 2*25 - old_y."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        doc_before = ezdxf.readfile(str(work))
+        start_y_before = doc_before.entitydb.get(handle).dxf.start.y
+
+        engine = EditEngine(work)
+        cs = make_mirror(handle, axis="x", value=25)
+        engine.apply_changeset(cs)
+
+        output = tmp_path / "mirror_x25.dxf"
+        engine.save(output)
+        doc_after = ezdxf.readfile(str(output))
+        start_y_after = doc_after.entitydb.get(handle).dxf.start.y
+
+        expected_y = 2 * 25 - start_y_before
+        assert abs(start_y_after - expected_y) < 0.01
+
+    def test_mirror_invalid_axis_in_engine_returns_failure(self, sample_dxf, tmp_path):
+        """If axis='z' slips past validation, engine returns success=False."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+        # Bypass the factory and set axis='z' directly
+        cs = ChangeSet(
+            prompt="test",
+            operations=[
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "z", "value": 0},
+                )
+            ],
+        )
+        results = engine.apply_changeset(cs)
+        assert results[0].success is False
+        assert (
+            "invalid" in results[0].description.lower() or "axis" in results[0].description.lower()
+        )
+
+    def test_mirror_entity_not_found_returns_failure(self, sample_dxf, tmp_path):
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        engine = EditEngine(work)
+        cs = make_mirror("MISSING_ENTITY_ZZZ", axis="x", value=0)
+        results = engine.apply_changeset(cs)
+
+        assert results[0].success is False
+        assert "not found" in results[0].description.lower()
+
+
+class TestMirrorPreview:
+    def test_preview_mirror_x_description(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_mirror(handle, axis="x", value=0)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Mirror" in desc
+        assert "x=0" in desc
+
+    def test_preview_mirror_y_description(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_mirror(handle, axis="y", value=50)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Mirror" in desc
+        assert "y=50" in desc
+
+    def test_preview_mirror_includes_entity_label(self, sample_context):
+        handle = _get_handle(sample_context, "LINE")
+        cs = make_mirror(handle, axis="x", value=10)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "LINE" in desc or "STRUCTURAL" in desc
+
+    def test_preview_mirror_unknown_handle_still_renders(self, sample_context):
+        cs = make_mirror("GHOST_HANDLE", axis="y", value=100)
+        validation = ValidationResult()
+        preview = PreviewModel(cs, sample_context, validation)
+
+        desc = preview.items[0].description
+        assert "Mirror" in desc
+
+
+class TestMirrorRevisionNotes:
+    def test_mirror_note_contains_axis_and_value(self):
+        config = RevisionNoteConfig(revision_number=5)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle="A1",
+                    params={"axis": "x", "value": 0},
+                ),
+                success=True,
+                entity_handle="A1",
+            )
+        ]
+        note = generate_note_text(changes, config)
+
+        assert note.startswith("REV 5")
+        assert "Mirrored" in note
+        assert "x=0" in note
+
+    def test_mirror_note_y_axis(self):
+        config = RevisionNoteConfig(revision_number=2)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle="B2",
+                    params={"axis": "y", "value": 50},
+                ),
+                success=True,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "y=50" in note
+
+    def test_mirror_failed_not_included_in_note(self):
+        config = RevisionNoteConfig(revision_number=1)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle="X1",
+                    params={"axis": "x", "value": 0},
+                ),
+                success=False,
+            )
+        ]
+        note = generate_note_text(changes, config)
+        assert "No successful" in note
+
+
+class TestMirrorToolExecutor:
+    def test_mirror_queues_operation(self, executor):
+        result = executor.execute("mirror_entity", {"handle": "H1", "axis": "x"})
+        assert result["status"] == "queued"
+        assert len(executor.operations) == 1
+        op = executor.operations[0]
+        assert op.op_type == OpType.MIRROR_ENTITY
+        assert op.target_handle == "H1"
+        assert op.params["axis"] == "x"
+
+    def test_mirror_includes_value_param(self, executor):
+        executor.execute("mirror_entity", {"handle": "H1", "axis": "y", "value": 50})
+        op = executor.operations[0]
+        assert op.params["value"] == 50
+
+    def test_mirror_default_value_zero(self, executor):
+        executor.execute("mirror_entity", {"handle": "H1", "axis": "x"})
+        op = executor.operations[0]
+        assert op.params["value"] == 0
+
+    def test_mirror_returns_handle_and_axis_in_result(self, executor):
+        result = executor.execute("mirror_entity", {"handle": "H1", "axis": "y"})
+        assert result["handle"] == "H1"
+        assert result["axis"] == "y"
+
+    def test_mirror_protected_layer_returns_error(self, executor):
+        result = executor.execute("mirror_entity", {"handle": "H3", "axis": "x"})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_mirror_entity_not_found_returns_error(self, executor):
+        result = executor.execute("mirror_entity", {"handle": "GHOST", "axis": "x"})
+        assert "error" in result
+        assert len(executor.operations) == 0
+
+    def test_mirror_y_axis_queues_correctly(self, executor):
+        result = executor.execute("mirror_entity", {"handle": "H2", "axis": "y", "value": 100})
+        assert result["status"] == "queued"
+        op = executor.operations[0]
+        assert op.params["axis"] == "y"
+        assert op.params["value"] == 100
+
+
+# ===========================================================================
+# Cross-operation integration tests
+# ===========================================================================
+
+
+class TestTransformCombinations:
+    """Tests that combine multiple V2 transforms in a single changeset."""
+
+    def test_rotate_then_copy_in_one_changeset(self, sample_context, rule_config):
+        """A changeset with rotate + copy on different entities passes validation."""
+        entities = [
+            e
+            for e in sample_context.entities
+            if e.layer.upper() not in {p.upper() for p in rule_config.protected_layers}
+        ]
+        assert len(entities) >= 2, "Fixture must have at least 2 editable entities"
+
+        cs = ChangeSet(
+            prompt="rotate then copy",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle=entities[0].handle,
+                    params={"angle": 45.0, "cx": 0, "cy": 0},
+                ),
+                EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle=entities[1].handle,
+                    params={"dx": 20.0, "dy": 0.0},
+                ),
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_scale_and_mirror_same_entity_passes_validation(self, sample_context, rule_config):
+        """Two ops on the same entity are both validated independently."""
+        handle = _get_editable_handle(sample_context, rule_config)
+        cs = ChangeSet(
+            prompt="scale then mirror",
+            operations=[
+                EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle=handle,
+                    params={"factor": 2.0, "cx": 0, "cy": 0},
+                ),
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=handle,
+                    params={"axis": "x", "value": 0},
+                ),
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert result.valid
+
+    def test_mixed_valid_and_protected_in_one_changeset(self, sample_context, rule_config):
+        """One valid op + one protected-layer op produces exactly one blocker."""
+        valid_handle = _get_editable_handle(sample_context, rule_config)
+        protected_handle = _get_protected_handle(sample_context)
+
+        cs = ChangeSet(
+            prompt="mixed",
+            operations=[
+                EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle=valid_handle,
+                    params={"angle": 90.0},
+                ),
+                EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle=protected_handle,
+                    params={"axis": "x", "value": 0},
+                ),
+            ],
+        )
+        result = validate_changeset(cs, sample_context, rule_config)
+        assert not result.valid
+        assert len(result.blockers) == 1
+        assert "protected layer" in result.blockers[0].message.lower()
+
+    def test_all_four_transforms_in_sequence(self, sample_dxf, tmp_path):
+        """Applying rotate → copy → scale → mirror in sequence all succeed."""
+        work = _copy_for_editing(sample_dxf, tmp_path)
+        handle = _get_first_handle_in_file(work, "LINE")
+
+        engine = EditEngine(work)
+
+        # Rotate the original
+        results_rotate = engine.apply_changeset(make_rotate(handle, angle=30.0))
+        assert results_rotate[0].success
+
+        # Copy the (now rotated) line
+        results_copy = engine.apply_changeset(make_copy(handle, dx=50.0, dy=0.0))
+        assert results_copy[0].success
+        copy_handle = results_copy[0].entity_handle
+
+        # Scale the copy
+        results_scale = engine.apply_changeset(make_scale(copy_handle, factor=0.5))
+        assert results_scale[0].success
+
+        # Mirror the copy
+        results_mirror = engine.apply_changeset(make_mirror(copy_handle, axis="y", value=0))
+        assert results_mirror[0].success
+
+        output = tmp_path / "all_transforms.dxf"
+        engine.save(output)
+        # Verify the output is a valid DXF
+        doc = ezdxf.readfile(str(output))
+        assert doc is not None
+
+    def test_tool_executor_accumulates_all_four_transform_ops(self, executor):
+        """All four transform tools can accumulate in a single executor session."""
+        executor.execute("rotate_entity", {"handle": "H1", "angle": 90.0})
+        executor.execute("copy_entity", {"handle": "H1", "dx": 10.0, "dy": 0.0})
+        executor.execute("scale_entity", {"handle": "H2", "factor": 2.0})
+        executor.execute("mirror_entity", {"handle": "H2", "axis": "x"})
+
+        assert len(executor.operations) == 4
+        op_types = [op.op_type for op in executor.operations]
+        assert OpType.ROTATE_ENTITY in op_types
+        assert OpType.COPY_ENTITY in op_types
+        assert OpType.SCALE_ENTITY in op_types
+        assert OpType.MIRROR_ENTITY in op_types
+
+    def test_revision_note_combines_all_four_transforms(self):
+        """Multiple V2 transform changes join in a single note with semicolons."""
+        config = RevisionNoteConfig(revision_number=9)
+        changes = [
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.ROTATE_ENTITY,
+                    target_handle="A1",
+                    params={"angle": 90.0},
+                ),
+                success=True,
+            ),
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.COPY_ENTITY,
+                    target_handle="B2",
+                    params={"dx": 20.0, "dy": 0.0},
+                ),
+                success=True,
+            ),
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.SCALE_ENTITY,
+                    target_handle="C3",
+                    params={"factor": 2.0},
+                ),
+                success=True,
+            ),
+            AppliedChange(
+                operation=EditOperation(
+                    op_type=OpType.MIRROR_ENTITY,
+                    target_handle="D4",
+                    params={"axis": "x", "value": 0},
+                ),
+                success=True,
+            ),
+        ]
+        note = generate_note_text(changes, config)
+        assert note.startswith("REV 9")
+        assert ";" in note  # Multiple summaries joined by semicolon


### PR DESCRIPTION
## Epic

EPIC-CAD-16 (Complete the drafting vocabulary), EPIC-CAD-17 (R-tree spatial index and entity cap removal), EPIC-CAD-18 (Entity creation — draw from scratch)

## Bead(s)

Phase 1 foundation work — removes the three blockers preventing professional use.

## Summary

- **R-tree spatial index**: Replace O(n) linear scan with R-tree for `nearest()` and `find_in_radius()` queries. Raise ENTITY_CAP from 500 → 5000 so real architectural drawings (2k-50k entities) work without truncation.
- **Transform operations**: Add `rotate_entity`, `copy_entity`, `scale_entity`, `mirror_entity` — the four missing drafting verbs. Each uses ezdxf Matrix44 transforms with configurable center/axis.
- **Entity creation**: Add `add_line`, `add_polyline`, `add_circle`, `add_arc`, `add_text` — users can now draw from scratch, not just rearrange existing entities.
- All 9 new operations follow the full pipeline: OpType enum → validator → edit engine → tool definition → tool executor → preview model → revision notes.

## Test plan

- [x] 375 new tests across 3 test files (test_v2_transforms.py, test_v2_creation.py, test_rtree_index.py)
- [x] Validation: missing params blocked, NaN/Inf blocked, protected layers blocked, zero scale blocked
- [x] Engine: save/reload DXF verification of geometric changes for every operation
- [x] R-tree consistency: brute-force vs R-tree results match on 1000-entity drawings
- [x] Entity cap: 1000 entities no longer truncated, 6000 entities correctly truncated at 5000
- [x] Tool executor: each tool queues correct EditOperation, protected layer returns error
- [x] Preview model + revision notes: correct descriptions for all 9 new op types
- [x] Full suite: 3,176 tests pass, 0 failures, 5 skipped (pre-existing)
- [x] Lint (`ruff check`) + format (`ruff format --check`) clean
- [x] mypy: only 2 pre-existing google.cloud.storage errors, no new type errors

## Docs

No new 000-docs — this is pure implementation. Architecture spec (060-PL-ROAD) to be created in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)