### PR TITLE
feat: EPIC-CAD-26 Revision summary report with zone-based area deltas

### DIFF
--- a/src/cad_dxf_agent/core/revision_report.py
+++ b/src/cad_dxf_agent/core/revision_report.py
@@ -1,0 +1,292 @@
+"""Revision report — human-readable comparison summary with delta analysis.
+
+Combines the comparison engine's structured changelog with zone detection
+on both drawing versions to produce area deltas and a plain-language
+revision summary for project managers and stakeholders.
+
+Public API:
+    generate_revision_report(master, revision, changelog) -> RevisionReport
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from cad_dxf_agent.core.comparison.changelog import ChangeLog, ChangeLogEntry
+from cad_dxf_agent.core.zone_detector import detect_zones
+from cad_dxf_agent.models.cad_schema import DrawingContext
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+
+class ZoneDelta(BaseModel):
+    """Change in a single zone between revisions."""
+
+    zone_type: str
+    status: str  # "added", "removed", "resized", "unchanged"
+    old_area: float | None = None
+    new_area: float | None = None
+    area_change: float = 0.0
+
+
+class ChangeCategorySummary(BaseModel):
+    """Summary of changes by category (added, modified, removed, moved)."""
+
+    category: str
+    count: int
+    layers_affected: list[str] = Field(default_factory=list)
+    sample_descriptions: list[str] = Field(default_factory=list)
+
+
+class RevisionReport(BaseModel):
+    """Structured revision report combining diff + zone analysis."""
+
+    headline: str
+    total_changes: int = 0
+    change_categories: list[ChangeCategorySummary] = Field(
+        default_factory=list,
+    )
+    zone_deltas: list[ZoneDelta] = Field(default_factory=list)
+    old_total_area: float = 0.0
+    new_total_area: float = 0.0
+    area_change: float = 0.0
+    old_zone_count: int = 0
+    new_zone_count: int = 0
+    plain_summary: str = ""
+
+
+def generate_revision_report(
+    master_context: DrawingContext,
+    revision_context: DrawingContext,
+    changelog: ChangeLog,
+    *,
+    master_zones: ZoneDetectionResult | None = None,
+    revision_zones: ZoneDetectionResult | None = None,
+) -> RevisionReport:
+    """Generate a human-readable revision report.
+
+    Args:
+        master_context: Original drawing context.
+        revision_context: Revised drawing context.
+        changelog: Structured change log from comparison engine.
+        master_zones: Pre-computed zones for master (computed if None).
+        revision_zones: Pre-computed zones for revision (computed if None).
+
+    Returns:
+        RevisionReport with change categories, zone deltas, and summary.
+    """
+    if master_zones is None:
+        master_zones = detect_zones(master_context)
+    if revision_zones is None:
+        revision_zones = detect_zones(revision_context)
+
+    # Categorize changes
+    change_categories = _categorize_changes(changelog.entries)
+
+    # Compute zone deltas
+    zone_deltas = _compute_zone_deltas(master_zones, revision_zones)
+
+    old_total = master_zones.total_area
+    new_total = revision_zones.total_area
+    area_change = new_total - old_total
+
+    # Build headline and summary
+    headline = _build_headline(changelog, zone_deltas, area_change)
+    plain_summary = _build_plain_summary(
+        changelog, change_categories, zone_deltas, area_change,
+        master_context, revision_context,
+    )
+
+    return RevisionReport(
+        headline=headline,
+        total_changes=len(changelog.entries),
+        change_categories=change_categories,
+        zone_deltas=zone_deltas,
+        old_total_area=round(old_total, 1),
+        new_total_area=round(new_total, 1),
+        area_change=round(area_change, 1),
+        old_zone_count=master_zones.zone_count,
+        new_zone_count=revision_zones.zone_count,
+        plain_summary=plain_summary,
+    )
+
+
+def _categorize_changes(
+    entries: list[ChangeLogEntry],
+) -> list[ChangeCategorySummary]:
+    """Group changelog entries by category."""
+    by_cat: dict[str, list[ChangeLogEntry]] = {}
+    for entry in entries:
+        by_cat.setdefault(entry.category, []).append(entry)
+
+    summaries: list[ChangeCategorySummary] = []
+    for category, cat_entries in sorted(by_cat.items()):
+        layers = sorted({e.layer for e in cat_entries})
+        descriptions = [e.description for e in cat_entries[:5]]
+        summaries.append(ChangeCategorySummary(
+            category=category,
+            count=len(cat_entries),
+            layers_affected=layers,
+            sample_descriptions=descriptions,
+        ))
+
+    return summaries
+
+
+def _compute_zone_deltas(
+    master_zones: ZoneDetectionResult,
+    revision_zones: ZoneDetectionResult,
+) -> list[ZoneDelta]:
+    """Compare zones between versions to find added/removed/resized spaces."""
+    deltas: list[ZoneDelta] = []
+
+    # Build lookup by inferred_type for comparison
+    old_by_type: dict[str, list[float]] = {}
+    for zone in master_zones.zones:
+        zone_type = zone.inferred_type or "unknown"
+        old_by_type.setdefault(zone_type, []).append(zone.area)
+
+    new_by_type: dict[str, list[float]] = {}
+    for zone in revision_zones.zones:
+        zone_type = zone.inferred_type or "unknown"
+        new_by_type.setdefault(zone_type, []).append(zone.area)
+
+    all_types = sorted(set(old_by_type.keys()) | set(new_by_type.keys()))
+
+    for zone_type in all_types:
+        old_areas = sorted(old_by_type.get(zone_type, []))
+        new_areas = sorted(new_by_type.get(zone_type, []))
+
+        old_count = len(old_areas)
+        new_count = len(new_areas)
+
+        if old_count == 0 and new_count > 0:
+            # All zones of this type are new
+            for area in new_areas:
+                deltas.append(ZoneDelta(
+                    zone_type=zone_type,
+                    status="added",
+                    new_area=round(area, 1),
+                    area_change=round(area, 1),
+                ))
+        elif old_count > 0 and new_count == 0:
+            # All zones of this type were removed
+            for area in old_areas:
+                deltas.append(ZoneDelta(
+                    zone_type=zone_type,
+                    status="removed",
+                    old_area=round(area, 1),
+                    area_change=round(-area, 1),
+                ))
+        else:
+            # Compare counts
+            matched = min(old_count, new_count)
+            for i in range(matched):
+                old_a = old_areas[i]
+                new_a = new_areas[i]
+                change = new_a - old_a
+                status = "resized" if abs(change) > 0.1 else "unchanged"
+                deltas.append(ZoneDelta(
+                    zone_type=zone_type,
+                    status=status,
+                    old_area=round(old_a, 1),
+                    new_area=round(new_a, 1),
+                    area_change=round(change, 1),
+                ))
+
+            # Extra new zones
+            for i in range(matched, new_count):
+                deltas.append(ZoneDelta(
+                    zone_type=zone_type,
+                    status="added",
+                    new_area=round(new_areas[i], 1),
+                    area_change=round(new_areas[i], 1),
+                ))
+
+            # Extra removed zones
+            for i in range(matched, old_count):
+                deltas.append(ZoneDelta(
+                    zone_type=zone_type,
+                    status="removed",
+                    old_area=round(old_areas[i], 1),
+                    area_change=round(-old_areas[i], 1),
+                ))
+
+    return deltas
+
+
+def _build_headline(
+    changelog: ChangeLog,
+    zone_deltas: list[ZoneDelta],
+    area_change: float,
+) -> str:
+    """Build a concise headline summarizing the revision."""
+    parts: list[str] = []
+    parts.append(f"{len(changelog.entries)} change(s) detected")
+
+    added = sum(1 for d in zone_deltas if d.status == "added")
+    removed = sum(1 for d in zone_deltas if d.status == "removed")
+    resized = sum(1 for d in zone_deltas if d.status == "resized")
+
+    delta_parts: list[str] = []
+    if added:
+        delta_parts.append(f"{added} room(s) added")
+    if removed:
+        delta_parts.append(f"{removed} room(s) removed")
+    if resized:
+        delta_parts.append(f"{resized} room(s) resized")
+
+    if delta_parts:
+        parts.append(", ".join(delta_parts))
+
+    if abs(area_change) > 0.1:
+        sign = "+" if area_change > 0 else ""
+        parts.append(f"net area: {sign}{area_change:.0f} sq units")
+
+    return " — ".join(parts)
+
+
+def _build_plain_summary(
+    changelog: ChangeLog,
+    change_categories: list[ChangeCategorySummary],
+    zone_deltas: list[ZoneDelta],
+    area_change: float,
+    master_context: DrawingContext,
+    revision_context: DrawingContext,
+) -> str:
+    """Build a multi-sentence plain-English summary."""
+    sentences: list[str] = []
+
+    sentences.append(
+        f"Comparison of '{master_context.file_path}' "
+        f"and '{revision_context.file_path}': "
+        f"{len(changelog.entries)} change(s) detected."
+    )
+
+    if change_categories:
+        cat_strs = [
+            f"{c.count} {c.category}" for c in change_categories
+        ]
+        sentences.append(f"Changes: {', '.join(cat_strs)}.")
+
+    added = [d for d in zone_deltas if d.status == "added"]
+    removed = [d for d in zone_deltas if d.status == "removed"]
+    resized = [d for d in zone_deltas if d.status == "resized"]
+
+    if added:
+        types = ", ".join(d.zone_type for d in added[:3])
+        sentences.append(f"{len(added)} space(s) added: {types}.")
+
+    if removed:
+        types = ", ".join(d.zone_type for d in removed[:3])
+        sentences.append(f"{len(removed)} space(s) removed: {types}.")
+
+    if resized:
+        sentences.append(f"{len(resized)} space(s) resized.")
+
+    if abs(area_change) > 0.1:
+        sign = "+" if area_change > 0 else ""
+        sentences.append(
+            f"Net area change: {sign}{area_change:.0f} square units."
+        )
+
+    return " ".join(sentences)

--- a/tests/unit/test_revision_report.py
+++ b/tests/unit/test_revision_report.py
@@ -1,0 +1,333 @@
+"""Tests for the revision report (EPIC-CAD-26)."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.core.comparison.changelog import ChangeLog, ChangeLogEntry
+from cad_dxf_agent.core.revision_report import (
+    RevisionReport,
+    ZoneDelta,
+    _build_headline,
+    _categorize_changes,
+    _compute_zone_deltas,
+    generate_revision_report,
+)
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
+
+# --- Helpers ---
+
+
+def _make_context(
+    entities: list[EntityRef] | None = None,
+    layers: list[str] | None = None,
+    file_path: str = "test.dxf",
+) -> DrawingContext:
+    layer_rules = [LayerRule(name=n, color=1) for n in (layers or ["0"])]
+    return DrawingContext(
+        file_path=file_path,
+        entities=entities or [],
+        layers=layer_rules,
+    )
+
+
+def _make_entry(
+    category: str = "modified",
+    entity_type: str = "LINE",
+    layer: str = "WALLS",
+    description: str = "Wall moved 10 units",
+) -> ChangeLogEntry:
+    return ChangeLogEntry(
+        category=category,
+        entity_type=entity_type,
+        layer=layer,
+        description=description,
+    )
+
+
+def _make_zone(
+    zone_id: str = "z1",
+    area: float = 200.0,
+    inferred_type: str | None = "room",
+) -> DetectedZone:
+    return DetectedZone(
+        zone_id=zone_id,
+        boundary=[
+            Point2D(x=0, y=0),
+            Point2D(x=20, y=0),
+            Point2D(x=20, y=10),
+            Point2D(x=0, y=10),
+        ],
+        area=area,
+        perimeter=60.0,
+        centroid=Point2D(x=10, y=5),
+        inferred_type=inferred_type,
+        source_handles=["h1"],
+    )
+
+
+def _make_zones_result(
+    zones: list[DetectedZone] | None = None,
+) -> ZoneDetectionResult:
+    zone_list = zones or []
+    return ZoneDetectionResult(
+        zones=zone_list,
+        total_area=sum(z.area for z in zone_list),
+        zone_count=len(zone_list),
+        confidence=0.8,
+    )
+
+
+# ===================================================================
+# Schema Tests
+# ===================================================================
+
+
+class TestRevisionReportSchema:
+    """Test RevisionReport model."""
+
+    def test_report_defaults(self):
+        r = RevisionReport(headline="Test")
+        assert r.total_changes == 0
+        assert r.zone_deltas == []
+        assert r.area_change == 0.0
+
+    def test_zone_delta_model(self):
+        d = ZoneDelta(
+            zone_type="bedroom",
+            status="added",
+            new_area=1500.0,
+            area_change=1500.0,
+        )
+        assert d.zone_type == "bedroom"
+        assert d.status == "added"
+
+
+# ===================================================================
+# Change Categorization
+# ===================================================================
+
+
+class TestCategorizeChanges:
+    """Test changelog entry categorization."""
+
+    def test_group_by_category(self):
+        entries = [
+            _make_entry("added", description="New wall"),
+            _make_entry("added", description="New door"),
+            _make_entry("modified", description="Wall moved"),
+            _make_entry("removed", description="Old fixture removed"),
+        ]
+        categories = _categorize_changes(entries)
+
+        cat_dict = {c.category: c for c in categories}
+        assert cat_dict["added"].count == 2
+        assert cat_dict["modified"].count == 1
+        assert cat_dict["removed"].count == 1
+
+    def test_layers_affected(self):
+        entries = [
+            _make_entry("modified", layer="WALLS"),
+            _make_entry("modified", layer="DOORS"),
+            _make_entry("modified", layer="WALLS"),
+        ]
+        categories = _categorize_changes(entries)
+
+        assert len(categories) == 1
+        assert set(categories[0].layers_affected) == {"WALLS", "DOORS"}
+
+    def test_empty_changelog(self):
+        categories = _categorize_changes([])
+        assert len(categories) == 0
+
+    def test_sample_descriptions_limited(self):
+        entries = [_make_entry("added", description=f"Item {i}") for i in range(10)]
+        categories = _categorize_changes(entries)
+
+        assert len(categories[0].sample_descriptions) <= 5
+
+
+# ===================================================================
+# Zone Delta Computation
+# ===================================================================
+
+
+class TestComputeZoneDeltas:
+    """Test zone-based area delta computation."""
+
+    def test_room_added(self):
+        old_zones = _make_zones_result()
+        new_zones = _make_zones_result([
+            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+        ])
+        deltas = _compute_zone_deltas(old_zones, new_zones)
+
+        assert len(deltas) == 1
+        assert deltas[0].status == "added"
+        assert deltas[0].zone_type == "bedroom"
+        assert deltas[0].new_area == 1500.0
+
+    def test_room_removed(self):
+        old_zones = _make_zones_result([
+            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+        ])
+        new_zones = _make_zones_result()
+        deltas = _compute_zone_deltas(old_zones, new_zones)
+
+        assert len(deltas) == 1
+        assert deltas[0].status == "removed"
+        assert deltas[0].old_area == 1500.0
+        assert deltas[0].area_change == -1500.0
+
+    def test_room_resized(self):
+        old_zones = _make_zones_result([
+            _make_zone("z1", area=1000.0, inferred_type="kitchen"),
+        ])
+        new_zones = _make_zones_result([
+            _make_zone("z1", area=1200.0, inferred_type="kitchen"),
+        ])
+        deltas = _compute_zone_deltas(old_zones, new_zones)
+
+        assert len(deltas) == 1
+        assert deltas[0].status == "resized"
+        assert deltas[0].area_change == 200.0
+
+    def test_room_unchanged(self):
+        zone = _make_zone("z1", area=1000.0, inferred_type="bedroom")
+        old_zones = _make_zones_result([zone])
+        new_zones = _make_zones_result([zone])
+        deltas = _compute_zone_deltas(old_zones, new_zones)
+
+        assert len(deltas) == 1
+        assert deltas[0].status == "unchanged"
+
+    def test_mixed_changes(self):
+        old_zones = _make_zones_result([
+            _make_zone("z1", area=1000.0, inferred_type="bedroom"),
+            _make_zone("z2", area=500.0, inferred_type="bathroom"),
+        ])
+        new_zones = _make_zones_result([
+            _make_zone("z1", area=1200.0, inferred_type="bedroom"),
+            _make_zone("z3", area=800.0, inferred_type="kitchen"),
+        ])
+        deltas = _compute_zone_deltas(old_zones, new_zones)
+
+        statuses = {d.status for d in deltas}
+        assert "resized" in statuses  # bedroom
+        assert "removed" in statuses  # bathroom
+        assert "added" in statuses  # kitchen
+
+
+# ===================================================================
+# Headline Building
+# ===================================================================
+
+
+class TestBuildHeadline:
+    """Test headline generation."""
+
+    def test_headline_with_changes(self):
+        changelog = ChangeLog(entries=[_make_entry(), _make_entry()])
+        deltas = [
+            ZoneDelta(zone_type="bedroom", status="added",
+                      new_area=1500.0, area_change=1500.0),
+        ]
+        headline = _build_headline(changelog, deltas, 1500.0)
+
+        assert "2 change(s)" in headline
+        assert "1 room(s) added" in headline
+        assert "+1500" in headline
+
+    def test_headline_no_changes(self):
+        changelog = ChangeLog(entries=[])
+        headline = _build_headline(changelog, [], 0.0)
+        assert "0 change(s)" in headline
+
+    def test_headline_negative_area(self):
+        changelog = ChangeLog(entries=[_make_entry()])
+        deltas = [
+            ZoneDelta(zone_type="closet", status="removed",
+                      old_area=50.0, area_change=-50.0),
+        ]
+        headline = _build_headline(changelog, deltas, -50.0)
+        assert "-50" in headline
+
+
+# ===================================================================
+# Full Report Generation
+# ===================================================================
+
+
+class TestGenerateRevisionReport:
+    """Integration tests for generate_revision_report()."""
+
+    def test_empty_drawings(self):
+        master = _make_context(file_path="master.dxf")
+        revision = _make_context(file_path="revision.dxf")
+        changelog = ChangeLog(entries=[])
+        master_zones = _make_zones_result()
+        revision_zones = _make_zones_result()
+
+        report = generate_revision_report(
+            master, revision, changelog,
+            master_zones=master_zones,
+            revision_zones=revision_zones,
+        )
+
+        assert isinstance(report, RevisionReport)
+        assert report.total_changes == 0
+        assert report.area_change == 0.0
+        assert "0 change(s)" in report.headline
+
+    def test_report_with_changes_and_zones(self):
+        master = _make_context(file_path="master.dxf")
+        revision = _make_context(file_path="revision.dxf")
+        changelog = ChangeLog(entries=[
+            _make_entry("added", description="New wall added"),
+            _make_entry("modified", description="Wall moved"),
+            _make_entry("removed", description="Old fixture removed"),
+        ])
+        master_zones = _make_zones_result([
+            _make_zone("z1", area=1000.0, inferred_type="bedroom"),
+        ])
+        revision_zones = _make_zones_result([
+            _make_zone("z1", area=1200.0, inferred_type="bedroom"),
+            _make_zone("z2", area=800.0, inferred_type="kitchen"),
+        ])
+
+        report = generate_revision_report(
+            master, revision, changelog,
+            master_zones=master_zones,
+            revision_zones=revision_zones,
+        )
+
+        assert report.total_changes == 3
+        assert len(report.change_categories) == 3
+        assert report.old_zone_count == 1
+        assert report.new_zone_count == 2
+        assert report.area_change == 1000.0  # +200 resize + 800 new
+
+    def test_plain_summary_readable(self):
+        master = _make_context(file_path="floor_plan_v1.dxf")
+        revision = _make_context(file_path="floor_plan_v2.dxf")
+        changelog = ChangeLog(entries=[
+            _make_entry("added", description="New bedroom wall"),
+        ])
+        master_zones = _make_zones_result()
+        revision_zones = _make_zones_result([
+            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+        ])
+
+        report = generate_revision_report(
+            master, revision, changelog,
+            master_zones=master_zones,
+            revision_zones=revision_zones,
+        )
+
+        assert "floor_plan_v1.dxf" in report.plain_summary
+        assert "1 change(s)" in report.plain_summary
+        assert "added" in report.plain_summary.lower()


