### PR TITLE
feat: EPIC-CAD-20 Intelligent batch operations

### DIFF
--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -553,6 +553,154 @@ ADD_TEXT_TOOL = {
 }
 
 # ---------------------------------------------------------------------------
+# Batch filter schema (shared across batch tools)
+# ---------------------------------------------------------------------------
+
+_BATCH_FILTER_PROPERTIES = {
+    "layer": {
+        "type": "string",
+        "description": "Filter: only entities on this layer",
+    },
+    "entity_type": {
+        "type": "string",
+        "description": (
+            "Filter: only entities of this type "
+            "(LINE, LWPOLYLINE, TEXT, MTEXT, INSERT, CIRCLE, ARC)"
+        ),
+    },
+    "text_contains": {
+        "type": "string",
+        "description": "Filter: only TEXT/MTEXT containing this substring",
+    },
+    "center_x": {
+        "type": "number",
+        "description": "Filter: center X for radius search",
+    },
+    "center_y": {
+        "type": "number",
+        "description": "Filter: center Y for radius search",
+    },
+    "radius": {
+        "type": "number",
+        "description": "Filter: search radius from (center_x, center_y)",
+    },
+}
+
+BATCH_MOVE = {
+    "name": "batch_move",
+    "description": (
+        "Move all entities matching the filter criteria by a displacement "
+        "vector (dx, dy). At least one filter (layer, entity_type, "
+        "text_contains, or radius) is required."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            **_BATCH_FILTER_PROPERTIES,
+            "dx": {
+                "type": "number",
+                "description": "Displacement in X direction (drawing units)",
+            },
+            "dy": {
+                "type": "number",
+                "description": "Displacement in Y direction (drawing units)",
+            },
+        },
+        "required": ["dx", "dy"],
+    },
+}
+
+BATCH_ROTATE = {
+    "name": "batch_rotate",
+    "description": (
+        "Rotate all entities matching the filter criteria by a given angle. "
+        "At least one filter is required."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            **_BATCH_FILTER_PROPERTIES,
+            "angle": {
+                "type": "number",
+                "description": "Rotation angle in degrees (counter-clockwise)",
+            },
+            "cx": {
+                "type": "number",
+                "description": "Rotation center X (default: each entity's own center)",
+            },
+            "cy": {
+                "type": "number",
+                "description": "Rotation center Y (default: each entity's own center)",
+            },
+        },
+        "required": ["angle"],
+    },
+}
+
+BATCH_SCALE = {
+    "name": "batch_scale",
+    "description": (
+        "Scale all entities matching the filter criteria by a uniform "
+        "factor. At least one filter is required."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            **_BATCH_FILTER_PROPERTIES,
+            "factor": {
+                "type": "number",
+                "description": "Scale factor (>1 enlarges, <1 shrinks)",
+            },
+            "cx": {
+                "type": "number",
+                "description": "Scale center X (default: each entity's own center)",
+            },
+            "cy": {
+                "type": "number",
+                "description": "Scale center Y (default: each entity's own center)",
+            },
+        },
+        "required": ["factor"],
+    },
+}
+
+BATCH_DELETE = {
+    "name": "batch_delete",
+    "description": (
+        "Delete all entities matching the filter criteria. "
+        "At least one filter is required. Use with caution."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": _BATCH_FILTER_PROPERTIES,
+        "required": [],
+    },
+}
+
+BATCH_EDIT_TEXT = {
+    "name": "batch_edit_text",
+    "description": (
+        "Find-and-replace text content across all TEXT/MTEXT entities "
+        "matching the filter criteria."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            **_BATCH_FILTER_PROPERTIES,
+            "find": {
+                "type": "string",
+                "description": "Text substring to find",
+            },
+            "replace": {
+                "type": "string",
+                "description": "Replacement text",
+            },
+        },
+        "required": ["find", "replace"],
+    },
+}
+
+# ---------------------------------------------------------------------------
 # Query tools (read-only) vs. edit tools (produce operations)
 # ---------------------------------------------------------------------------
 
