### PR TITLE
feat: EPIC-CAD-29 stateless API v1 — agent-mode drawing intelligence

### DIFF
--- a/tests/web/test_api_v1.py
+++ b/tests/web/test_api_v1.py
@@ -1,0 +1,315 @@
+"""Tests for API v1 — stateless drawing intelligence endpoints.
+
+These endpoints accept DXF file uploads directly (no session) and
+return structured JSON. Designed for agent/CLI/CI consumption.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.helpers.dxf_factory import (
+    create_empty_dxf,
+    create_empty_layers_drawing,
+    create_structural_drawing,
+)
+
+
+@pytest.fixture()
+def client():
+    """Create a test client with dev mode (no auth)."""
+    import os
+
+    os.environ["CAD_WEB_DEV_MODE"] = "1"
+    from web.backend.main import app
+
+    return TestClient(app)
+
+
+def _upload(client: TestClient, path: str, dxf_path: Path):
+    """Helper to POST a DXF file to a v1 endpoint."""
+    with open(dxf_path, "rb") as f:
+        return client.post(path, files={"file": ("test.dxf", f)})
+
+
+# ===================================================================
+# POST /api/v1/analyze
+# ===================================================================
+
+
+class TestV1Analyze:
+    """Test the /api/v1/analyze endpoint."""
+
+    def test_analyze_structural(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/analyze", dxf)
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "entity_count" in data
+        assert data["entity_count"] > 0
+        assert "layer_count" in data
+        assert data["layer_count"] > 0
+        assert "layers" in data
+        assert isinstance(data["layers"], list)
+        assert "entity_types" in data
+        assert isinstance(data["entity_types"], dict)
+
+    def test_analyze_returns_layer_breakdown(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/analyze", dxf)
+        data = resp.json()
+
+        layer_names = {lr["name"] for lr in data["layers"]}
+        assert "STRUCTURAL" in layer_names
+        assert "NOTES" in layer_names
+
+        for layer in data["layers"]:
+            assert "entity_count" in layer
+            assert "name" in layer
+
+    def test_analyze_returns_type_distribution(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/analyze", dxf)
+        data = resp.json()
+
+        assert "LINE" in data["entity_types"] or "TEXT" in data["entity_types"]
+
+    def test_analyze_empty_drawing(self, client, tmp_path):
+        dxf = create_empty_dxf(tmp_path)
+        resp = _upload(client, "/api/v1/analyze", dxf)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entity_count"] == 0
+
+    def test_analyze_rejects_non_dxf(self, client, tmp_path):
+        txt_path = tmp_path / "test.txt"
+        txt_path.write_text("not a dxf")
+        with open(txt_path, "rb") as f:
+            resp = client.post(
+                "/api/v1/analyze",
+                files={"file": ("test.txt", f)},
+            )
+        assert resp.status_code == 400
+
+
+# ===================================================================
+# POST /api/v1/health
+# ===================================================================
+
+
+class TestV1Health:
+    """Test the /api/v1/health endpoint.
+
+    Health checker may not be available on all branches (EPIC-CAD-19).
+    Tests accept either 200 (available) or 501 (not yet merged).
+    """
+
+    @staticmethod
+    def _health_available():
+        try:
+            import cad_dxf_agent.core.health_checker  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    def test_health_structural(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/health", dxf)
+        if not self._health_available():
+            assert resp.status_code == 501
+            return
+
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "score" in data
+        assert 0 <= data["score"] <= 100
+        assert "summary" in data
+        assert "issues" in data
+        assert isinstance(data["issues"], list)
+        assert "checks_run" in data
+        assert len(data["checks_run"]) > 0
+
+    def test_health_issue_structure(self, client, tmp_path):
+        if not self._health_available():
+            pytest.skip("health_checker not available")
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/health", dxf)
+        data = resp.json()
+
+        for issue in data["issues"]:
+            assert "severity" in issue
+            assert "category" in issue
+            assert "title" in issue
+            assert "description" in issue
+            assert issue["severity"] in ("critical", "warning", "info")
+
+    def test_health_severity_counts(self, client, tmp_path):
+        if not self._health_available():
+            pytest.skip("health_checker not available")
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/health", dxf)
+        data = resp.json()
+
+        assert "critical_count" in data
+        assert "warning_count" in data
+        assert "info_count" in data
+        assert isinstance(data["critical_count"], int)
+
+    def test_health_empty_drawing(self, client, tmp_path):
+        if not self._health_available():
+            pytest.skip("health_checker not available")
+        dxf = create_empty_dxf(tmp_path)
+        resp = _upload(client, "/api/v1/health", dxf)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["score"] == 0  # empty drawing = 0 score
+
+    def test_health_drawing_with_orphan_layers(self, client, tmp_path):
+        """Drawing with empty layers should flag orphan layer issues."""
+        if not self._health_available():
+            pytest.skip("health_checker not available")
+        dxf = create_empty_layers_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/health", dxf)
+        data = resp.json()
+
+        layer_issues = [
+            i for i in data["issues"]
+            if i["category"] == "layer"
+        ]
+        assert len(layer_issues) > 0
+
+
+# ===================================================================
+# POST /api/v1/zones
+# ===================================================================
+
+
+class TestV1Zones:
+    """Test the /api/v1/zones endpoint."""
+
+    def test_zones_structural(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/zones", dxf)
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "zone_count" in data
+        assert isinstance(data["zone_count"], int)
+        assert "total_area" in data
+        assert "zones" in data
+        assert isinstance(data["zones"], list)
+
+    def test_zones_structure(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        resp = _upload(client, "/api/v1/zones", dxf)
+        data = resp.json()
+
+        for zone in data["zones"]:
+            assert "area" in zone
+            assert "centroid" in zone
+            assert "x" in zone["centroid"]
+            assert "y" in zone["centroid"]
+
+    def test_zones_empty_drawing(self, client, tmp_path):
+        dxf = create_empty_dxf(tmp_path)
+        resp = _upload(client, "/api/v1/zones", dxf)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["zone_count"] == 0
+        assert data["zones"] == []
+
+
+# ===================================================================
+# POST /api/v1/entities
+# ===================================================================
+
+
+class TestV1Entities:
+    """Test the /api/v1/entities endpoint."""
+
+    def test_entities_unfiltered(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities",
+                files={"file": ("test.dxf", f)},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total" in data
+        assert "entities" in data
+        assert data["total"] > 0
+
+    def test_entities_filter_by_layer(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities?layer=STRUCTURAL",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        for e in data["entities"]:
+            assert e["layer"] == "STRUCTURAL"
+
+    def test_entities_filter_by_type(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities?entity_type=TEXT",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        for e in data["entities"]:
+            assert e["type"] == "TEXT"
+
+    def test_entities_filter_by_text(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities?text_contains=FOOTING",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        assert data["total"] > 0
+        for e in data["entities"]:
+            assert "text" in e
+
+    def test_entities_with_limit(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities?limit=5",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        assert data["returned"] <= 5
+
+    def test_entities_entity_structure(self, client, tmp_path):
+        dxf = create_structural_drawing(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        for e in data["entities"]:
+            assert "handle" in e
+            assert "type" in e
+            assert "layer" in e
+
+    def test_entities_empty_drawing(self, client, tmp_path):
+        dxf = create_empty_dxf(tmp_path)
+        with open(dxf, "rb") as f:
+            resp = client.post(
+                "/api/v1/entities",
+                files={"file": ("test.dxf", f)},
+            )
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["entities"] == []

--- a/web/backend/api_v1.py
+++ b/web/backend/api_v1.py
@@ -1,0 +1,237 @@
+"""API v1 — stateless drawing intelligence endpoints for agent consumption.
+
+Every endpoint accepts a DXF file upload and returns structured JSON.
+No session, no auth (initially) — designed for CLI tools, CI/CD pipelines,
+MCP servers, and AI agents that need headless drawing analysis.
+
+Routes:
+    POST /api/v1/analyze   → DrawingContext summary + entity stats
+    POST /api/v1/health    → HealthReport (score, issues, evidence)
+    POST /api/v1/zones     → ZoneDetectionResult (rooms, areas)
+    POST /api/v1/entities  → Filtered entity search
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+
+from cad_dxf_agent.core.dxf_reader import load_dxf
+from cad_dxf_agent.core.entity_index import EntityIndex
+from cad_dxf_agent.otel import span as otel_span
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["v1-agent"])
+
+
+def _save_upload(file: UploadFile) -> Path:
+    """Save uploaded file to a temp path and return it."""
+    if not file.filename:
+        raise HTTPException(400, "No filename provided")
+
+    suffix = Path(file.filename).suffix.lower()
+    if suffix not in (".dxf", ".dwg"):
+        raise HTTPException(
+            400, f"Unsupported file type: {suffix}. Expected .dxf or .dwg"
+        )
+
+    with tempfile.NamedTemporaryFile(
+        suffix=suffix, delete=False, prefix="cadv1_"
+    ) as tmp:
+        data = file.file.read()
+        tmp.write(data)
+        tmp.flush()
+        return Path(tmp.name)
+
+
+def _load_context(file: UploadFile):
+    """Upload → save → load_dxf → DrawingContext."""
+    path = _save_upload(file)
+    try:
+        return load_dxf(str(path))
+    except Exception as e:
+        raise HTTPException(400, f"Failed to parse DXF: {e}") from None
+    finally:
+        path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/analyze
+# ---------------------------------------------------------------------------
+
+
+@router.post("/analyze")
+async def analyze(file: UploadFile = File(...)):
+    """Analyze a DXF file and return a structured drawing context summary.
+
+    Returns entity counts, layer breakdown, entity type distribution,
+    and drawing metadata.
+    """
+    with otel_span("api.v1.analyze"):
+        context = _load_context(file)
+        index = EntityIndex(context)
+
+        # Layer breakdown
+        layers = []
+        for layer in context.layers:
+            entities = index.get_by_layer(layer.name)
+            layers.append({
+                "name": layer.name,
+                "entity_count": len(entities),
+                "color": layer.color,
+            })
+
+        # Entity type distribution
+        type_counts: dict[str, int] = {}
+        for entity in context.entities:
+            t = entity.entity_type.value
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+        return {
+            "entity_count": context.entity_count,
+            "layer_count": len(context.layers),
+            "layers": layers,
+            "entity_types": type_counts,
+            "blocks": context.blocks,
+            "metadata": context.metadata,
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/health
+# ---------------------------------------------------------------------------
+
+
+@router.post("/health")
+async def health_check(file: UploadFile = File(...)):
+    """Run deterministic health checks on a DXF file.
+
+    Returns a scored health report with categorized issues and
+    entity-level evidence references.
+    """
+    with otel_span("api.v1.health"):
+        context = _load_context(file)
+
+        try:
+            from cad_dxf_agent.core.health_checker import check_drawing_health
+        except ImportError:
+            raise HTTPException(
+                501, "Health checker not available"
+            ) from None
+
+        report = check_drawing_health(context, include_zones=False)
+
+        return {
+            "score": report.score,
+            "summary": report.summary,
+            "issues": [issue.model_dump() for issue in report.issues],
+            "checks_run": report.checks_run,
+            "entity_count": report.entity_count,
+            "layer_count": report.layer_count,
+            "critical_count": report.critical_count,
+            "warning_count": report.warning_count,
+            "info_count": report.info_count,
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/zones
+# ---------------------------------------------------------------------------
+
+
+@router.post("/zones")
+async def detect_zones(file: UploadFile = File(...)):
+    """Detect enclosed zones/rooms in a DXF file.
+
+    Returns detected zones with area, perimeter, centroid, and
+    inferred room type when text labels are present.
+    """
+    with otel_span("api.v1.zones"):
+        context = _load_context(file)
+
+        from cad_dxf_agent.core.zone_detector import detect_zones as run_zones
+
+        result = run_zones(context)
+
+        zones = []
+        for z in result.zones:
+            zone_data: dict = {
+                "zone_id": z.zone_id,
+                "area": z.area,
+                "perimeter": z.perimeter,
+                "centroid": {"x": z.centroid.x, "y": z.centroid.y},
+                "boundary_points": len(z.boundary),
+                "inferred_type": z.inferred_type,
+                "confidence": z.confidence,
+            }
+            zones.append(zone_data)
+
+        return {
+            "zone_count": result.zone_count,
+            "total_area": result.total_area,
+            "zones": zones,
+        }
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/entities
+# ---------------------------------------------------------------------------
+
+
+@router.post("/entities")
+async def search_entities(
+    file: UploadFile = File(...),
+    layer: str | None = Query(None, description="Filter by layer name"),
+    entity_type: str | None = Query(
+        None, description="Filter by entity type (LINE, TEXT, etc.)"
+    ),
+    text_contains: str | None = Query(
+        None, description="Filter TEXT/MTEXT by content substring"
+    ),
+    limit: int = Query(100, ge=1, le=1000, description="Max entities to return"),
+):
+    """Search entities in a DXF file with optional filters.
+
+    Returns matching entities with handles, types, layers, positions,
+    and text content.
+    """
+    with otel_span("api.v1.entities"):
+        context = _load_context(file)
+        index = EntityIndex(context)
+
+        candidates = index.filter(layer=layer, entity_type=entity_type)
+
+        if text_contains:
+            text_matches = index.search_text(text_contains)
+            match_handles = {e.handle for e in text_matches}
+            candidates = [
+                e for e in candidates if e.handle in match_handles
+            ]
+
+        total = len(candidates)
+        entities = []
+        for e in candidates[:limit]:
+            d: dict = {
+                "handle": e.handle,
+                "type": e.entity_type.value,
+                "layer": e.layer,
+            }
+            if e.insert_point:
+                d["x"] = e.insert_point.x
+                d["y"] = e.insert_point.y
+            if e.text_content:
+                d["text"] = e.text_content
+            if e.block_name:
+                d["block_name"] = e.block_name
+            entities.append(d)
+
+        return {
+            "total": total,
+            "returned": len(entities),
+            "truncated": total > limit,
+            "entities": entities,
+        }

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -49,6 +49,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 
+from .api_v1 import router as v1_router
 from .auth import get_licensed_user
 from .session import SessionManager
 
@@ -93,6 +94,9 @@ ALLOWED_ORIGINS = [
 custom_origin = os.getenv("CAD_WEB_CORS_ORIGIN")
 if custom_origin:
     ALLOWED_ORIGINS.append(custom_origin)
+
+# Register API v1 router (stateless agent endpoints)
+app.include_router(v1_router)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Epic
EPIC-CAD-29: Agent mode — API-first + MCP server (Story 29a: core v1 endpoints)

## Summary
- Four stateless `/api/v1/*` endpoints for headless drawing intelligence: analyze, health, zones, entities
- Each accepts DXF upload, returns structured JSON — no session or auth required
- Designed for AI agents, CLI tools, CI/CD pipelines, and MCP server consumption
- Health endpoint gracefully returns 501 when health_checker module isn't merged yet

## Test plan
- 20 new tests in `tests/web/test_api_v1.py` (16 pass, 4 skip for missing health_checker)
- Full suite: 3,199 passed, 9 skipped
- Lint clean on all new files (`ruff check` passes)

## API Surface
| Endpoint | Method | Input | Output |
|----------|--------|-------|--------|
| `/api/v1/analyze` | POST | DXF file | Entity counts, layers, type distribution |
| `/api/v1/health` | POST | DXF file | Health score, issues, severity counts |
| `/api/v1/zones` | POST | DXF file | Detected zones with area, perimeter, centroid |
| `/api/v1/entities` | POST | DXF file + query params | Filtered entity search results |

## Files
- `web/backend/api_v1.py` (NEW) — APIRouter with 4 endpoints + upload helpers
- `web/backend/main.py` (MODIFIED) — router import + include
- `tests/web/test_api_v1.py` (NEW) — 20 tests covering all endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)