### PR TITLE
feat: EPIC-CAD-23 automated takeoff engine — count everything

### DIFF
--- a/src/cad_dxf_agent/core/takeoff_engine.py
+++ b/src/cad_dxf_agent/core/takeoff_engine.py
@@ -1,0 +1,206 @@
+"""Takeoff engine — automated quantity extraction from drawings.
+
+Orchestrates zone areas, symbol counts, linear measurements, and
+block counts into a structured TakeoffReport. Deterministic (no LLM).
+
+Public API:
+    generate_takeoff(context, zones=None) -> TakeoffReport
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+from cad_dxf_agent.core.zone_detector import detect_zones
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityRef, EntityType
+from cad_dxf_agent.models.takeoff_schema import (
+    TakeoffCategory,
+    TakeoffReport,
+    TakeoffReportItem,
+)
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+
+def generate_takeoff(
+    context: DrawingContext,
+    *,
+    zones: ZoneDetectionResult | None = None,
+) -> TakeoffReport:
+    """Generate a comprehensive takeoff report from a drawing.
+
+    Args:
+        context: Drawing context with entities.
+        zones: Pre-computed zone detection result (computed if None).
+
+    Returns:
+        TakeoffReport with categorized items.
+    """
+    if zones is None:
+        zones = detect_zones(context)
+
+    items: list[TakeoffReportItem] = []
+
+    # 1. Block/symbol counts
+    items.extend(_count_symbols(context))
+
+    # 2. Linear measurements (wall lengths, pipe runs, etc.)
+    items.extend(_measure_linear(context))
+
+    # 3. Zone areas (room square footage)
+    items.extend(_measure_zone_areas(zones))
+
+    # 4. Entity counts per layer
+    items.extend(_count_by_layer(context))
+
+    return TakeoffReport(
+        items=items,
+        total_items=len(items),
+        zone_count=zones.zone_count,
+        entity_count=context.entity_count,
+    )
+
+
+def _count_symbols(context: DrawingContext) -> list[TakeoffReportItem]:
+    """Count INSERT blocks by block name."""
+    items: list[TakeoffReportItem] = []
+    by_block: dict[str, list[EntityRef]] = {}
+
+    for entity in context.entities:
+        if entity.entity_type != EntityType.INSERT:
+            continue
+        if not entity.block_name:
+            continue
+        by_block.setdefault(entity.block_name, []).append(entity)
+
+    for block_name, entities in sorted(by_block.items()):
+        layers = sorted({e.layer for e in entities})
+        handles = [e.handle for e in entities]
+        items.append(TakeoffReportItem(
+            name=block_name,
+            category=TakeoffCategory.SYMBOL,
+            quantity=len(entities),
+            unit="ea",
+            source_layer=layers[0] if layers else None,
+            entity_handles=handles,
+            notes=f"Block inserts across {len(layers)} layer(s)",
+        ))
+
+    return items
+
+
+def _measure_linear(context: DrawingContext) -> list[TakeoffReportItem]:
+    """Measure total linear length of LINE and LWPOLYLINE entities per layer."""
+    items: list[TakeoffReportItem] = []
+    layer_lengths: dict[str, float] = {}
+    layer_handles: dict[str, list[str]] = {}
+
+    for entity in context.entities:
+        length = _entity_length(entity)
+        if length <= 0:
+            continue
+
+        layer_lengths[entity.layer] = layer_lengths.get(entity.layer, 0) + length
+        layer_handles.setdefault(entity.layer, []).append(entity.handle)
+
+    for layer, total_length in sorted(layer_lengths.items()):
+        handles = layer_handles.get(layer, [])
+        items.append(TakeoffReportItem(
+            name=f"Linear on '{layer}'",
+            category=TakeoffCategory.LINEAR,
+            quantity=round(total_length, 2),
+            unit="drawing_units",
+            source_layer=layer,
+            entity_handles=handles[:20],
+            notes=f"{len(handles)} segment(s)",
+        ))
+
+    return items
+
+
+def _measure_zone_areas(zones: ZoneDetectionResult) -> list[TakeoffReportItem]:
+    """Extract area measurements from detected zones."""
+    items: list[TakeoffReportItem] = []
+
+    for zone in zones.zones:
+        zone_type = zone.inferred_type or "unknown"
+        items.append(TakeoffReportItem(
+            name=f"{zone_type.replace('_', ' ').title()} ({zone.zone_id[:8]})",
+            category=TakeoffCategory.AREA,
+            quantity=round(zone.area, 2),
+            unit="sq_drawing_units",
+            zone_id=zone.zone_id,
+            entity_handles=zone.source_handles,
+            notes=f"Perimeter: {zone.perimeter:.1f}",
+        ))
+
+    return items
+
+
+def _count_by_layer(context: DrawingContext) -> list[TakeoffReportItem]:
+    """Count non-INSERT entities per layer."""
+    items: list[TakeoffReportItem] = []
+    layer_counts: Counter[str] = Counter()
+    layer_handles: dict[str, list[str]] = {}
+
+    for entity in context.entities:
+        if entity.entity_type == EntityType.INSERT:
+            continue
+        layer_counts[entity.layer] += 1
+        layer_handles.setdefault(entity.layer, []).append(entity.handle)
+
+    for layer, count in layer_counts.most_common():
+        if count < 2:
+            continue
+        handles = layer_handles.get(layer, [])
+        items.append(TakeoffReportItem(
+            name=f"Entities on '{layer}'",
+            category=TakeoffCategory.COUNT,
+            quantity=count,
+            unit="ea",
+            source_layer=layer,
+            entity_handles=handles[:20],
+        ))
+
+    return items
+
+
+def _entity_length(entity: EntityRef) -> float:
+    """Compute length of a LINE or LWPOLYLINE entity."""
+    if entity.entity_type == EntityType.LINE:
+        return _line_length(entity)
+    if entity.entity_type == EntityType.LWPOLYLINE:
+        return _polyline_length(entity)
+    return 0.0
+
+
+def _line_length(entity: EntityRef) -> float:
+    """Compute length of a LINE entity from start/end points."""
+    if entity.insert_point is None:
+        return 0.0
+    end = entity.attributes.get("end_point")
+    if end is None:
+        return 0.0
+    dx = end[0] - entity.insert_point.x
+    dy = end[1] - entity.insert_point.y
+    return math.sqrt(dx * dx + dy * dy)
+
+
+def _polyline_length(entity: EntityRef) -> float:
+    """Compute total length of a LWPOLYLINE from its vertices."""
+    vertices = entity.attributes.get("vertices", [])
+    if len(vertices) < 2:
+        return 0.0
+    total = 0.0
+    for i in range(len(vertices) - 1):
+        dx = vertices[i + 1][0] - vertices[i][0]
+        dy = vertices[i + 1][1] - vertices[i][1]
+        total += math.sqrt(dx * dx + dy * dy)
+
+    # Add closing segment if closed
+    if entity.attributes.get("is_closed", False) and len(vertices) >= 3:
+        dx = vertices[0][0] - vertices[-1][0]
+        dy = vertices[0][1] - vertices[-1][1]
+        total += math.sqrt(dx * dx + dy * dy)
+
+    return total

--- a/src/cad_dxf_agent/models/takeoff_schema.py
+++ b/src/cad_dxf_agent/models/takeoff_schema.py
@@ -1,0 +1,69 @@
+"""Takeoff report schemas — structured quantity takeoff outputs.
+
+Extends the design_ops TakeoffItem pattern with categorized items,
+zone-based area measurements, and linear measurements. Designed for
+export to CSV/spreadsheet formats.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class TakeoffCategory(StrEnum):
+    """Category of a takeoff item."""
+
+    SYMBOL = "symbol"
+    LINEAR = "linear"
+    AREA = "area"
+    COUNT = "count"
+    TEXT_DERIVED = "text_derived"
+
+
+class TakeoffReportItem(BaseModel):
+    """A single takeoff line item with category and evidence."""
+
+    name: str
+    category: TakeoffCategory
+    quantity: float
+    unit: str
+    source_layer: str | None = None
+    zone_id: str | None = None
+    entity_handles: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class TakeoffReport(BaseModel):
+    """Aggregate takeoff report with categorized items."""
+
+    items: list[TakeoffReportItem] = Field(default_factory=list)
+    total_items: int = 0
+    zone_count: int = 0
+    entity_count: int = 0
+
+    @property
+    def by_category(self) -> dict[str, list[TakeoffReportItem]]:
+        """Group items by category."""
+        result: dict[str, list[TakeoffReportItem]] = {}
+        for item in self.items:
+            result.setdefault(item.category.value, []).append(item)
+        return result
+
+    def to_csv_rows(self) -> list[list[str]]:
+        """Export items as CSV rows (header + data)."""
+        rows: list[list[str]] = [
+            ["Category", "Name", "Quantity", "Unit", "Layer", "Zone", "Notes"],
+        ]
+        for item in self.items:
+            rows.append([
+                item.category.value,
+                item.name,
+                f"{item.quantity:.2f}" if isinstance(item.quantity, float) else str(item.quantity),
+                item.unit,
+                item.source_layer or "",
+                item.zone_id or "",
+                item.notes,
+            ])
+        return rows

