### PR TITLE
feat: EPIC-CAD-25 RFI generator — detect what's missing

### DIFF
--- a/src/cad_dxf_agent/core/rfi_generator.py
+++ b/src/cad_dxf_agent/core/rfi_generator.py
@@ -1,0 +1,366 @@
+"""RFI generator — detect ambiguities and missing information in drawings.
+
+Deterministic analysis producing structured RFI (Request for Information)
+items that a contractor would typically raise about incomplete or
+ambiguous drawing details.
+
+Public API:
+    generate_rfi(context, zones=None) -> RFIReport
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from cad_dxf_agent.core.zone_detector import detect_zones
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityType
+from cad_dxf_agent.models.rfi_schema import (
+    RFICategory,
+    RFIItem,
+    RFIReport,
+    RFISeverity,
+)
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+# Block patterns for symbol detection
+_DOOR_PATTERN = re.compile(r"door|dr[_\-\s]|entry|exit|gate", re.IGNORECASE)
+_WINDOW_PATTERN = re.compile(r"window|wndw|win[_\-\s]|glazing", re.IGNORECASE)
+
+
+def generate_rfi(
+    context: DrawingContext,
+    *,
+    zones: ZoneDetectionResult | None = None,
+) -> RFIReport:
+    """Generate RFI items from drawing analysis.
+
+    Args:
+        context: Drawing context with entities.
+        zones: Pre-computed zone detection (computed if None).
+
+    Returns:
+        RFIReport with categorized questions.
+    """
+    if zones is None:
+        zones = detect_zones(context)
+
+    items: list[RFIItem] = []
+    checks_run: list[str] = []
+    rfi_counter = 0
+
+    for check_fn, check_name in _ALL_CHECKS:
+        checks_run.append(check_name)
+        new_items = check_fn(context, zones, rfi_counter)
+        rfi_counter += len(new_items)
+        items.extend(new_items)
+
+    critical = sum(1 for i in items if i.severity == RFISeverity.CRITICAL)
+    major = sum(1 for i in items if i.severity == RFISeverity.MAJOR)
+    minor = sum(1 for i in items if i.severity == RFISeverity.MINOR)
+
+    return RFIReport(
+        items=items,
+        total_items=len(items),
+        critical_count=critical,
+        major_count=major,
+        minor_count=minor,
+        checks_run=checks_run,
+        entity_count=context.entity_count,
+        zone_count=zones.zone_count,
+    )
+
+
+# --- Check functions ---
+
+
+def _check_unlabeled_rooms(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag rooms/zones that have no inferred type label."""
+    items: list[RFIItem] = []
+
+    for zone in zones.zones:
+        if zone.inferred_type is None:
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.MISSING_LABEL,
+                severity=RFISeverity.MAJOR,
+                question=(
+                    f"What is the intended use of the space at "
+                    f"({zone.centroid.x:.0f}, {zone.centroid.y:.0f})?"
+                ),
+                location_description=(
+                    f"Zone {zone.zone_id[:8]} — area {zone.area:.0f} "
+                    f"sq units, no room label detected"
+                ),
+                zone_id=zone.zone_id,
+                entity_handles=zone.source_handles,
+                suggested_resolution="Add a room name/label text entity inside the space.",
+            ))
+
+    return items
+
+
+def _check_dimensions_near_doors(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag doors that have no nearby DIMENSION entity."""
+    items: list[RFIItem] = []
+
+    doors = [
+        e for e in context.entities
+        if e.entity_type == EntityType.INSERT
+        and e.block_name
+        and _DOOR_PATTERN.search(e.block_name)
+    ]
+
+    if not doors:
+        return items
+
+    dim_entities = [
+        e for e in context.entities
+        if e.entity_type == EntityType.DIMENSION
+        and e.insert_point is not None
+    ]
+
+    for door in doors:
+        if door.insert_point is None:
+            continue
+
+        has_nearby_dim = False
+        search_radius = 50.0
+
+        for dim in dim_entities:
+            dx = dim.insert_point.x - door.insert_point.x  # type: ignore[union-attr]
+            dy = dim.insert_point.y - door.insert_point.y  # type: ignore[union-attr]
+            if (dx * dx + dy * dy) ** 0.5 <= search_radius:
+                has_nearby_dim = True
+                break
+
+        if not has_nearby_dim:
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.MISSING_DIMENSION,
+                severity=RFISeverity.CRITICAL,
+                question=(
+                    f"What is the clear opening width of door "
+                    f"'{door.block_name}' at "
+                    f"({door.insert_point.x:.0f}, "
+                    f"{door.insert_point.y:.0f})?"
+                ),
+                location_description=(
+                    f"Door block '{door.block_name}' on layer "
+                    f"'{door.layer}' — no dimension entity within "
+                    f"{search_radius:.0f} units"
+                ),
+                entity_handles=[door.handle],
+                suggested_resolution=(
+                    "Add a dimension entity showing door clear opening width."
+                ),
+            ))
+
+    return items
+
+
+def _check_symbols_without_legend(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag unique block names that don't appear in any text legend."""
+    items: list[RFIItem] = []
+
+    inserts = [
+        e for e in context.entities
+        if e.entity_type == EntityType.INSERT and e.block_name
+    ]
+    if not inserts:
+        return items
+
+    block_names = {e.block_name for e in inserts}
+
+    # Collect all text content for legend searching
+    all_text = " ".join(
+        e.text_content.upper()
+        for e in context.entities
+        if e.entity_type in (EntityType.TEXT, EntityType.MTEXT)
+        and e.text_content
+    )
+
+    for block_name in sorted(block_names):
+        # Check if block name (or simplified form) appears in text
+        simplified = re.sub(r"[_\-\s]", "", block_name.upper())
+        if block_name.upper() not in all_text and simplified not in all_text:
+            handles = [
+                e.handle for e in inserts
+                if e.block_name == block_name
+            ][:5]
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.AMBIGUOUS_SYMBOL,
+                severity=RFISeverity.MINOR,
+                question=(
+                    f"What does the symbol '{block_name}' represent? "
+                    f"No legend entry found."
+                ),
+                location_description=(
+                    f"Block '{block_name}' appears "
+                    f"{len([e for e in inserts if e.block_name == block_name])} "
+                    f"time(s) but is not referenced in any text/legend"
+                ),
+                entity_handles=handles,
+                suggested_resolution="Add a symbol legend or schedule referencing this block.",
+            ))
+
+    return items
+
+
+def _check_empty_layers(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag layers that exist but have no entities (may be orphaned)."""
+    items: list[RFIItem] = []
+
+    entity_layers = {e.layer for e in context.entities}
+
+    for layer in context.layers:
+        if layer.name not in entity_layers and layer.name != "0":
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.INCOMPLETE_SECTION,
+                severity=RFISeverity.MINOR,
+                question=(
+                    f"Layer '{layer.name}' exists but contains no "
+                    f"entities. Is content missing?"
+                ),
+                location_description=f"Layer '{layer.name}' — 0 entities",
+                suggested_resolution=(
+                    "Verify layer content was included in the export, "
+                    "or remove the layer if unused."
+                ),
+            ))
+
+    return items
+
+
+def _check_unclosed_boundaries(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag LWPOLYLINE entities that are nearly closed but not quite."""
+    items: list[RFIItem] = []
+    tolerance_close = 5.0  # "almost closed" threshold
+    tolerance_actual = 0.5  # "actually closed" threshold
+
+    for entity in context.entities:
+        if entity.entity_type != EntityType.LWPOLYLINE:
+            continue
+
+        vertices = entity.attributes.get("vertices", [])
+        if len(vertices) < 3:
+            continue
+
+        if entity.attributes.get("is_closed", False):
+            continue
+
+        # Check gap between first and last vertex
+        first = vertices[0]
+        last = vertices[-1]
+        dx = first[0] - last[0]
+        dy = first[1] - last[1]
+        gap = (dx * dx + dy * dy) ** 0.5
+
+        if tolerance_actual < gap <= tolerance_close:
+            pos = entity.insert_point
+            loc = f"({pos.x:.0f}, {pos.y:.0f})" if pos else "unknown"
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.COORDINATION,
+                severity=RFISeverity.MAJOR,
+                question=(
+                    f"Polyline on layer '{entity.layer}' at {loc} "
+                    f"has a {gap:.1f}-unit gap. Should this boundary "
+                    f"be closed?"
+                ),
+                location_description=(
+                    f"LWPOLYLINE {entity.handle} on layer "
+                    f"'{entity.layer}' — gap of {gap:.1f} units "
+                    f"between first and last vertex"
+                ),
+                entity_handles=[entity.handle],
+                suggested_resolution="Close the polyline or confirm the gap is intentional.",
+            ))
+
+    return items
+
+
+def _check_mixed_text_heights(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    start_id: int,
+) -> list[RFIItem]:
+    """Flag layers with inconsistent text heights (may indicate drafting errors)."""
+    items: list[RFIItem] = []
+
+    # Group text heights by layer
+    layer_heights: dict[str, Counter[float]] = {}
+    for entity in context.entities:
+        if entity.entity_type not in (EntityType.TEXT, EntityType.MTEXT):
+            continue
+        if entity.text_geometry and entity.text_geometry.effective_height > 0:
+            height = round(entity.text_geometry.effective_height, 2)
+            layer_heights.setdefault(entity.layer, Counter())[height] += 1
+
+    for layer, height_counts in layer_heights.items():
+        if len(height_counts) < 3:
+            continue
+
+        # Find the dominant height
+        dominant_height, dominant_count = height_counts.most_common(1)[0]
+        total = sum(height_counts.values())
+        outlier_count = total - dominant_count
+
+        if outlier_count >= 2 and outlier_count / total > 0.1:
+            outlier_heights = sorted(
+                h for h in height_counts if h != dominant_height
+            )
+            items.append(RFIItem(
+                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                category=RFICategory.COORDINATION,
+                severity=RFISeverity.MINOR,
+                question=(
+                    f"Layer '{layer}' has {len(height_counts)} "
+                    f"different text heights. Is this intentional?"
+                ),
+                location_description=(
+                    f"Layer '{layer}' — dominant height "
+                    f"{dominant_height}, also has "
+                    f"{', '.join(str(h) for h in outlier_heights[:3])}"
+                ),
+                suggested_resolution=(
+                    "Standardize text heights per layer, or confirm "
+                    "variations are intentional (e.g., titles vs labels)."
+                ),
+            ))
+
+    return items
+
+
+# --- Check registry ---
+
+_ALL_CHECKS = [
+    (_check_unlabeled_rooms, "unlabeled_rooms"),
+    (_check_dimensions_near_doors, "dimensions_near_doors"),
+    (_check_symbols_without_legend, "symbols_without_legend"),
+    (_check_empty_layers, "empty_layers"),
+    (_check_unclosed_boundaries, "unclosed_boundaries"),
+    (_check_mixed_text_heights, "mixed_text_heights"),
+]