### PR DESCRIPTION
## Epic
EPIC-CAD-26: Revision summary report

## Bead(s)
cad-dxf-agent-lk9

## Summary
- **Revision report engine** that combines the comparison changelog with zone detection on both drawing versions to produce area deltas and plain-language summaries
- **Zone delta computation** tracks added/removed/resized/unchanged rooms with area changes, matching zones by inferred type
- **Human-readable output** for project managers: "12 changes detected: 3 walls moved, 2 rooms added — net area +180 sq ft"

## What's new
| File | Purpose |
|------|---------|
| `core/revision_report.py` | `generate_revision_report()` → `RevisionReport` with zone deltas, change categories, headline, plain summary |
| `tests/unit/test_revision_report.py` | 17 tests: schemas, categorization, zone deltas (add/remove/resize/unchanged/mixed), headline, full integration |

## Architecture
- `_categorize_changes()` groups `ChangeLogEntry` by category with layer and description info
- `_compute_zone_deltas()` compares zones by `inferred_type` — handles N:M matching (sorted by area)
- `_build_headline()` produces concise one-liner with change count, room changes, net area
- `_build_plain_summary()` produces multi-sentence plain-English paragraph referencing file names

## Test plan
- [x] 17 unit tests all passing
- [x] Full suite: 3200 passed, 5 skipped
- [x] Lint clean (`ruff check`)
- [x] Schema defaults, zone delta edge cases, empty inputs, mixed changes all covered

## Docs
No new docs — feature documented inline with comprehensive docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)