### PR TITLE
feat: EPIC-CAD-24 plain-English drawing summary

### DIFF
--- a/src/cad_dxf_agent/core/drawing_summarizer.py
+++ b/src/cad_dxf_agent/core/drawing_summarizer.py
@@ -1,0 +1,254 @@
+"""Drawing summarizer — plain-English explanation of any drawing.
+
+Deterministic (no LLM). Combines entity statistics, zone detection,
+family detection, and primitive extraction to produce a structured
+summary accessible to non-CAD users.
+
+Public API:
+    summarize_drawing(context, zones=None) -> DrawingSummary
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from cad_dxf_agent.core.family_detector import detect_document_family
+from cad_dxf_agent.core.primitive_extractors import classify_layers, extract_symbols
+from cad_dxf_agent.core.zone_detector import detect_zones
+from cad_dxf_agent.models.cad_schema import DrawingContext, EntityType
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+
+class RoomSummary(BaseModel):
+    """Summary of a single detected room."""
+
+    name: str
+    area: float
+    zone_id: str
+
+
+class DrawingSummary(BaseModel):
+    """Structured plain-English summary of a drawing."""
+
+    headline: str
+    drawing_type: str
+    entity_count: int = 0
+    layer_count: int = 0
+    total_area: float = 0.0
+    room_count: int = 0
+    rooms: list[RoomSummary] = Field(default_factory=list)
+    key_features: list[str] = Field(default_factory=list)
+    layer_breakdown: list[str] = Field(default_factory=list)
+    plain_description: str = ""
+
+
+def summarize_drawing(
+    context: DrawingContext,
+    *,
+    zones: ZoneDetectionResult | None = None,
+) -> DrawingSummary:
+    """Generate a plain-English summary of a drawing.
+
+    Args:
+        context: Drawing context with entities.
+        zones: Pre-computed zone detection (computed if None).
+
+    Returns:
+        DrawingSummary with headline, rooms, features, and description.
+    """
+    if zones is None:
+        zones = detect_zones(context)
+
+    family = detect_document_family(context)
+    layer_cls = classify_layers(context)
+    symbols = extract_symbols(context)
+
+    # Drawing type from family detection
+    drawing_type = family.family.value.replace("_", " ").title()
+
+    # Room summaries from zones
+    rooms: list[RoomSummary] = []
+    for zone in zones.zones:
+        room_name = (zone.inferred_type or "unknown space").replace("_", " ").title()
+        rooms.append(RoomSummary(
+            name=room_name,
+            area=round(zone.area, 1),
+            zone_id=zone.zone_id,
+        ))
+
+    # Key features
+    key_features = _extract_key_features(context, zones, symbols)
+
+    # Layer breakdown
+    layer_breakdown = _build_layer_breakdown(context, layer_cls)
+
+    # Build headline
+    headline = _build_headline(drawing_type, context, zones, rooms)
+
+    # Build plain description
+    plain_description = _build_description(
+        drawing_type, context, zones, rooms, key_features,
+    )
+
+    return DrawingSummary(
+        headline=headline,
+        drawing_type=drawing_type,
+        entity_count=context.entity_count,
+        layer_count=len(context.layers),
+        total_area=round(zones.total_area, 1),
+        room_count=len(rooms),
+        rooms=rooms,
+        key_features=key_features,
+        layer_breakdown=layer_breakdown,
+        plain_description=plain_description,
+    )
+
+
+def _extract_key_features(
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    symbols,
+) -> list[str]:
+    """Extract notable features as short descriptions."""
+    features: list[str] = []
+
+    # Entity type distribution
+    type_counts: dict[str, int] = {}
+    for entity in context.entities:
+        t = entity.entity_type.value
+        type_counts[t] = type_counts.get(t, 0) + 1
+
+    if EntityType.INSERT.value in type_counts:
+        count = type_counts[EntityType.INSERT.value]
+        features.append(f"{count} symbol(s) placed ({symbols.unique_blocks} unique block types)")
+
+    if EntityType.DIMENSION.value in type_counts:
+        features.append(f"{type_counts[EntityType.DIMENSION.value]} dimension(s)")
+
+    if EntityType.TEXT.value in type_counts or EntityType.MTEXT.value in type_counts:
+        text_count = (
+            type_counts.get(EntityType.TEXT.value, 0)
+            + type_counts.get(EntityType.MTEXT.value, 0)
+        )
+        features.append(f"{text_count} text label(s)")
+
+    # Zone features
+    if zones.zone_count > 0:
+        room_types = set()
+        for zone in zones.zones:
+            if zone.inferred_type:
+                room_types.add(zone.inferred_type.replace("_", " "))
+        if room_types:
+            features.append(f"Room types: {', '.join(sorted(room_types))}")
+
+    # Block highlights
+    if symbols.unique_blocks > 0:
+        top_blocks = sorted(
+            symbols.counts_by_block.items(),
+            key=lambda x: x[1],
+            reverse=True,
+        )[:3]
+        for block_name, count in top_blocks:
+            features.append(f"{count}x {block_name}")
+
+    return features
+
+
+def _build_layer_breakdown(context: DrawingContext, layer_cls) -> list[str]:
+    """Build layer descriptions."""
+    breakdown: list[str] = []
+
+    # Count entities per layer
+    layer_entity_counts: dict[str, int] = {}
+    for entity in context.entities:
+        layer_entity_counts[entity.layer] = layer_entity_counts.get(entity.layer, 0) + 1
+
+    for layer in context.layers:
+        count = layer_entity_counts.get(layer.name, 0)
+        if count > 0:
+            category = _classify_single_layer(layer.name, layer_cls)
+            breakdown.append(f"{layer.name}: {count} entities ({category})")
+
+    return breakdown
+
+
+def _classify_single_layer(name: str, layer_cls) -> str:
+    """Classify a single layer name into a category."""
+    if name in layer_cls.structural:
+        return "structural"
+    if name in layer_cls.annotation:
+        return "annotation"
+    if name in layer_cls.dimension:
+        return "dimension"
+    if name in layer_cls.title_border:
+        return "title/border"
+    if name in layer_cls.mep:
+        return "MEP"
+    return "general"
+
+
+def _build_headline(
+    drawing_type: str,
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    rooms: list[RoomSummary],
+) -> str:
+    """Build a concise headline summarizing the drawing."""
+    parts = [drawing_type]
+
+    if zones.zone_count > 0:
+        room_type_counts: dict[str, int] = {}
+        for room in rooms:
+            room_type_counts[room.name] = room_type_counts.get(room.name, 0) + 1
+
+        type_strs = []
+        for rtype, count in sorted(room_type_counts.items()):
+            if count > 1:
+                type_strs.append(f"{count} {rtype}s")
+            else:
+                type_strs.append(rtype)
+
+        if type_strs:
+            parts.append(f"with {', '.join(type_strs[:4])}")
+
+    parts.append(f"— {context.entity_count} entities")
+
+    return " ".join(parts)
+
+
+def _build_description(
+    drawing_type: str,
+    context: DrawingContext,
+    zones: ZoneDetectionResult,
+    rooms: list[RoomSummary],
+    key_features: list[str],
+) -> str:
+    """Build a multi-sentence plain-English description."""
+    sentences: list[str] = []
+
+    sentences.append(
+        f"This is a {drawing_type.lower()} drawing containing "
+        f"{context.entity_count} entities across "
+        f"{len(context.layers)} layers."
+    )
+
+    if zones.zone_count > 0:
+        sentences.append(
+            f"{zones.zone_count} enclosed space(s) detected "
+            f"with a total area of {zones.total_area:.0f} square units."
+        )
+
+        if rooms:
+            room_list = ", ".join(
+                f"{r.name} ({r.area:.0f} sq units)" for r in rooms[:5]
+            )
+            sentences.append(f"Spaces: {room_list}.")
+    else:
+        sentences.append("No enclosed spaces detected.")
+
+    if key_features:
+        sentences.append(
+            f"Key features: {'; '.join(key_features[:4])}."
+        )
+
+    return " ".join(sentences)

--- a/src/cad_dxf_agent/llm/stage_handlers/summarize_handler.py
+++ b/src/cad_dxf_agent/llm/stage_handlers/summarize_handler.py
@@ -1,0 +1,52 @@
+"""Stage handler for the summarize stage.
+
+Uses enriched context + zone detection to produce a structured
+plain-English drawing summary suitable for non-CAD users.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cad_dxf_agent.core.drawing_summarizer import summarize_drawing
+from cad_dxf_agent.models.cad_schema import DrawingContext
+from cad_dxf_agent.models.objective_schema import ObjectiveClassification
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+
+class SummarizeHandler:
+    """Stage handler that produces plain-English drawing summaries."""
+
+    def execute(
+        self,
+        classification: ObjectiveClassification,
+        context: dict[str, Any],
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Run drawing summarization and return structured summary."""
+        drawing_context = context.get("drawing_context")
+        if drawing_context is None:
+            return {"summary": "No drawing context available for summary"}
+
+        if not isinstance(drawing_context, DrawingContext):
+            drawing_context = DrawingContext(**drawing_context)
+
+        # Use pre-computed zones if available from upstream stage
+        zones = context.get("zones")
+        if zones is not None and not isinstance(zones, ZoneDetectionResult):
+            zones = ZoneDetectionResult(**zones)
+
+        result = summarize_drawing(drawing_context, zones=zones)
+
+        return {
+            "summary": result.headline,
+            "plain_description": result.plain_description,
+            "drawing_type": result.drawing_type,
+            "entity_count": result.entity_count,
+            "layer_count": result.layer_count,
+            "total_area": result.total_area,
+            "room_count": result.room_count,
+            "rooms": [r.model_dump() for r in result.rooms],
+            "key_features": result.key_features,
+            "layer_breakdown": result.layer_breakdown,
+        }

--- a/tests/unit/test_drawing_summarizer.py
+++ b/tests/unit/test_drawing_summarizer.py
@@ -1,0 +1,330 @@
+"""Tests for the drawing summarizer (EPIC-CAD-24)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.drawing_summarizer import (
+    DrawingSummary,
+    summarize_drawing,
+)
+from cad_dxf_agent.llm.stage_handlers.summarize_handler import SummarizeHandler
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveClassification,
+    ObjectiveTag,
+    RequestClass,
+)
+from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
+
+# --- Helpers ---
+
+
+def _make_entity(
+    handle: str,
+    entity_type: EntityType = EntityType.LINE,
+    layer: str = "0",
+    insert_point: Point2D | None = None,
+    text_content: str | None = None,
+    block_name: str | None = None,
+    attributes: dict | None = None,
+) -> EntityRef:
+    return EntityRef(
+        handle=handle,
+        entity_type=entity_type,
+        layer=layer,
+        space="Model",
+        insert_point=insert_point,
+        text_content=text_content,
+        block_name=block_name,
+        attributes=attributes or {},
+    )
+
+
+def _make_context(
+    entities: list[EntityRef] | None = None,
+    layers: list[str] | None = None,
+) -> DrawingContext:
+    layer_rules = [LayerRule(name=n, color=1) for n in (layers or ["0"])]
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities or [],
+        layers=layer_rules,
+    )
+
+
+def _make_zone(
+    zone_id: str = "z1",
+    area: float = 200.0,
+    inferred_type: str | None = "room",
+) -> DetectedZone:
+    return DetectedZone(
+        zone_id=zone_id,
+        boundary=[
+            Point2D(x=0, y=0),
+            Point2D(x=20, y=0),
+            Point2D(x=20, y=10),
+            Point2D(x=0, y=10),
+        ],
+        area=area,
+        perimeter=60.0,
+        centroid=Point2D(x=10, y=5),
+        inferred_type=inferred_type,
+        source_handles=["h1"],
+    )
+
+
+def _make_zones_result(
+    zones: list[DetectedZone] | None = None,
+) -> ZoneDetectionResult:
+    zone_list = zones or []
+    return ZoneDetectionResult(
+        zones=zone_list,
+        total_area=sum(z.area for z in zone_list),
+        zone_count=len(zone_list),
+        confidence=0.8,
+    )
+
+
+# ===================================================================
+# Schema Tests
+# ===================================================================
+
+
+class TestDrawingSummarySchema:
+    """Test DrawingSummary model."""
+
+    def test_summary_defaults(self):
+        s = DrawingSummary(headline="Test", drawing_type="unknown")
+        assert s.entity_count == 0
+        assert s.rooms == []
+        assert s.plain_description == ""
+
+    def test_summary_with_rooms(self):
+        from cad_dxf_agent.core.drawing_summarizer import RoomSummary
+
+        s = DrawingSummary(
+            headline="Test",
+            drawing_type="Residential",
+            rooms=[
+                RoomSummary(name="Bedroom", area=150.0, zone_id="z1"),
+                RoomSummary(name="Kitchen", area=100.0, zone_id="z2"),
+            ],
+            room_count=2,
+        )
+        assert s.room_count == 2
+        assert s.rooms[0].name == "Bedroom"
+
+
+# ===================================================================
+# summarize_drawing() Tests
+# ===================================================================
+
+
+class TestSummarizeDrawing:
+    """Test the summarize_drawing() function."""
+
+    def test_empty_drawing(self):
+        context = _make_context()
+        zones = _make_zones_result()
+        summary = summarize_drawing(context, zones=zones)
+
+        assert isinstance(summary, DrawingSummary)
+        assert summary.entity_count == 0
+        assert summary.room_count == 0
+        assert "0 entities" in summary.headline
+
+    def test_drawing_with_rooms(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+            _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
+            _make_entity("t1", EntityType.TEXT, "NOTES",
+                         text_content="BEDROOM"),
+        ]
+        bedroom = _make_zone("z1", area=1500.0, inferred_type="bedroom")
+        kitchen = _make_zone("z2", area=1000.0, inferred_type="kitchen")
+
+        context = _make_context(entities=entities, layers=["STRUCTURAL", "NOTES"])
+        zones = _make_zones_result([bedroom, kitchen])
+
+        summary = summarize_drawing(context, zones=zones)
+
+        assert summary.room_count == 2
+        assert summary.total_area == 2500.0
+        assert len(summary.rooms) == 2
+        room_names = {r.name for r in summary.rooms}
+        assert "Bedroom" in room_names
+        assert "Kitchen" in room_names
+
+    def test_headline_includes_drawing_type(self):
+        context = _make_context(entities=[
+            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+        ], layers=["STRUCTURAL"])
+        zones = _make_zones_result()
+
+        summary = summarize_drawing(context, zones=zones)
+
+        # Should contain the detected family type
+        assert len(summary.headline) > 0
+        assert summary.drawing_type != ""
+
+    def test_key_features_include_symbols(self):
+        entities = [
+            _make_entity("d1", EntityType.INSERT, "DOORS",
+                         block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS",
+                         block_name="DOOR_36"),
+            _make_entity("w1", EntityType.INSERT, "WINDOWS",
+                         block_name="WIN_48"),
+        ]
+        context = _make_context(entities=entities, layers=["DOORS", "WINDOWS"])
+        zones = _make_zones_result()
+
+        summary = summarize_drawing(context, zones=zones)
+
+        # Should mention symbols
+        features_text = " ".join(summary.key_features)
+        assert "symbol" in features_text.lower() or "DOOR" in features_text
+
+    def test_key_features_include_text_count(self):
+        entities = [
+            _make_entity("t1", EntityType.TEXT, "NOTES",
+                         text_content="Note 1"),
+            _make_entity("t2", EntityType.MTEXT, "NOTES",
+                         text_content="Note 2"),
+        ]
+        context = _make_context(entities=entities, layers=["NOTES"])
+        zones = _make_zones_result()
+
+        summary = summarize_drawing(context, zones=zones)
+
+        features_text = " ".join(summary.key_features)
+        assert "text" in features_text.lower()
+
+    def test_layer_breakdown(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "WALLS"),
+            _make_entity("l2", EntityType.LINE, "WALLS"),
+            _make_entity("t1", EntityType.TEXT, "NOTES"),
+        ]
+        context = _make_context(entities=entities, layers=["WALLS", "NOTES"])
+        zones = _make_zones_result()
+
+        summary = summarize_drawing(context, zones=zones)
+
+        assert len(summary.layer_breakdown) >= 2
+        # Should contain layer names and counts
+        breakdown_text = " ".join(summary.layer_breakdown)
+        assert "WALLS" in breakdown_text
+        assert "NOTES" in breakdown_text
+
+    def test_plain_description_is_readable(self):
+        entities = [
+            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+            _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
+        ]
+        bedroom = _make_zone("z1", area=1500.0, inferred_type="bedroom")
+        context = _make_context(entities=entities, layers=["STRUCTURAL"])
+        zones = _make_zones_result([bedroom])
+
+        summary = summarize_drawing(context, zones=zones)
+
+        assert len(summary.plain_description) > 0
+        assert "entities" in summary.plain_description.lower()
+        assert "1500" in summary.plain_description  # area
+
+    def test_no_zones_description(self):
+        entities = [_make_entity("l1", EntityType.LINE, "0")]
+        context = _make_context(entities=entities)
+        zones = _make_zones_result()
+
+        summary = summarize_drawing(context, zones=zones)
+
+        assert "No enclosed spaces" in summary.plain_description
+
+    def test_room_types_in_features(self):
+        zones_list = [
+            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+            _make_zone("z2", area=1000.0, inferred_type="kitchen"),
+            _make_zone("z3", area=500.0, inferred_type="bathroom"),
+        ]
+        context = _make_context(entities=[
+            _make_entity("l1", EntityType.LINE, "0"),
+        ])
+        zones = _make_zones_result(zones_list)
+
+        summary = summarize_drawing(context, zones=zones)
+
+        features_text = " ".join(summary.key_features)
+        assert "bedroom" in features_text.lower()
+        assert "kitchen" in features_text.lower()
+
+
+# ===================================================================
+# SummarizeHandler Stage Handler Tests
+# ===================================================================
+
+
+class TestSummarizeHandler:
+    """Test the SummarizeHandler stage handler."""
+
+    def test_handler_no_context(self):
+        handler = SummarizeHandler()
+        classification = ObjectiveClassification(
+            request_class=RequestClass.SUMMARIZE,
+            objective_tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
+            confidence=0.9,
+        )
+        result = handler.execute(classification, {}, "summarize this")
+        assert "No drawing context" in result["summary"]
+
+    def test_handler_with_drawing_context(self):
+        handler = SummarizeHandler()
+        classification = ObjectiveClassification(
+            request_class=RequestClass.SUMMARIZE,
+            objective_tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
+            confidence=0.9,
+        )
+        context = _make_context(entities=[
+            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+            _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
+        ], layers=["STRUCTURAL"])
+        zones = _make_zones_result()
+
+        result = handler.execute(
+            classification,
+            {"drawing_context": context, "zones": zones},
+            "summarize this drawing",
+        )
+
+        assert "summary" in result
+        assert "drawing_type" in result
+        assert "entity_count" in result
+        assert result["entity_count"] == 2
+
+    def test_handler_with_zones(self):
+        handler = SummarizeHandler()
+        classification = ObjectiveClassification(
+            request_class=RequestClass.SUMMARIZE,
+            objective_tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
+            confidence=0.9,
+        )
+        context = _make_context(entities=[
+            _make_entity("l1", EntityType.LINE, "0"),
+        ])
+        bedroom = _make_zone("z1", area=1500.0, inferred_type="bedroom")
+        zones = _make_zones_result([bedroom])
+
+        result = handler.execute(
+            classification,
+            {"drawing_context": context, "zones": zones},
+            "explain this drawing",
+        )
+
+        assert result["room_count"] == 1
+        assert len(result["rooms"]) == 1
+        assert result["rooms"][0]["name"] == "Bedroom"


### PR DESCRIPTION
## Epic
EPIC-CAD-24: Plain-English drawing summary

## Summary
- Deterministic summarizer producing human-readable drawing explanations
- DrawingSummary with headline, rooms, key features, layer breakdown, plain description
- SummarizeHandler stage handler wired into existing SUMMARIZE pipeline
- Opens IntentCAD to non-CAD users: homeowners, facility managers, real estate agents

## Files
| File | Type | Purpose |
|------|------|---------|
| `core/drawing_summarizer.py` | NEW | summarize_drawing() + DrawingSummary model |
| `llm/stage_handlers/summarize_handler.py` | NEW | Pipeline stage handler |
| `tests/unit/test_drawing_summarizer.py` | NEW | 14 tests |

## Test plan
- 14 new unit tests (all pass)
- Full suite: 3,197 passed, 5 skipped
- Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)