--- a/src/cad_dxf_agent/models/rfi_schema.py
+++ b/src/cad_dxf_agent/models/rfi_schema.py
@@ -1,0 +1,57 @@
+"""RFI (Request for Information) generation schemas.
+
+Represents structured questions that contractors would ask about
+ambiguous or incomplete drawing information. Each RFI item references
+specific entities and locations for traceability.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class RFISeverity(StrEnum):
+    """How critical the information gap is."""
+
+    CRITICAL = "critical"
+    MAJOR = "major"
+    MINOR = "minor"
+
+
+class RFICategory(StrEnum):
+    """Type of information gap."""
+
+    MISSING_DIMENSION = "missing_dimension"
+    AMBIGUOUS_SYMBOL = "ambiguous_symbol"
+    MISSING_LABEL = "missing_label"
+    INCOMPLETE_SECTION = "incomplete_section"
+    COORDINATION = "coordination"
+    GENERAL = "general"
+
+
+class RFIItem(BaseModel):
+    """A single RFI question with location and evidence."""
+
+    rfi_id: str
+    category: RFICategory
+    severity: RFISeverity
+    question: str
+    location_description: str
+    entity_handles: list[str] = Field(default_factory=list)
+    zone_id: str | None = None
+    suggested_resolution: str = ""
+
+
+class RFIReport(BaseModel):
+    """Aggregate RFI report from drawing analysis."""
+
+    items: list[RFIItem] = Field(default_factory=list)
+    total_items: int = 0
+    critical_count: int = 0
+    major_count: int = 0
+    minor_count: int = 0
+    checks_run: list[str] = Field(default_factory=list)
+    entity_count: int = 0
+    zone_count: int = 0

--- a/tests/unit/test_rfi_generator.py
+++ b/tests/unit/test_rfi_generator.py
@@ -1,0 +1,427 @@
+"""Tests for the RFI generator (EPIC-CAD-25)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.rfi_generator import (
+    _check_dimensions_near_doors,
+    _check_empty_layers,
+    _check_symbols_without_legend,
+    _check_unclosed_boundaries,
+    _check_unlabeled_rooms,
+    generate_rfi,
+)
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+    TextGeometry,
+)
+from cad_dxf_agent.models.rfi_schema import (
+    RFICategory,
+    RFIReport,
+    RFISeverity,
+)
+from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
+
+# --- Helpers ---
+
+
+def _make_entity(
+    handle: str,
+    entity_type: EntityType = EntityType.LINE,
+    layer: str = "0",
+    insert_point: Point2D | None = None,
+    text_content: str | None = None,
+    block_name: str | None = None,
+    attributes: dict | None = None,
+    text_geometry: TextGeometry | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        space="Model",
+        insert_point=insert_point,
+        text_content=text_content,
+        block_name=block_name,
+        attributes=attributes or {},
+        text_geometry=text_geometry,
+    )
+
+
+def _make_context(
+    entities: list[EntityRef] | None = None,
+    layers: list[str] | None = None,
+) -> DrawingContext:
+    layer_rules = [LayerRule(name=n, color=1) for n in (layers or ["0"])]
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities or [],
+        layers=layer_rules,
+    )
+
+
+def _make_zone(
+    zone_id: str = "z1",
+    area: float = 200.0,
+    inferred_type: str | None = "room",
+) -> DetectedZone:
+    return DetectedZone(
+        zone_id=zone_id,
+        boundary=[
+            Point2D(x=0, y=0),
+            Point2D(x=20, y=0),
+            Point2D(x=20, y=10),
+            Point2D(x=0, y=10),
+        ],
+        area=area,
+        perimeter=60.0,
+        centroid=Point2D(x=10, y=5),
+        inferred_type=inferred_type,
+        source_handles=["h1"],
+    )
+
+
+def _make_zones_result(
+    zones: list[DetectedZone] | None = None,
+) -> ZoneDetectionResult:
+    zone_list = zones or []
+    return ZoneDetectionResult(
+        zones=zone_list,
+        total_area=sum(z.area for z in zone_list),
+        zone_count=len(zone_list),
+        confidence=0.8,
+    )
+
+
+# ===================================================================
+# Schema Tests
+# ===================================================================
+
+
+class TestRFISchema:
+    """Test RFI models."""
+
+    def test_rfi_report_defaults(self):
+        report = RFIReport()
+        assert report.total_items == 0
+        assert report.critical_count == 0
+        assert report.items == []
+
+    def test_severity_enum(self):
+        assert RFISeverity.CRITICAL == "critical"
+        assert RFISeverity.MAJOR == "major"
+        assert RFISeverity.MINOR == "minor"
+
+    def test_category_enum(self):
+        assert RFICategory.MISSING_DIMENSION == "missing_dimension"
+        assert RFICategory.AMBIGUOUS_SYMBOL == "ambiguous_symbol"
+
+
+# ===================================================================
+# Unlabeled Rooms Check
+# ===================================================================
+
+
+class TestUnlabeledRooms:
+    """Test detection of rooms without labels."""
+
+    def test_unlabeled_room_flagged(self):
+        zone = _make_zone("z1", area=200.0, inferred_type=None)
+        context = _make_context()
+        zones = _make_zones_result([zone])
+
+        items = _check_unlabeled_rooms(context, zones, 0)
+        assert len(items) == 1
+        assert items[0].severity == RFISeverity.MAJOR
+        assert items[0].category == RFICategory.MISSING_LABEL
+        assert items[0].zone_id == "z1"
+
+    def test_labeled_room_not_flagged(self):
+        zone = _make_zone("z1", area=200.0, inferred_type="bedroom")
+        context = _make_context()
+        zones = _make_zones_result([zone])
+
+        items = _check_unlabeled_rooms(context, zones, 0)
+        assert len(items) == 0
+
+    def test_multiple_unlabeled_rooms(self):
+        zone_list = [
+            _make_zone("z1", inferred_type=None),
+            _make_zone("z2", inferred_type="kitchen"),
+            _make_zone("z3", inferred_type=None),
+        ]
+        context = _make_context()
+        zones = _make_zones_result(zone_list)
+
+        items = _check_unlabeled_rooms(context, zones, 0)
+        assert len(items) == 2
+
+
+# ===================================================================
+# Dimensions Near Doors Check
+# ===================================================================
+
+
+class TestDimensionsNearDoors:
+    """Test detection of doors without nearby dimensions."""
+
+    def test_door_without_dimension_flagged(self):
+        door = _make_entity(
+            "d1", EntityType.INSERT, "DOORS",
+            insert_point=Point2D(x=100, y=100),
+            block_name="DOOR_36",
+        )
+        context = _make_context(entities=[door])
+        zones = _make_zones_result()
+
+        items = _check_dimensions_near_doors(context, zones, 0)
+        assert len(items) == 1
+        assert items[0].severity == RFISeverity.CRITICAL
+        assert items[0].category == RFICategory.MISSING_DIMENSION
+
+    def test_door_with_nearby_dimension_not_flagged(self):
+        door = _make_entity(
+            "d1", EntityType.INSERT, "DOORS",
+            insert_point=Point2D(x=100, y=100),
+            block_name="DOOR_36",
+        )
+        dim = _make_entity(
+            "dim1", EntityType.DIMENSION, "DIM",
+            insert_point=Point2D(x=105, y=100),
+        )
+        context = _make_context(entities=[door, dim])
+        zones = _make_zones_result()
+
+        items = _check_dimensions_near_doors(context, zones, 0)
+        assert len(items) == 0
+
+    def test_non_door_inserts_ignored(self):
+        insert = _make_entity(
+            "i1", EntityType.INSERT, "FIXTURES",
+            insert_point=Point2D(x=100, y=100),
+            block_name="TOILET",
+        )
+        context = _make_context(entities=[insert])
+        zones = _make_zones_result()
+
+        items = _check_dimensions_near_doors(context, zones, 0)
+        assert len(items) == 0
+
+
+# ===================================================================
+# Symbols Without Legend Check
+# ===================================================================
+
+
+class TestSymbolsWithoutLegend:
+    """Test detection of block symbols without legend entries."""
+
+    def test_symbol_without_legend_flagged(self):
+        insert = _make_entity(
+            "i1", EntityType.INSERT, "SYMBOLS",
+            block_name="FIRE_EXT_A",
+        )
+        context = _make_context(entities=[insert])
+        zones = _make_zones_result()
+
+        items = _check_symbols_without_legend(context, zones, 0)
+        assert len(items) == 1
+        assert items[0].category == RFICategory.AMBIGUOUS_SYMBOL
+        assert "FIRE_EXT_A" in items[0].question
+
+    def test_symbol_with_legend_not_flagged(self):
+        insert = _make_entity(
+            "i1", EntityType.INSERT, "SYMBOLS",
+            block_name="OUTLET",
+        )
+        legend_text = _make_entity(
+            "t1", EntityType.TEXT, "NOTES",
+            text_content="OUTLET - Standard 120V duplex receptacle",
+        )
+        context = _make_context(entities=[insert, legend_text])
+        zones = _make_zones_result()
+
+        items = _check_symbols_without_legend(context, zones, 0)
+        assert len(items) == 0
+
+    def test_no_inserts_no_findings(self):
+        context = _make_context(entities=[
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+        ])
+        zones = _make_zones_result()
+
+        items = _check_symbols_without_legend(context, zones, 0)
+        assert len(items) == 0
+
+
+# ===================================================================
+# Empty Layers Check
+# ===================================================================
+
+
+class TestEmptyLayers:
+    """Test detection of layers without entities."""
+
+    def test_empty_layer_flagged(self):
+        entities = [_make_entity("l1", EntityType.LINE, "WALLS")]
+        context = _make_context(
+            entities=entities,
+            layers=["WALLS", "ELECTRICAL", "PLUMBING"],
+        )
+        zones = _make_zones_result()
+
+        items = _check_empty_layers(context, zones, 0)
+        assert len(items) == 2  # ELECTRICAL and PLUMBING
+        categories = {i.category for i in items}
+        assert RFICategory.INCOMPLETE_SECTION in categories
+
+    def test_all_layers_populated_no_findings(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+            _make_entity("t1", EntityType.TEXT, "NOTES"),
+        ]
+        context = _make_context(entities=entities, layers=["WALLS", "NOTES"])
+        zones = _make_zones_result()
+
+        items = _check_empty_layers(context, zones, 0)
+        assert len(items) == 0
+
+    def test_layer_0_not_flagged(self):
+        context = _make_context(entities=[], layers=["0"])
+        zones = _make_zones_result()
+
+        items = _check_empty_layers(context, zones, 0)
+        assert len(items) == 0
+
+
+# ===================================================================
+# Unclosed Boundaries Check
+# ===================================================================
+
+
+class TestUnclosedBoundaries:
+    """Test detection of nearly-closed polylines."""
+
+    def test_nearly_closed_polyline_flagged(self):
+        poly = _make_entity(
+            "p1", EntityType.LWPOLYLINE, "WALLS",
+            insert_point=Point2D(x=0, y=0),
+            attributes={
+                "vertices": [[0, 0], [100, 0], [100, 100], [2, 0]],
+                "is_closed": False,
+            },
+        )
+        context = _make_context(entities=[poly])
+        zones = _make_zones_result()
+
+        items = _check_unclosed_boundaries(context, zones, 0)
+        assert len(items) == 1
+        assert items[0].severity == RFISeverity.MAJOR
+
+    def test_clearly_open_polyline_not_flagged(self):
+        poly = _make_entity(
+            "p1", EntityType.LWPOLYLINE, "WALLS",
+            insert_point=Point2D(x=0, y=0),
+            attributes={
+                "vertices": [[0, 0], [100, 0], [100, 100], [50, 100]],
+                "is_closed": False,
+            },
+        )
+        context = _make_context(entities=[poly])
+        zones = _make_zones_result()
+
+        items = _check_unclosed_boundaries(context, zones, 0)
+        # Gap is ~50 units — too large, not flagged
+        assert len(items) == 0
+
+    def test_closed_polyline_not_flagged(self):
+        poly = _make_entity(
+            "p1", EntityType.LWPOLYLINE, "WALLS",
+            attributes={
+                "vertices": [[0, 0], [100, 0], [100, 100], [0, 100]],
+                "is_closed": True,
+            },
+        )
+        context = _make_context(entities=[poly])
+        zones = _make_zones_result()
+
+        items = _check_unclosed_boundaries(context, zones, 0)
+        assert len(items) == 0
+
+
+# ===================================================================
+# Full RFI Generation
+# ===================================================================
+
+
+class TestGenerateRFI:
+    """Integration tests for generate_rfi()."""
+
+    def test_empty_drawing(self):
+        context = _make_context()
+        zones = _make_zones_result()
+        report = generate_rfi(context, zones=zones)
+
+        assert isinstance(report, RFIReport)
+        assert report.total_items == 0
+        assert len(report.checks_run) > 0
+
+    def test_drawing_with_issues(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=50, y=50),
+                         block_name="DOOR_36"),
+            _make_entity("i1", EntityType.INSERT, "FIXTURES",
+                         block_name="CUSTOM_WIDGET"),
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+        ]
+        context = _make_context(
+            entities=entities,
+            layers=["DOORS", "FIXTURES", "WALLS", "ELECTRICAL"],
+        )
+        zone = _make_zone("z1", inferred_type=None)
+        zones = _make_zones_result([zone])
+
+        report = generate_rfi(context, zones=zones)
+
+        assert report.total_items > 0
+        # Should have: unlabeled room, door without dimension,
+        # symbols without legend, empty ELECTRICAL layer
+        assert report.critical_count >= 1  # Door without dimension
+        assert report.major_count >= 1  # Unlabeled room
+
+    def test_rfi_ids_sequential(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=50, y=50),
+                         block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS",
+                         insert_point=Point2D(x=150, y=50),
+                         block_name="DR-SINGLE"),
+        ]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        report = generate_rfi(context, zones=zones)
+
+        rfi_ids = [i.rfi_id for i in report.items]
+        # All should be unique
+        assert len(rfi_ids) == len(set(rfi_ids))
+
+    def test_severity_counts_accurate(self):
+        context = _make_context(
+            entities=[
+                _make_entity("d1", EntityType.INSERT, "DOORS",
+                             insert_point=Point2D(x=50, y=50),
+                             block_name="EXIT_DOOR"),
+            ],
+            layers=["DOORS", "UNUSED_LAYER"],
+        )
+        zones = _make_zones_result()
+        report = generate_rfi(context, zones=zones)
+
+        total = report.critical_count + report.major_count + report.minor_count
+        assert total == report.total_items


### PR DESCRIPTION
## Epic
EPIC-CAD-25: RFI generator for contractors

## Summary
- Six detection checks: unlabeled rooms, missing door dimensions, symbols without legend, empty layers, unclosed boundaries, mixed text heights
- Each RFI item has severity (critical/major/minor), question text, location, and entity-handle evidence
- Designed for contractor workflows — catches ambiguities before they become $500+ RFIs on the job site

## Files
| File | Type | Purpose |
|------|------|---------|
| `models/rfi_schema.py` | NEW | RFIItem, RFIReport, severity/category enums |
| `core/rfi_generator.py` | NEW | generate_rfi() + 6 check functions |
| `tests/unit/test_rfi_generator.py` | NEW | 22 tests |

## Test plan
- 22 new unit tests (all pass)
- Full suite: 3,205 passed, 5 skipped
- Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)