@@ -574,6 +722,12 @@ EDIT_TOOLS = [
     ADD_CIRCLE,
     ADD_ARC,
     ADD_TEXT_TOOL,
+    # V3 batch operations
+    BATCH_MOVE,
+    BATCH_ROTATE,
+    BATCH_SCALE,
+    BATCH_DELETE,
+    BATCH_EDIT_TEXT,
 ]
 ALL_TOOLS = QUERY_TOOLS + EDIT_TOOLS
 

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -69,6 +69,12 @@ class ToolExecutor:
             "add_circle": self._add_circle,
             "add_arc": self._add_arc,
             "add_text": self._add_text,
+            # V3 batch tools
+            "batch_move": self._batch_move,
+            "batch_rotate": self._batch_rotate,
+            "batch_scale": self._batch_scale,
+            "batch_delete": self._batch_delete,
+            "batch_edit_text": self._batch_edit_text,
         }
 
         handler = dispatch.get(tool_name)
@@ -490,6 +496,231 @@ class ToolExecutor:
             "operation": "add_text",
             "text": args["text"],
             "insert": insert,
+        }
+
+
+    # --- V3 batch tools ---
+
+    def _resolve_batch_filter(
+        self, args: dict[str, Any]
+    ) -> list[EntityRef] | dict[str, Any]:
+        """Apply filter criteria and return matching entities.
+
+        Returns list[EntityRef] on success, or error dict if no filters
+        or no matches.
+        """
+        layer = args.get("layer")
+        entity_type = args.get("entity_type")
+        text_contains = args.get("text_contains")
+        center_x = args.get("center_x")
+        center_y = args.get("center_y")
+        radius = args.get("radius")
+
+        has_filter = any([
+            layer, entity_type, text_contains,
+            (center_x is not None and center_y is not None and radius),
+        ])
+        if not has_filter:
+            return {
+                "error": (
+                    "At least one filter is required (layer, entity_type, "
+                    "text_contains, or center_x/center_y/radius)"
+                )
+            }
+
+        # Spatial filter first if specified
+        if (
+            center_x is not None
+            and center_y is not None
+            and radius is not None
+        ):
+            candidates = self._index.find_in_radius(
+                float(center_x),
+                float(center_y),
+                float(radius),
+                entity_type=entity_type,
+                layer=layer,
+            )
+        else:
+            candidates = self._index.filter(
+                layer=layer, entity_type=entity_type
+            )
+
+        # Text filter
+        if text_contains:
+            text_matches = self._index.search_text(text_contains)
+            match_handles = {e.handle for e in text_matches}
+            candidates = [
+                e for e in candidates if e.handle in match_handles
+            ]
+
+        # Exclude protected layers
+        candidates = [
+            e for e in candidates
+            if e.layer.upper() not in self._protected
+        ]
+
+        if not candidates:
+            return {"error": "No matching entities found"}
+
+        return candidates
+
+    def _batch_move(self, args: dict[str, Any]) -> dict[str, Any]:
+        result = self._resolve_batch_filter(args)
+        if isinstance(result, dict):
+            return result
+
+        dx, dy = args["dx"], args["dy"]
+        for entity in result:
+            op = EditOperation(
+                op_type=OpType.MOVE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_space=entity.space,
+                params={"dx": dx, "dy": dy},
+            )
+            self._operations.append(op)
+
+        return {
+            "status": "queued",
+            "operation": "batch_move",
+            "matched": len(result),
+            "dx": dx,
+            "dy": dy,
+        }
+
+    def _batch_rotate(self, args: dict[str, Any]) -> dict[str, Any]:
+        result = self._resolve_batch_filter(args)
+        if isinstance(result, dict):
+            return result
+
+        angle = args["angle"]
+        # If cx/cy given, use shared center; otherwise each entity rotates
+        # around its own insert_point (cx=cy=0 means use entity center)
+        cx = args.get("cx")
+        cy = args.get("cy")
+
+        for entity in result:
+            params: dict[str, Any] = {"angle": angle}
+            if cx is not None and cy is not None:
+                params["cx"] = cx
+                params["cy"] = cy
+            elif entity.insert_point:
+                params["cx"] = entity.insert_point.x
+                params["cy"] = entity.insert_point.y
+            else:
+                params["cx"] = 0
+                params["cy"] = 0
+
+            op = EditOperation(
+                op_type=OpType.ROTATE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_space=entity.space,
+                params=params,
+            )
+            self._operations.append(op)
+
+        return {
+            "status": "queued",
+            "operation": "batch_rotate",
+            "matched": len(result),
+            "angle": angle,
+        }
+
+    def _batch_scale(self, args: dict[str, Any]) -> dict[str, Any]:
+        result = self._resolve_batch_filter(args)
+        if isinstance(result, dict):
+            return result
+
+        factor = args["factor"]
+        cx = args.get("cx")
+        cy = args.get("cy")
+
+        for entity in result:
+            params: dict[str, Any] = {"factor": factor}
+            if cx is not None and cy is not None:
+                params["cx"] = cx
+                params["cy"] = cy
+            elif entity.insert_point:
+                params["cx"] = entity.insert_point.x
+                params["cy"] = entity.insert_point.y
+            else:
+                params["cx"] = 0
+                params["cy"] = 0
+
+            op = EditOperation(
+                op_type=OpType.SCALE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_space=entity.space,
+                params=params,
+            )
+            self._operations.append(op)
+
+        return {
+            "status": "queued",
+            "operation": "batch_scale",
+            "matched": len(result),
+            "factor": factor,
+        }
+
+    def _batch_delete(self, args: dict[str, Any]) -> dict[str, Any]:
+        result = self._resolve_batch_filter(args)
+        if isinstance(result, dict):
+            return result
+
+        for entity in result:
+            op = EditOperation(
+                op_type=OpType.DELETE_ENTITY,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_space=entity.space,
+            )
+            self._operations.append(op)
+
+        return {
+            "status": "queued",
+            "operation": "batch_delete",
+            "matched": len(result),
+        }
+
+    def _batch_edit_text(self, args: dict[str, Any]) -> dict[str, Any]:
+        find_str = args["find"]
+        replace_str = args["replace"]
+
+        result = self._resolve_batch_filter(args)
+        if isinstance(result, dict):
+            return result
+
+        # Further filter: only TEXT/MTEXT with the find string
+        text_entities = [
+            e for e in result
+            if e.entity_type.value in ("TEXT", "MTEXT")
+            and e.text_content
+            and find_str in e.text_content
+        ]
+
+        if not text_entities:
+            return {"error": f"No text entities contain '{find_str}'"}
+
+        for entity in text_entities:
+            new_text = entity.text_content.replace(find_str, replace_str)
+            op = EditOperation(
+                op_type=OpType.EDIT_TEXT,
+                target_handle=entity.handle,
+                target_layer=entity.layer,
+                target_space=entity.space,
+                params={"new_text": new_text},
+            )
+            self._operations.append(op)
+
+        return {
+            "status": "queued",
+            "operation": "batch_edit_text",
+            "matched": len(text_entities),
+            "find": find_str,
+            "replace": replace_str,
         }
 
 