--- a/tests/unit/test_takeoff_engine.py
+++ b/tests/unit/test_takeoff_engine.py
@@ -1,0 +1,501 @@
+"""Tests for the takeoff engine (EPIC-CAD-23)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.takeoff_engine import (
+    _count_by_layer,
+    _count_symbols,
+    _entity_length,
+    _measure_linear,
+    _measure_zone_areas,
+    generate_takeoff,
+)
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.takeoff_schema import (
+    TakeoffCategory,
+    TakeoffReport,
+    TakeoffReportItem,
+)
+from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
+
+# --- Helpers ---
+
+
+def _make_entity(
+    handle: str,
+    entity_type: EntityType = EntityType.LINE,
+    layer: str = "0",
+    insert_point: Point2D | None = None,
+    block_name: str | None = None,
+    attributes: dict | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        space="Model",
+        insert_point=insert_point,
+        block_name=block_name,
+        attributes=attributes or {},
+    )
+
+
+def _make_context(
+    entities: list[EntityRef] | None = None,
+    layers: list[str] | None = None,
+) -> DrawingContext:
+    layer_rules = [LayerRule(name=n, color=1) for n in (layers or ["0"])]
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities or [],
+        layers=layer_rules,
+    )
+
+
+def _make_zone(
+    zone_id: str = "z1",
+    area: float = 200.0,
+    perimeter: float = 60.0,
+    inferred_type: str | None = "room",
+) -> DetectedZone:
+    return DetectedZone(
+        zone_id=zone_id,
+        boundary=[
+            Point2D(x=0, y=0),
+            Point2D(x=20, y=0),
+            Point2D(x=20, y=10),
+            Point2D(x=0, y=10),
+        ],
+        area=area,
+        perimeter=perimeter,
+        centroid=Point2D(x=10, y=5),
+        inferred_type=inferred_type,
+        source_handles=["h1"],
+    )
+
+
+def _make_zones_result(
+    zones: list[DetectedZone] | None = None,
+) -> ZoneDetectionResult:
+    zone_list = zones or []
+    return ZoneDetectionResult(
+        zones=zone_list,
+        total_area=sum(z.area for z in zone_list),
+        zone_count=len(zone_list),
+        confidence=0.8,
+    )
+
+
+# ===================================================================
+# Schema Tests
+# ===================================================================
+
+
+class TestTakeoffSchema:
+    """Test TakeoffReport and TakeoffReportItem models."""
+
+    def test_report_item_creation(self):
+        item = TakeoffReportItem(
+            name="DOOR_36",
+            category=TakeoffCategory.SYMBOL,
+            quantity=5,
+            unit="ea",
+            source_layer="DOORS",
+        )
+        assert item.name == "DOOR_36"
+        assert item.category == TakeoffCategory.SYMBOL
+        assert item.quantity == 5
+
+    def test_report_by_category(self):
+        report = TakeoffReport(
+            items=[
+                TakeoffReportItem(
+                    name="Door", category=TakeoffCategory.SYMBOL,
+                    quantity=3, unit="ea",
+                ),
+                TakeoffReportItem(
+                    name="Wall", category=TakeoffCategory.LINEAR,
+                    quantity=120.0, unit="ft",
+                ),
+                TakeoffReportItem(
+                    name="Door2", category=TakeoffCategory.SYMBOL,
+                    quantity=2, unit="ea",
+                ),
+            ],
+            total_items=3,
+        )
+        by_cat = report.by_category
+        assert len(by_cat["symbol"]) == 2
+        assert len(by_cat["linear"]) == 1
+
+    def test_report_csv_export(self):
+        report = TakeoffReport(
+            items=[
+                TakeoffReportItem(
+                    name="DOOR_36", category=TakeoffCategory.SYMBOL,
+                    quantity=5, unit="ea", source_layer="DOORS",
+                ),
+            ],
+            total_items=1,
+        )
+        rows = report.to_csv_rows()
+        assert len(rows) == 2  # header + 1 data row
+        assert rows[0][0] == "Category"
+        assert rows[1][0] == "symbol"
+        assert rows[1][1] == "DOOR_36"
+
+    def test_category_enum_values(self):
+        assert TakeoffCategory.SYMBOL == "symbol"
+        assert TakeoffCategory.LINEAR == "linear"
+        assert TakeoffCategory.AREA == "area"
+        assert TakeoffCategory.COUNT == "count"
+
+    def test_empty_report_csv(self):
+        report = TakeoffReport()
+        rows = report.to_csv_rows()
+        assert len(rows) == 1  # header only
+
+
+# ===================================================================
+# Symbol Counting
+# ===================================================================
+
+
+class TestCountSymbols:
+    """Test INSERT block counting."""
+
+    def test_count_blocks(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
+            _make_entity("w1", EntityType.INSERT, "WINDOWS", block_name="WIN_48"),
+        ]
+        context = _make_context(entities=entities)
+        items = _count_symbols(context)
+
+        assert len(items) == 2  # DOOR_36 and WIN_48
+        door_item = next(i for i in items if i.name == "DOOR_36")
+        assert door_item.quantity == 2
+        assert door_item.category == TakeoffCategory.SYMBOL
+        assert door_item.unit == "ea"
+
+    def test_no_inserts(self):
+        entities = [_make_entity("l1", EntityType.LINE, "WALLS")]
+        context = _make_context(entities=entities)
+        items = _count_symbols(context)
+        assert len(items) == 0
+
+    def test_insert_without_block_name_ignored(self):
+        entities = [
+            _make_entity("i1", EntityType.INSERT, "0"),
+        ]
+        context = _make_context(entities=entities)
+        items = _count_symbols(context)
+        assert len(items) == 0
+
+
+# ===================================================================
+# Linear Measurements
+# ===================================================================
+
+
+class TestMeasureLinear:
+    """Test linear measurement extraction."""
+
+    def test_line_length(self):
+        line = _make_entity(
+            "l1", EntityType.LINE, "WALLS",
+            insert_point=Point2D(x=0, y=0),
+            attributes={"end_point": [30, 40]},
+        )
+        length = _entity_length(line)
+        assert abs(length - 50.0) < 0.01  # 3-4-5 triangle
+
+    def test_polyline_length(self):
+        poly = _make_entity(
+            "p1", EntityType.LWPOLYLINE, "WALLS",
+            attributes={
+                "vertices": [[0, 0], [10, 0], [10, 10]],
+                "is_closed": False,
+            },
+        )
+        length = _entity_length(poly)
+        assert abs(length - 20.0) < 0.01
+
+    def test_closed_polyline_includes_closing_segment(self):
+        poly = _make_entity(
+            "p1", EntityType.LWPOLYLINE, "WALLS",
+            attributes={
+                "vertices": [[0, 0], [10, 0], [10, 10], [0, 10]],
+                "is_closed": True,
+            },
+        )
+        length = _entity_length(poly)
+        assert abs(length - 40.0) < 0.01
+
+    def test_measure_linear_per_layer(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=0, y=0),
+                         attributes={"end_point": [10, 0]}),
+            _make_entity("l2", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=10, y=0),
+                         attributes={"end_point": [20, 0]}),
+            _make_entity("l3", EntityType.LINE, "PIPES",
+                         insert_point=Point2D(x=0, y=0),
+                         attributes={"end_point": [5, 0]}),
+        ]
+        context = _make_context(entities=entities)
+        items = _measure_linear(context)
+
+        walls_item = next(i for i in items if i.source_layer == "WALLS")
+        assert walls_item.quantity == 20.0
+        assert walls_item.category == TakeoffCategory.LINEAR
+
+        pipes_item = next(i for i in items if i.source_layer == "PIPES")
+        assert pipes_item.quantity == 5.0
+
+    def test_non_linear_entities_ignored(self):
+        entities = [
+            _make_entity("t1", EntityType.TEXT, "NOTES"),
+            _make_entity("i1", EntityType.INSERT, "DOORS", block_name="DOOR"),
+        ]
+        context = _make_context(entities=entities)
+        items = _measure_linear(context)
+        assert len(items) == 0
+
+    def test_line_without_endpoint_zero_length(self):
+        line = _make_entity(
+            "l1", EntityType.LINE, "WALLS",
+            insert_point=Point2D(x=0, y=0),
+        )
+        assert _entity_length(line) == 0.0
+
+
+# ===================================================================
+# Zone Area Measurements
+# ===================================================================
+
+
+class TestMeasureZoneAreas:
+    """Test zone area extraction."""
+
+    def test_single_zone(self):
+        zone = _make_zone(zone_id="z1", area=1500.0, inferred_type="bedroom")
+        zones = _make_zones_result([zone])
+        items = _measure_zone_areas(zones)
+
+        assert len(items) == 1
+        assert items[0].category == TakeoffCategory.AREA
+        assert items[0].quantity == 1500.0
+        assert items[0].unit == "sq_drawing_units"
+        assert items[0].zone_id == "z1"
+        assert "Bedroom" in items[0].name
+
+    def test_multiple_zones(self):
+        zones_list = [
+            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+            _make_zone("z2", area=2000.0, inferred_type="kitchen"),
+            _make_zone("z3", area=800.0, inferred_type="bathroom"),
+        ]
+        zones = _make_zones_result(zones_list)
+        items = _measure_zone_areas(zones)
+
+        assert len(items) == 3
+        total_area = sum(i.quantity for i in items)
+        assert abs(total_area - 4300.0) < 0.01
+
+    def test_no_zones(self):
+        zones = _make_zones_result()
+        items = _measure_zone_areas(zones)
+        assert len(items) == 0
+
+    def test_unknown_zone_type(self):
+        zone = _make_zone("z1", area=500.0, inferred_type=None)
+        zones = _make_zones_result([zone])
+        items = _measure_zone_areas(zones)
+
+        assert len(items) == 1
+        assert "Unknown" in items[0].name
+
+
+# ===================================================================
+# Layer Entity Counting
+# ===================================================================
+
+
+class TestCountByLayer:
+    """Test per-layer entity counting."""
+
+    def test_counts_non_insert_entities(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+            _make_entity("l2", EntityType.LINE, "WALLS"),
+            _make_entity("l3", EntityType.LINE, "WALLS"),
+            _make_entity("t1", EntityType.TEXT, "NOTES"),
+            _make_entity("t2", EntityType.TEXT, "NOTES"),
+        ]
+        context = _make_context(entities=entities)
+        items = _count_by_layer(context)
+
+        assert len(items) == 2
+        walls_item = next(i for i in items if i.source_layer == "WALLS")
+        assert walls_item.quantity == 3
+
+    def test_inserts_excluded(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS", block_name="DOOR"),
+            _make_entity("d2", EntityType.INSERT, "DOORS", block_name="DOOR"),
+        ]
+        context = _make_context(entities=entities)
+        items = _count_by_layer(context)
+        assert len(items) == 0
+
+    def test_single_entity_layer_excluded(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+        ]
+        context = _make_context(entities=entities)
+        items = _count_by_layer(context)
+        assert len(items) == 0  # Only 1 entity, below threshold of 2
+
+
+# ===================================================================
+# Full Takeoff Generation
+# ===================================================================
+
+
+class TestGenerateTakeoff:
+    """Integration tests for generate_takeoff()."""
+
+    def test_empty_drawing(self):
+        context = _make_context()
+        zones = _make_zones_result()
+        report = generate_takeoff(context, zones=zones)
+
+        assert isinstance(report, TakeoffReport)
+        assert report.total_items == 0
+        assert report.entity_count == 0
+
+    def test_full_drawing(self):
+        entities = [
+            # Doors (symbols)
+            _make_entity("d1", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=10, y=0),
+                         block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=50, y=0),
+                         block_name="DOOR_36"),
+            # Walls (lines)
+            _make_entity("l1", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=0, y=0),
+                         attributes={"end_point": [100, 0]}),
+            _make_entity("l2", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=100, y=0),
+                         attributes={"end_point": [100, 50]}),
+            # Text
+            _make_entity("t1", EntityType.TEXT, "NOTES"),
+            _make_entity("t2", EntityType.TEXT, "NOTES"),
+        ]
+        bedroom = _make_zone("z1", area=5000.0, inferred_type="bedroom")
+        kitchen = _make_zone("z2", area=3000.0, inferred_type="kitchen")
+
+        context = _make_context(entities=entities, layers=["DOORS", "WALLS", "NOTES"])
+        zones = _make_zones_result([bedroom, kitchen])
+
+        report = generate_takeoff(context, zones=zones)
+
+        assert report.total_items > 0
+        assert report.zone_count == 2
+        assert report.entity_count == 6
+
+        by_cat = report.by_category
+        assert "symbol" in by_cat
+        assert "linear" in by_cat
+        assert "area" in by_cat
+
+        # Check symbol count
+        door_items = [i for i in by_cat["symbol"] if i.name == "DOOR_36"]
+        assert len(door_items) == 1
+        assert door_items[0].quantity == 2
+
+        # Check linear measurement
+        wall_items = [i for i in by_cat["linear"] if i.source_layer == "WALLS"]
+        assert len(wall_items) == 1
+        expected_length = 100.0 + 50.0
+        assert abs(wall_items[0].quantity - expected_length) < 0.01
+
+        # Check area measurements
+        assert len(by_cat["area"]) == 2
+
+    def test_csv_export_integration(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=10, y=0),
+                         block_name="DOOR_36"),
+        ]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        report = generate_takeoff(context, zones=zones)
+        rows = report.to_csv_rows()
+
+        assert len(rows) >= 2  # header + at least 1 data row
+        assert rows[0] == ["Category", "Name", "Quantity", "Unit",
+                           "Layer", "Zone", "Notes"]
+
+    def test_polyline_linear_measurement(self):
+        entities = [
+            _make_entity("p1", EntityType.LWPOLYLINE, "WALLS",
+                         attributes={
+                             "vertices": [[0, 0], [100, 0], [100, 50]],
+                             "is_closed": False,
+                         }),
+        ]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        report = generate_takeoff(context, zones=zones)
+        linear_items = [i for i in report.items
+                        if i.category == TakeoffCategory.LINEAR]
+
+        assert len(linear_items) == 1
+        assert abs(linear_items[0].quantity - 150.0) < 0.01
+
+    def test_diagonal_line_measurement(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=0, y=0),
+                         attributes={"end_point": [30, 40]}),
+        ]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        report = generate_takeoff(context, zones=zones)
+        linear_items = [i for i in report.items
+                        if i.category == TakeoffCategory.LINEAR]
+
+        assert len(linear_items) == 1
+        assert abs(linear_items[0].quantity - 50.0) < 0.01  # 3-4-5
+
+    def test_report_entity_handles_limited(self):
+        """Verify entity handle lists are bounded to prevent huge payloads."""
+        entities = [
+            _make_entity(f"l{i}", EntityType.LINE, "WALLS",
+                         insert_point=Point2D(x=i * 10, y=0),
+                         attributes={"end_point": [i * 10 + 10, 0]})
+            for i in range(50)
+        ]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        report = generate_takeoff(context, zones=zones)
+
+        for item in report.items:
+            assert len(item.entity_handles) <= 50


### PR DESCRIPTION
## Epic
EPIC-CAD-23: Automated takeoff engine

## Summary
- Four extraction strategies: symbol counts, linear measurements, zone areas, layer entity counts
- Structured `TakeoffReport` with `by_category` grouping and `to_csv_rows()` export
- Entity-level evidence (handles) and zone IDs for full traceability
- Replaces manual counting that costs estimators hours per drawing set

## Files
| File | Type | Purpose |
|------|------|---------|
| `models/takeoff_schema.py` | NEW | TakeoffReportItem, TakeoffReport, TakeoffCategory |
| `core/takeoff_engine.py` | NEW | generate_takeoff() + 4 extraction functions |
| `tests/unit/test_takeoff_engine.py` | NEW | 27 tests |

## Test plan
- 27 new unit tests (all pass)
- Full suite: 3,210 passed, 5 skipped
- Tests cover: schema models, symbol counting, linear measurement, zone areas, layer counts, CSV export, full-drawing integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)