--- a/tests/unit/test_batch_operations.py
+++ b/tests/unit/test_batch_operations.py
@@ -1,0 +1,447 @@
+"""Tests for batch operations — bulk edit tools with filter criteria.
+
+Covers all 5 batch tools (batch_move, batch_rotate, batch_scale,
+batch_delete, batch_edit_text), filter resolution, protected layer
+exclusion, and error handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.tool_executor import ToolExecutor
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+    TextGeometry,
+)
+from cad_dxf_agent.models.ops_schema import OpType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ent(
+    handle: str,
+    etype: EntityType,
+    layer: str = "STRUCTURAL",
+    x: float = 0,
+    y: float = 0,
+    text: str | None = None,
+    text_height: float | None = None,
+) -> EntityRef:
+    point = Point2D(x=x, y=y)
+    tg = TextGeometry(height=text_height) if text_height else None
+    return EntityRef(
+        handle=handle,
+        entity_type=etype,
+        layer=layer,
+        insert_point=point,
+        text_content=text,
+        text_geometry=tg,
+    )
+
+
+def _ctx(entities: list[EntityRef], layers: list[str] | None = None):
+    layer_names = layers or list({e.layer for e in entities})
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities,
+        layers=[LayerRule(name=n) for n in layer_names],
+    )
+
+
+def _executor(ctx, protected=None):
+    return ToolExecutor(ctx, protected_layers=protected or [])
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mixed_drawing():
+    """Drawing with lines on STRUCTURAL, text on NOTES, inserts on MARKS."""
+    return _ctx([
+        _ent("L1", EntityType.LINE, "STRUCTURAL", 0, 0),
+        _ent("L2", EntityType.LINE, "STRUCTURAL", 10, 0),
+        _ent("L3", EntityType.LINE, "STRUCTURAL", 20, 0),
+        _ent("T1", EntityType.TEXT, "NOTES", 5, 5, text="Room A"),
+        _ent("T2", EntityType.TEXT, "NOTES", 15, 5, text="Room B"),
+        _ent("T3", EntityType.MTEXT, "NOTES", 25, 5, text="Room C"),
+        _ent("I1", EntityType.INSERT, "MARKS", 50, 50),
+        _ent("I2", EntityType.INSERT, "MARKS", 60, 50),
+    ])
+
+
+# ===================================================================
+# Tests: Filter resolution
+# ===================================================================
+
+
+class TestBatchFilterResolution:
+    """Test the _resolve_batch_filter shared method."""
+
+    def test_no_filter_returns_error(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {"dx": 5, "dy": 0})
+        assert "error" in result
+        assert "filter" in result["error"].lower()
+
+    def test_filter_by_layer(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 5, "dy": 0,
+        })
+        assert result["status"] == "queued"
+        assert result["matched"] == 3
+        assert len(exe.operations) == 3
+        for op in exe.operations:
+            assert op.op_type == OpType.MOVE_ENTITY
+
+    def test_filter_by_entity_type(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "entity_type": "TEXT", "dx": 0, "dy": 10,
+        })
+        assert result["matched"] == 2  # T1, T2 (not MTEXT T3)
+
+    def test_filter_by_text_contains(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "text_contains": "Room", "dx": 1, "dy": 1,
+        })
+        # All 3 text entities contain "Room"
+        assert result["matched"] == 3
+
+    def test_filter_by_radius(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "center_x": 55, "center_y": 50, "radius": 10,
+            "dx": 0, "dy": 5,
+        })
+        # I1 at (50,50) and I2 at (60,50) are within radius 10 of (55,50)
+        assert result["matched"] == 2
+
+    def test_combined_filters(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "layer": "NOTES", "entity_type": "TEXT",
+            "dx": 0, "dy": 5,
+        })
+        # Only TEXT on NOTES: T1, T2 (not T3 which is MTEXT)
+        assert result["matched"] == 2
+
+    def test_no_matches_returns_error(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "layer": "NONEXISTENT", "dx": 1, "dy": 1,
+        })
+        assert "error" in result
+        assert "No matching" in result["error"]
+
+    def test_protected_layers_excluded(self, mixed_drawing):
+        exe = _executor(mixed_drawing, protected=["TITLE", "NOTES"])
+        result = exe.execute("batch_move", {
+            "layer": "NOTES", "dx": 1, "dy": 1,
+        })
+        # All NOTES entities excluded by protection
+        assert "error" in result
+        assert "No matching" in result["error"]
+
+
+# ===================================================================
+# Tests: batch_move
+# ===================================================================
+
+
+class TestBatchMove:
+    """Test batch_move tool."""
+
+    def test_basic_batch_move(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 10, "dy": -5,
+        })
+        assert result["status"] == "queued"
+        assert result["matched"] == 3
+        assert result["dx"] == 10
+        assert result["dy"] == -5
+
+        for op in exe.operations:
+            assert op.op_type == OpType.MOVE_ENTITY
+            assert op.params["dx"] == 10
+            assert op.params["dy"] == -5
+
+    def test_batch_move_preserves_entity_metadata(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 1, "dy": 1,
+        })
+        handles = {op.target_handle for op in exe.operations}
+        assert handles == {"L1", "L2", "L3"}
+
+
+# ===================================================================
+# Tests: batch_rotate
+# ===================================================================
+
+
+class TestBatchRotate:
+    """Test batch_rotate tool."""
+
+    def test_basic_batch_rotate(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_rotate", {
+            "layer": "STRUCTURAL", "angle": 90,
+        })
+        assert result["matched"] == 3
+        assert result["angle"] == 90
+
+        for op in exe.operations:
+            assert op.op_type == OpType.ROTATE_ENTITY
+            assert op.params["angle"] == 90
+
+    def test_batch_rotate_with_shared_center(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_rotate", {
+            "layer": "STRUCTURAL", "angle": 45,
+            "cx": 100, "cy": 200,
+        })
+        for op in exe.operations:
+            assert op.params["cx"] == 100
+            assert op.params["cy"] == 200
+
+    def test_batch_rotate_uses_entity_center(self, mixed_drawing):
+        """Without cx/cy, each entity rotates around its own center."""
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_rotate", {
+            "layer": "STRUCTURAL", "angle": 30,
+        })
+        # L1 at (0,0), L2 at (10,0), L3 at (20,0)
+        centers = [(op.params["cx"], op.params["cy"]) for op in exe.operations]
+        assert (0, 0) in centers
+        assert (10, 0) in centers
+        assert (20, 0) in centers
+
+
+# ===================================================================
+# Tests: batch_scale
+# ===================================================================
+
+
+class TestBatchScale:
+    """Test batch_scale tool."""
+
+    def test_basic_batch_scale(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_scale", {
+            "layer": "MARKS", "factor": 2.0,
+        })
+        assert result["matched"] == 2
+        assert result["factor"] == 2.0
+
+        for op in exe.operations:
+            assert op.op_type == OpType.SCALE_ENTITY
+            assert op.params["factor"] == 2.0
+
+    def test_batch_scale_with_shared_center(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_scale", {
+            "layer": "MARKS", "factor": 0.5,
+            "cx": 55, "cy": 50,
+        })
+        for op in exe.operations:
+            assert op.params["cx"] == 55
+            assert op.params["cy"] == 50
+
+
+# ===================================================================
+# Tests: batch_delete
+# ===================================================================
+
+
+class TestBatchDelete:
+    """Test batch_delete tool."""
+
+    def test_basic_batch_delete(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_delete", {
+            "layer": "MARKS",
+        })
+        assert result["matched"] == 2
+        assert len(exe.operations) == 2
+        for op in exe.operations:
+            assert op.op_type == OpType.DELETE_ENTITY
+
+    def test_batch_delete_by_type(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_delete", {
+            "entity_type": "INSERT",
+        })
+        assert result["matched"] == 2
+
+    def test_batch_delete_requires_filter(self, mixed_drawing):
+        """batch_delete without any filter should fail."""
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_delete", {})
+        assert "error" in result
+
+
+# ===================================================================
+# Tests: batch_edit_text
+# ===================================================================
+
+
+class TestBatchEditText:
+    """Test batch_edit_text tool."""
+
+    def test_basic_find_replace(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_edit_text", {
+            "layer": "NOTES",
+            "find": "Room",
+            "replace": "Space",
+        })
+        assert result["matched"] == 3
+        assert result["find"] == "Room"
+        assert result["replace"] == "Space"
+
+        for op in exe.operations:
+            assert op.op_type == OpType.EDIT_TEXT
+            assert "Space" in op.params["new_text"]
+
+    def test_find_replace_partial_match(self, mixed_drawing):
+        """Only entities containing the find string get edited."""
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_edit_text", {
+            "text_contains": "Room A",
+            "find": "A",
+            "replace": "1",
+        })
+        assert result["matched"] == 1
+        assert exe.operations[0].params["new_text"] == "Room 1"
+
+    def test_find_not_found_returns_error(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_edit_text", {
+            "layer": "NOTES",
+            "find": "NONEXISTENT",
+            "replace": "X",
+        })
+        assert "error" in result
+
+    def test_non_text_entities_excluded(self, mixed_drawing):
+        """batch_edit_text should only affect TEXT/MTEXT, not LINE etc."""
+        exe = _executor(mixed_drawing)
+        result = exe.execute("batch_edit_text", {
+            "layer": "STRUCTURAL",
+            "find": "foo",
+            "replace": "bar",
+        })
+        # No TEXT/MTEXT on STRUCTURAL layer
+        assert "error" in result
+
+
+# ===================================================================
+# Tests: Tool definition presence
+# ===================================================================
+
+
+class TestBatchToolDefinitions:
+    """Verify batch tools are registered in tool_definitions."""
+
+    def test_batch_tools_in_edit_tools(self):
+        from cad_dxf_agent.llm.tool_definitions import EDIT_TOOLS
+
+        names = {t["name"] for t in EDIT_TOOLS}
+        assert "batch_move" in names
+        assert "batch_rotate" in names
+        assert "batch_scale" in names
+        assert "batch_delete" in names
+        assert "batch_edit_text" in names
+
+    def test_batch_tools_in_all_tools(self):
+        from cad_dxf_agent.llm.tool_definitions import ALL_TOOLS
+
+        names = {t["name"] for t in ALL_TOOLS}
+        assert "batch_move" in names
+        assert "batch_edit_text" in names
+
+    def test_batch_tools_are_edit_tools(self):
+        from cad_dxf_agent.llm.tool_definitions import is_edit_tool
+
+        assert is_edit_tool("batch_move")
+        assert is_edit_tool("batch_rotate")
+        assert is_edit_tool("batch_scale")
+        assert is_edit_tool("batch_delete")
+        assert is_edit_tool("batch_edit_text")
+
+    def test_batch_tool_schemas_valid(self):
+        from cad_dxf_agent.llm.tool_definitions import get_tool_by_name
+
+        for name in [
+            "batch_move", "batch_rotate", "batch_scale",
+            "batch_delete", "batch_edit_text",
+        ]:
+            tool = get_tool_by_name(name)
+            assert tool is not None, f"Tool {name} not found"
+            assert "parameters" in tool
+            assert tool["parameters"]["type"] == "object"
+
+
+# ===================================================================
+# Tests: Edge cases
+# ===================================================================
+
+
+class TestBatchEdgeCases:
+    """Test edge cases and interactions."""
+
+    def test_batch_ops_mix_with_individual_ops(self, mixed_drawing):
+        """Batch and individual ops accumulate in the same operation list."""
+        exe = _executor(mixed_drawing)
+
+        # Individual op first
+        exe.execute("move_entity", {"handle": "L1", "dx": 1, "dy": 1})
+
+        # Then batch op
+        exe.execute("batch_move", {
+            "layer": "NOTES", "dx": 5, "dy": 5,
+        })
+
+        # Should have 1 individual + 3 batch = 4 total
+        assert len(exe.operations) == 4
+
+    def test_multiple_batch_ops_accumulate(self, mixed_drawing):
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 1, "dy": 0,
+        })
+        exe.execute("batch_rotate", {
+            "layer": "NOTES", "angle": 45,
+        })
+        # 3 moves + 3 rotates = 6
+        assert len(exe.operations) == 6
+
+    def test_empty_drawing_returns_error(self):
+        ctx = _ctx([], layers=["STRUCTURAL"])
+        exe = _executor(ctx)
+        result = exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 1, "dy": 1,
+        })
+        assert "error" in result
+
+    def test_batch_operations_preserve_space(self, mixed_drawing):
+        """Operations should preserve the entity's space attribute."""
+        exe = _executor(mixed_drawing)
+        exe.execute("batch_move", {
+            "layer": "STRUCTURAL", "dx": 1, "dy": 0,
+        })
+        for op in exe.operations:
+            assert op.target_space == "Model"

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -76,6 +76,12 @@ class TestToolDefinitions:
             "add_circle",
             "add_arc",
             "add_text",
+            # V3 batch
+            "batch_move",
+            "batch_rotate",
+            "batch_scale",
+            "batch_delete",
+            "batch_edit_text",
         }
         assert names == expected
 


### PR DESCRIPTION
## Epic
EPIC-CAD-20: Intelligent batch operations

## Summary
- **5 batch tools** for bulk editing: `batch_move`, `batch_rotate`, `batch_scale`, `batch_delete`, `batch_edit_text`
- **Flexible filter criteria**: layer, entity_type, text_contains, spatial radius — combinable, at least one required
- **Reuses existing pipeline**: generates individual EditOperations per matched entity, flowing through validation → preview → apply → revision notes unchanged
- Protected layer exclusion automatic — no entity on a protected layer is ever included in batch results

## Test plan
- 30 unit tests covering filter resolution (8), batch_move (2), batch_rotate (3), batch_scale (2), batch_delete (3), batch_edit_text (4), tool definitions (4), edge cases (4)
- Full test suite passes (3308 tests, 0 failures excluding live/gui)
- Updated `test_tool_definitions.py` expected set to include 5 new batch tools

## Docs
- Tool definitions are self-documenting with parameter descriptions
- Architecture note: batch is tool-layer concern, not engine-layer — no new OpTypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)