### PR TITLE
feat: EPIC-CAD-21 compliance endpoint + stage handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ disallow_untyped_defs = false
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "fitz.*", "matplotlib.*", "fpdf.*", "google.*", "vertexai.*"]
+module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "fitz.*", "matplotlib.*", "fpdf.*", "google.*", "vertexai.*", "rtree.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/cad_dxf_agent/core/compliance_rules.py
+++ b/src/cad_dxf_agent/core/compliance_rules.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable
 
 from cad_dxf_agent.core.entity_index import EntityIndex
 from cad_dxf_agent.core.zone_detector import detect_zones
@@ -30,6 +31,12 @@ from cad_dxf_agent.models.compliance_schema import (
 from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
 
 logger = logging.getLogger(__name__)
+
+# Type alias for check functions
+_CheckFn = Callable[
+    [DrawingContext, ZoneDetectionResult, EntityIndex, ComplianceThresholds],
+    list[ComplianceFinding],
+]
 
 # --- Block name patterns for door/window detection ---
 _DOOR_PATTERNS = re.compile(
@@ -470,19 +477,8 @@ def _check_dead_end_corridors(
 
 # --- Check registry ---
 
-_ALL_CHECKS: list[
-    tuple[
-        type[None]
-        | type[
-            list[ComplianceFinding]
-        ],
-        ComplianceCategory,
-        str,
-    ]
-] = []
-
-# Use a simpler approach: list of (function, category, name) tuples
-_ALL_CHECKS = [
+# Check registry: list of (function, category, name) tuples
+_ALL_CHECKS: list[tuple[_CheckFn, ComplianceCategory, str]] = [
     (_check_door_widths, ComplianceCategory.DOOR, "door_widths"),
     (_check_door_count, ComplianceCategory.DOOR, "door_count"),
     (_check_hallway_widths, ComplianceCategory.CORRIDOR, "hallway_widths"),

--- a/src/cad_dxf_agent/core/compliance_rules.py
+++ b/src/cad_dxf_agent/core/compliance_rules.py
@@ -69,8 +69,7 @@ def check_compliance(
         prof = BUILTIN_PROFILES.get(profile)
         if prof is None:
             raise ValueError(
-                f"Unknown profile: {profile}. "
-                f"Available: {', '.join(BUILTIN_PROFILES)}"
+                f"Unknown profile: {profile}. Available: {', '.join(BUILTIN_PROFILES)}"
             )
     else:
         prof = profile
@@ -92,15 +91,9 @@ def check_compliance(
             results = check_fn(context, zones, index, thresholds)
             findings.extend(results)
 
-    violation_count = sum(
-        1 for f in findings if f.severity == ComplianceSeverity.VIOLATION
-    )
-    warning_count = sum(
-        1 for f in findings if f.severity == ComplianceSeverity.WARNING
-    )
-    pass_count = sum(
-        1 for f in findings if f.severity == ComplianceSeverity.PASS
-    )
+    violation_count = sum(1 for f in findings if f.severity == ComplianceSeverity.VIOLATION)
+    warning_count = sum(1 for f in findings if f.severity == ComplianceSeverity.WARNING)
+    pass_count = sum(1 for f in findings if f.severity == ComplianceSeverity.PASS)
 
     return ComplianceReport(
         profile_name=prof.name,
@@ -139,36 +132,40 @@ def _check_door_widths(
         width = _extract_dimension_from_attributes(entity.attributes)
 
         if width is not None and width < thresholds.min_door_width:
-            findings.append(ComplianceFinding(
-                rule_id="DOOR-WIDTH-001",
-                category=ComplianceCategory.DOOR,
-                severity=ComplianceSeverity.VIOLATION,
-                title="Door width below minimum",
-                description=(
-                    f"Door '{entity.block_name}' has width {width:.1f} "
-                    f"but minimum is {thresholds.min_door_width:.1f}"
-                ),
-                code_reference="ADA 404.2.3 / IBC 1010.1.1",
-                entity_handles=[entity.handle],
-                measured_value=width,
-                required_value=thresholds.min_door_width,
-                unit="drawing_units",
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="DOOR-WIDTH-001",
+                    category=ComplianceCategory.DOOR,
+                    severity=ComplianceSeverity.VIOLATION,
+                    title="Door width below minimum",
+                    description=(
+                        f"Door '{entity.block_name}' has width {width:.1f} "
+                        f"but minimum is {thresholds.min_door_width:.1f}"
+                    ),
+                    code_reference="ADA 404.2.3 / IBC 1010.1.1",
+                    entity_handles=[entity.handle],
+                    measured_value=width,
+                    required_value=thresholds.min_door_width,
+                    unit="drawing_units",
+                )
+            )
         elif width is not None and width >= thresholds.min_door_width:
-            findings.append(ComplianceFinding(
-                rule_id="DOOR-WIDTH-001",
-                category=ComplianceCategory.DOOR,
-                severity=ComplianceSeverity.PASS,
-                title="Door width meets minimum",
-                description=(
-                    f"Door '{entity.block_name}' width {width:.1f} "
-                    f"meets minimum {thresholds.min_door_width:.1f}"
-                ),
-                entity_handles=[entity.handle],
-                measured_value=width,
-                required_value=thresholds.min_door_width,
-                unit="drawing_units",
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="DOOR-WIDTH-001",
+                    category=ComplianceCategory.DOOR,
+                    severity=ComplianceSeverity.PASS,
+                    title="Door width meets minimum",
+                    description=(
+                        f"Door '{entity.block_name}' width {width:.1f} "
+                        f"meets minimum {thresholds.min_door_width:.1f}"
+                    ),
+                    entity_handles=[entity.handle],
+                    measured_value=width,
+                    required_value=thresholds.min_door_width,
+                    unit="drawing_units",
+                )
+            )
 
     return findings
 
@@ -186,48 +183,49 @@ def _check_hallway_widths(
     """
     findings: list[ComplianceFinding] = []
 
-    hallways = [
-        z for z in zones.zones
-        if z.inferred_type in ("hallway", "corridor")
-    ]
+    hallways = [z for z in zones.zones if z.inferred_type in ("hallway", "corridor")]
 
     for zone in hallways:
         min_dim = _zone_min_dimension(zone)
         if min_dim < thresholds.min_hallway_width:
-            findings.append(ComplianceFinding(
-                rule_id="CORRIDOR-WIDTH-001",
-                category=ComplianceCategory.CORRIDOR,
-                severity=ComplianceSeverity.VIOLATION,
-                title="Corridor width below minimum",
-                description=(
-                    f"Corridor (zone {zone.zone_id[:8]}) has width "
-                    f"{min_dim:.1f} but minimum is "
-                    f"{thresholds.min_hallway_width:.1f}"
-                ),
-                code_reference="IBC 1020.2 / ADA 403.5.1",
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-                measured_value=min_dim,
-                required_value=thresholds.min_hallway_width,
-                unit="drawing_units",
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="CORRIDOR-WIDTH-001",
+                    category=ComplianceCategory.CORRIDOR,
+                    severity=ComplianceSeverity.VIOLATION,
+                    title="Corridor width below minimum",
+                    description=(
+                        f"Corridor (zone {zone.zone_id[:8]}) has width "
+                        f"{min_dim:.1f} but minimum is "
+                        f"{thresholds.min_hallway_width:.1f}"
+                    ),
+                    code_reference="IBC 1020.2 / ADA 403.5.1",
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                    measured_value=min_dim,
+                    required_value=thresholds.min_hallway_width,
+                    unit="drawing_units",
+                )
+            )
         else:
-            findings.append(ComplianceFinding(
-                rule_id="CORRIDOR-WIDTH-001",
-                category=ComplianceCategory.CORRIDOR,
-                severity=ComplianceSeverity.PASS,
-                title="Corridor width meets minimum",
-                description=(
-                    f"Corridor (zone {zone.zone_id[:8]}) width "
-                    f"{min_dim:.1f} meets minimum "
-                    f"{thresholds.min_hallway_width:.1f}"
-                ),
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-                measured_value=min_dim,
-                required_value=thresholds.min_hallway_width,
-                unit="drawing_units",
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="CORRIDOR-WIDTH-001",
+                    category=ComplianceCategory.CORRIDOR,
+                    severity=ComplianceSeverity.PASS,
+                    title="Corridor width meets minimum",
+                    description=(
+                        f"Corridor (zone {zone.zone_id[:8]}) width "
+                        f"{min_dim:.1f} meets minimum "
+                        f"{thresholds.min_hallway_width:.1f}"
+                    ),
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                    measured_value=min_dim,
+                    required_value=thresholds.min_hallway_width,
+                    unit="drawing_units",
+                )
+            )
 
     return findings
 
@@ -245,8 +243,14 @@ def _check_room_areas(
     findings: list[ComplianceFinding] = []
 
     habitable_types = {
-        "bedroom", "living_room", "family_room", "dining_room",
-        "kitchen", "office", "room", "large_room",
+        "bedroom",
+        "living_room",
+        "family_room",
+        "dining_room",
+        "kitchen",
+        "office",
+        "room",
+        "large_room",
     }
     bathroom_types = {"bathroom"}
 
@@ -257,63 +261,67 @@ def _check_room_areas(
                 min_area = thresholds.min_bedroom_area
 
             if zone.area < min_area:
-                findings.append(ComplianceFinding(
-                    rule_id="ROOM-AREA-001",
-                    category=ComplianceCategory.ROOM_SIZE,
-                    severity=ComplianceSeverity.VIOLATION,
-                    title=f"{zone.inferred_type.replace('_', ' ').title()} "
-                          f"area below minimum",
-                    description=(
-                        f"Zone {zone.zone_id[:8]} "
-                        f"({zone.inferred_type}) has area {zone.area:.1f} "
-                        f"but minimum is {min_area:.1f}"
-                    ),
-                    code_reference="IBC 1208.1 / IRC R304.1",
-                    zone_id=zone.zone_id,
-                    entity_handles=zone.source_handles,
-                    measured_value=zone.area,
-                    required_value=min_area,
-                    unit="drawing_units²",
-                ))
+                findings.append(
+                    ComplianceFinding(
+                        rule_id="ROOM-AREA-001",
+                        category=ComplianceCategory.ROOM_SIZE,
+                        severity=ComplianceSeverity.VIOLATION,
+                        title=f"{zone.inferred_type.replace('_', ' ').title()} area below minimum",
+                        description=(
+                            f"Zone {zone.zone_id[:8]} "
+                            f"({zone.inferred_type}) has area {zone.area:.1f} "
+                            f"but minimum is {min_area:.1f}"
+                        ),
+                        code_reference="IBC 1208.1 / IRC R304.1",
+                        zone_id=zone.zone_id,
+                        entity_handles=zone.source_handles,
+                        measured_value=zone.area,
+                        required_value=min_area,
+                        unit="drawing_units²",
+                    )
+                )
             else:
-                findings.append(ComplianceFinding(
-                    rule_id="ROOM-AREA-001",
-                    category=ComplianceCategory.ROOM_SIZE,
-                    severity=ComplianceSeverity.PASS,
-                    title=f"{zone.inferred_type.replace('_', ' ').title()} "
-                          f"area meets minimum",
-                    description=(
-                        f"Zone {zone.zone_id[:8]} "
-                        f"({zone.inferred_type}) area {zone.area:.1f} "
-                        f"meets minimum {min_area:.1f}"
-                    ),
-                    zone_id=zone.zone_id,
-                    entity_handles=zone.source_handles,
-                    measured_value=zone.area,
-                    required_value=min_area,
-                    unit="drawing_units²",
-                ))
+                findings.append(
+                    ComplianceFinding(
+                        rule_id="ROOM-AREA-001",
+                        category=ComplianceCategory.ROOM_SIZE,
+                        severity=ComplianceSeverity.PASS,
+                        title=f"{zone.inferred_type.replace('_', ' ').title()} area meets minimum",
+                        description=(
+                            f"Zone {zone.zone_id[:8]} "
+                            f"({zone.inferred_type}) area {zone.area:.1f} "
+                            f"meets minimum {min_area:.1f}"
+                        ),
+                        zone_id=zone.zone_id,
+                        entity_handles=zone.source_handles,
+                        measured_value=zone.area,
+                        required_value=min_area,
+                        unit="drawing_units²",
+                    )
+                )
 
         elif zone.inferred_type in bathroom_types:
             min_area = thresholds.min_bathroom_area
             if zone.area < min_area:
-                findings.append(ComplianceFinding(
-                    rule_id="ROOM-AREA-002",
-                    category=ComplianceCategory.ROOM_SIZE,
-                    severity=ComplianceSeverity.WARNING,
-                    title="Bathroom area below recommended minimum",
-                    description=(
-                        f"Zone {zone.zone_id[:8]} (bathroom) has area "
-                        f"{zone.area:.1f} but recommended minimum is "
-                        f"{min_area:.1f}"
-                    ),
-                    code_reference="IRC R304",
-                    zone_id=zone.zone_id,
-                    entity_handles=zone.source_handles,
-                    measured_value=zone.area,
-                    required_value=min_area,
-                    unit="drawing_units²",
-                ))
+                findings.append(
+                    ComplianceFinding(
+                        rule_id="ROOM-AREA-002",
+                        category=ComplianceCategory.ROOM_SIZE,
+                        severity=ComplianceSeverity.WARNING,
+                        title="Bathroom area below recommended minimum",
+                        description=(
+                            f"Zone {zone.zone_id[:8]} (bathroom) has area "
+                            f"{zone.area:.1f} but recommended minimum is "
+                            f"{min_area:.1f}"
+                        ),
+                        code_reference="IRC R304",
+                        zone_id=zone.zone_id,
+                        entity_handles=zone.source_handles,
+                        measured_value=zone.area,
+                        required_value=min_area,
+                        unit="drawing_units²",
+                    )
+                )
 
     return findings
 
@@ -332,8 +340,14 @@ def _check_egress(
     findings: list[ComplianceFinding] = []
 
     habitable_types = {
-        "bedroom", "living_room", "family_room", "dining_room",
-        "kitchen", "office", "room", "large_room",
+        "bedroom",
+        "living_room",
+        "family_room",
+        "dining_room",
+        "kitchen",
+        "office",
+        "room",
+        "large_room",
     }
 
     doors = _find_blocks_by_pattern(context, _DOOR_PATTERNS)
@@ -359,35 +373,39 @@ def _check_egress(
                 break
 
         if not has_egress:
-            findings.append(ComplianceFinding(
-                rule_id="EGRESS-001",
-                category=ComplianceCategory.EGRESS,
-                severity=ComplianceSeverity.WARNING,
-                title="Room may lack egress",
-                description=(
-                    f"Zone {zone.zone_id[:8]} "
-                    f"({zone.inferred_type}) has no door or window "
-                    f"detected within {search_radius:.0f} units of "
-                    f"its centroid"
-                ),
-                code_reference="IBC 1030.1 / IRC R310.1",
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="EGRESS-001",
+                    category=ComplianceCategory.EGRESS,
+                    severity=ComplianceSeverity.WARNING,
+                    title="Room may lack egress",
+                    description=(
+                        f"Zone {zone.zone_id[:8]} "
+                        f"({zone.inferred_type}) has no door or window "
+                        f"detected within {search_radius:.0f} units of "
+                        f"its centroid"
+                    ),
+                    code_reference="IBC 1030.1 / IRC R310.1",
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                )
+            )
         else:
-            findings.append(ComplianceFinding(
-                rule_id="EGRESS-001",
-                category=ComplianceCategory.EGRESS,
-                severity=ComplianceSeverity.PASS,
-                title="Room has egress",
-                description=(
-                    f"Zone {zone.zone_id[:8]} "
-                    f"({zone.inferred_type}) has door/window "
-                    f"within {search_radius:.0f} units"
-                ),
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="EGRESS-001",
+                    category=ComplianceCategory.EGRESS,
+                    severity=ComplianceSeverity.PASS,
+                    title="Room has egress",
+                    description=(
+                        f"Zone {zone.zone_id[:8]} "
+                        f"({zone.inferred_type}) has door/window "
+                        f"within {search_radius:.0f} units"
+                    ),
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                )
+            )
 
     return findings
 
@@ -409,27 +427,31 @@ def _check_door_count(
 
     doors = _find_blocks_by_pattern(context, _DOOR_PATTERNS)
     if not doors:
-        findings.append(ComplianceFinding(
-            rule_id="DOOR-COUNT-001",
-            category=ComplianceCategory.DOOR,
-            severity=ComplianceSeverity.WARNING,
-            title="No doors detected in drawing",
-            description=(
-                "Drawing has rooms but no door blocks detected. "
-                "Verify door symbols use standard block names "
-                "(DOOR, DR-, ENTRY, EXIT)."
-            ),
-            code_reference="IBC 1010.1",
-        ))
+        findings.append(
+            ComplianceFinding(
+                rule_id="DOOR-COUNT-001",
+                category=ComplianceCategory.DOOR,
+                severity=ComplianceSeverity.WARNING,
+                title="No doors detected in drawing",
+                description=(
+                    "Drawing has rooms but no door blocks detected. "
+                    "Verify door symbols use standard block names "
+                    "(DOOR, DR-, ENTRY, EXIT)."
+                ),
+                code_reference="IBC 1010.1",
+            )
+        )
     else:
-        findings.append(ComplianceFinding(
-            rule_id="DOOR-COUNT-001",
-            category=ComplianceCategory.DOOR,
-            severity=ComplianceSeverity.PASS,
-            title=f"{len(doors)} door(s) detected",
-            description=f"Drawing has {len(doors)} door block(s).",
-            entity_handles=[d.handle for d in doors[:10]],
-        ))
+        findings.append(
+            ComplianceFinding(
+                rule_id="DOOR-COUNT-001",
+                category=ComplianceCategory.DOOR,
+                severity=ComplianceSeverity.PASS,
+                title=f"{len(doors)} door(s) detected",
+                description=f"Drawing has {len(doors)} door block(s).",
+                entity_handles=[d.handle for d in doors[:10]],
+            )
+        )
 
     return findings
 
@@ -446,31 +468,30 @@ def _check_dead_end_corridors(
     """
     findings: list[ComplianceFinding] = []
 
-    hallways = [
-        z for z in zones.zones
-        if z.inferred_type in ("hallway", "corridor")
-    ]
+    hallways = [z for z in zones.zones if z.inferred_type in ("hallway", "corridor")]
 
     for zone in hallways:
         max_dim = _zone_max_dimension(zone)
         if max_dim > thresholds.max_dead_end_corridor_length:
-            findings.append(ComplianceFinding(
-                rule_id="CORRIDOR-LENGTH-001",
-                category=ComplianceCategory.CORRIDOR,
-                severity=ComplianceSeverity.WARNING,
-                title="Corridor may exceed dead-end limit",
-                description=(
-                    f"Corridor (zone {zone.zone_id[:8]}) has length "
-                    f"{max_dim:.1f} which exceeds dead-end limit of "
-                    f"{thresholds.max_dead_end_corridor_length:.1f}"
-                ),
-                code_reference="IBC 1020.4",
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-                measured_value=max_dim,
-                required_value=thresholds.max_dead_end_corridor_length,
-                unit="drawing_units",
-            ))
+            findings.append(
+                ComplianceFinding(
+                    rule_id="CORRIDOR-LENGTH-001",
+                    category=ComplianceCategory.CORRIDOR,
+                    severity=ComplianceSeverity.WARNING,
+                    title="Corridor may exceed dead-end limit",
+                    description=(
+                        f"Corridor (zone {zone.zone_id[:8]}) has length "
+                        f"{max_dim:.1f} which exceeds dead-end limit of "
+                        f"{thresholds.max_dead_end_corridor_length:.1f}"
+                    ),
+                    code_reference="IBC 1020.4",
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                    measured_value=max_dim,
+                    required_value=thresholds.max_dead_end_corridor_length,
+                    unit="drawing_units",
+                )
+            )
 
     return findings
 

--- a/src/cad_dxf_agent/core/cross_drawing_checker.py
+++ b/src/cad_dxf_agent/core/cross_drawing_checker.py
@@ -92,9 +92,7 @@ def check_consistency(
 
     # Count by severity
     error_count = sum(1 for f in findings if f.severity == ConsistencySeverity.ERROR)
-    warning_count = sum(
-        1 for f in findings if f.severity == ConsistencySeverity.WARNING
-    )
+    warning_count = sum(1 for f in findings if f.severity == ConsistencySeverity.WARNING)
     info_count = sum(1 for f in findings if f.severity == ConsistencySeverity.INFO)
 
     return ConsistencyReport(
@@ -158,9 +156,7 @@ def _check_room_labels(sheets: list[SheetInfo]) -> list[ConsistencyFinding]:
         if not sheet.room_labels:
             findings.append(
                 ConsistencyFinding(
-                    finding_id=_generate_finding_id(
-                        "room_labels", "no_labels", sheet.file_path
-                    ),
+                    finding_id=_generate_finding_id("room_labels", "no_labels", sheet.file_path),
                     category=ConsistencyCategory.ROOM_LABELS,
                     severity=ConsistencySeverity.INFO,
                     title="No room labels detected",
@@ -185,7 +181,9 @@ def _check_room_labels(sheets: list[SheetInfo]) -> list[ConsistencyFinding]:
             findings.append(
                 ConsistencyFinding(
                     finding_id=_generate_finding_id(
-                        "room_labels", f"missing_{label}", sheet_a.file_path,
+                        "room_labels",
+                        f"missing_{label}",
+                        sheet_a.file_path,
                         sheet_b.file_path,
                     ),
                     category=ConsistencyCategory.ROOM_LABELS,
@@ -205,7 +203,9 @@ def _check_room_labels(sheets: list[SheetInfo]) -> list[ConsistencyFinding]:
             findings.append(
                 ConsistencyFinding(
                     finding_id=_generate_finding_id(
-                        "room_labels", f"missing_{label}", sheet_b.file_path,
+                        "room_labels",
+                        f"missing_{label}",
+                        sheet_b.file_path,
                         sheet_a.file_path,
                     ),
                     category=ConsistencyCategory.ROOM_LABELS,
@@ -252,7 +252,8 @@ def _check_layer_naming(
             findings.append(
                 ConsistencyFinding(
                     finding_id=_generate_finding_id(
-                        "layer_naming", f"case_{lower_name}",
+                        "layer_naming",
+                        f"case_{lower_name}",
                         contexts[0].file_path,
                     ),
                     category=ConsistencyCategory.LAYER_NAMING,
@@ -285,7 +286,9 @@ def _check_layer_naming(
         findings.append(
             ConsistencyFinding(
                 finding_id=_generate_finding_id(
-                    "layer_naming", "mixed_delimiters", contexts[0].file_path,
+                    "layer_naming",
+                    "mixed_delimiters",
+                    contexts[0].file_path,
                 ),
                 category=ConsistencyCategory.LAYER_NAMING,
                 severity=ConsistencySeverity.INFO,
@@ -303,14 +306,14 @@ def _check_layer_naming(
     # Check for layers unique to a single sheet (excluding defaults)
     non_default_layers = all_layers - _DEFAULT_LAYERS
     for layer in sorted(non_default_layers):
-        present_in = [
-            fp for fp, layer_set in layers_per_sheet.items() if layer in layer_set
-        ]
+        present_in = [fp for fp, layer_set in layers_per_sheet.items() if layer in layer_set]
         if len(present_in) == 1 and len(contexts) > 1:
             findings.append(
                 ConsistencyFinding(
                     finding_id=_generate_finding_id(
-                        "layer_naming", f"unique_{layer}", present_in[0],
+                        "layer_naming",
+                        f"unique_{layer}",
+                        present_in[0],
                     ),
                     category=ConsistencyCategory.LAYER_NAMING,
                     severity=ConsistencySeverity.INFO,
@@ -355,7 +358,8 @@ def _check_block_consistency(
                     findings.append(
                         ConsistencyFinding(
                             finding_id=_generate_finding_id(
-                                "block_consistency", f"missing_{block}",
+                                "block_consistency",
+                                f"missing_{block}",
                                 sheet.file_path,
                             ),
                             category=ConsistencyCategory.BLOCK_CONSISTENCY,
@@ -391,7 +395,9 @@ def _check_entity_counts(
             findings.append(
                 ConsistencyFinding(
                     finding_id=_generate_finding_id(
-                        "entity_counts", "empty", sheet.file_path,
+                        "entity_counts",
+                        "empty",
+                        sheet.file_path,
                     ),
                     category=ConsistencyCategory.ENTITY_COUNTS,
                     severity=ConsistencySeverity.ERROR,
@@ -415,7 +421,9 @@ def _check_entity_counts(
                     findings.append(
                         ConsistencyFinding(
                             finding_id=_generate_finding_id(
-                                "entity_counts", "outlier", sheet.file_path,
+                                "entity_counts",
+                                "outlier",
+                                sheet.file_path,
                             ),
                             category=ConsistencyCategory.ENTITY_COUNTS,
                             severity=ConsistencySeverity.WARNING,
@@ -469,7 +477,10 @@ def _check_coordinate_alignment(
                 findings.append(
                     ConsistencyFinding(
                         finding_id=_generate_finding_id(
-                            "coordinate_alignment", "no_overlap", path_a, path_b,
+                            "coordinate_alignment",
+                            "no_overlap",
+                            path_a,
+                            path_b,
                         ),
                         category=ConsistencyCategory.COORDINATE_ALIGNMENT,
                         severity=ConsistencySeverity.ERROR,
@@ -496,8 +507,10 @@ def _check_coordinate_alignment(
                 findings.append(
                     ConsistencyFinding(
                         finding_id=_generate_finding_id(
-                            "coordinate_alignment", "scale_mismatch",
-                            path_a, path_b,
+                            "coordinate_alignment",
+                            "scale_mismatch",
+                            path_a,
+                            path_b,
                         ),
                         category=ConsistencyCategory.COORDINATE_ALIGNMENT,
                         severity=ConsistencySeverity.WARNING,

--- a/src/cad_dxf_agent/core/document_store.py
+++ b/src/cad_dxf_agent/core/document_store.py
@@ -189,7 +189,7 @@ class GCSDocumentStore(DocumentStore):
 
     def _get_client(self):
         if self._client is None:
-            from google.cloud import storage
+            from google.cloud import storage  # type: ignore[attr-defined]
 
             self._client = storage.Client()
         return self._client

--- a/src/cad_dxf_agent/core/drawing_summarizer.py
+++ b/src/cad_dxf_agent/core/drawing_summarizer.py
@@ -70,11 +70,13 @@ def summarize_drawing(
     rooms: list[RoomSummary] = []
     for zone in zones.zones:
         room_name = (zone.inferred_type or "unknown space").replace("_", " ").title()
-        rooms.append(RoomSummary(
-            name=room_name,
-            area=round(zone.area, 1),
-            zone_id=zone.zone_id,
-        ))
+        rooms.append(
+            RoomSummary(
+                name=room_name,
+                area=round(zone.area, 1),
+                zone_id=zone.zone_id,
+            )
+        )
 
     # Key features
     key_features = _extract_key_features(context, zones, symbols)
@@ -87,7 +89,11 @@ def summarize_drawing(
 
     # Build plain description
     plain_description = _build_description(
-        drawing_type, context, zones, rooms, key_features,
+        drawing_type,
+        context,
+        zones,
+        rooms,
+        key_features,
     )
 
     return DrawingSummary(
@@ -126,9 +132,8 @@ def _extract_key_features(
         features.append(f"{type_counts[EntityType.DIMENSION.value]} dimension(s)")
 
     if EntityType.TEXT.value in type_counts or EntityType.MTEXT.value in type_counts:
-        text_count = (
-            type_counts.get(EntityType.TEXT.value, 0)
-            + type_counts.get(EntityType.MTEXT.value, 0)
+        text_count = type_counts.get(EntityType.TEXT.value, 0) + type_counts.get(
+            EntityType.MTEXT.value, 0
         )
         features.append(f"{text_count} text label(s)")
 
@@ -239,16 +244,12 @@ def _build_description(
         )
 
         if rooms:
-            room_list = ", ".join(
-                f"{r.name} ({r.area:.0f} sq units)" for r in rooms[:5]
-            )
+            room_list = ", ".join(f"{r.name} ({r.area:.0f} sq units)" for r in rooms[:5])
             sentences.append(f"Spaces: {room_list}.")
     else:
         sentences.append("No enclosed spaces detected.")
 
     if key_features:
-        sentences.append(
-            f"Key features: {'; '.join(key_features[:4])}."
-        )
+        sentences.append(f"Key features: {'; '.join(key_features[:4])}.")
 
     return " ".join(sentences)

--- a/src/cad_dxf_agent/core/health_checker.py
+++ b/src/cad_dxf_agent/core/health_checker.py
@@ -295,16 +295,15 @@ def _check_overlapping_entities(
         for key, handles in list(overlap_groups.items())[:5]:
             parts = key.split(",")
             for handle in handles[:3]:
-                found_entity = index.get_by_handle(handle)
-                if found_entity is not None:
-                    entity = found_entity
+                found = index.get_by_handle(handle)
+                if found is not None:
                     evidence.append(
                         EvidenceRef(
                             entity_handle=handle,
-                            layer=entity.layer,
-                            entity_type=entity.entity_type.value,
-                            location=(entity.insert_point.x, entity.insert_point.y)
-                            if entity.insert_point
+                            layer=found.layer,
+                            entity_type=found.entity_type.value,
+                            location=(found.insert_point.x, found.insert_point.y)
+                            if found.insert_point
                             else None,
                             description=(
                                 f"Overlaps with {len(handles) - 1} other "

--- a/src/cad_dxf_agent/core/health_checker.py
+++ b/src/cad_dxf_agent/core/health_checker.py
@@ -180,11 +180,7 @@ def _check_inconsistent_text_heights(
             # More than 2 distinct heights on one layer = likely inconsistency
             height_counts = Counter(round(h, 2) for h in heights)
             dominant = height_counts.most_common(1)[0]
-            outliers = [
-                (handle, h)
-                for handle, h in entries
-                if round(h, 2) != dominant[0]
-            ]
+            outliers = [(handle, h) for handle, h in entries if round(h, 2) != dominant[0]]
 
             issues.append(
                 HealthIssue(
@@ -285,16 +281,9 @@ def _check_overlapping_entities(
             overlap_threshold,
         )
         # Filter to same-layer neighbors (excluding self)
-        same_layer = [
-            n for n in nearby
-            if n.handle != entity.handle and n.layer == entity.layer
-        ]
+        same_layer = [n for n in nearby if n.handle != entity.handle and n.layer == entity.layer]
         if same_layer:
-            key = (
-                f"{entity.insert_point.x:.2f},"
-                f"{entity.insert_point.y:.2f},"
-                f"{entity.layer}"
-            )
+            key = f"{entity.insert_point.x:.2f},{entity.insert_point.y:.2f},{entity.layer}"
             handles = [entity.handle] + [n.handle for n in same_layer]
             overlap_groups[key] = handles
             checked.update(n.handle for n in same_layer)
@@ -362,8 +351,7 @@ def _check_missing_text_content(
                 severity=HealthSeverity.WARNING,
                 category=HealthCategory.TEXT,
                 title=(
-                    f"{len(empty_texts)} empty text "
-                    f"entit{'y' if len(empty_texts) == 1 else 'ies'}"
+                    f"{len(empty_texts)} empty text entit{'y' if len(empty_texts) == 1 else 'ies'}"
                 ),
                 description=(
                     f"{len(empty_texts)} TEXT/MTEXT "
@@ -376,9 +364,7 @@ def _check_missing_text_content(
                         entity_handle=e.handle,
                         layer=e.layer,
                         entity_type=e.entity_type.value,
-                        location=(e.insert_point.x, e.insert_point.y)
-                        if e.insert_point
-                        else None,
+                        location=(e.insert_point.x, e.insert_point.y) if e.insert_point else None,
                         description="Empty text content",
                     )
                     for e in empty_texts[:10]

--- a/src/cad_dxf_agent/core/health_checker.py
+++ b/src/cad_dxf_agent/core/health_checker.py
@@ -166,7 +166,7 @@ def _check_inconsistent_text_heights(
             continue
 
         height = entity.text_geometry.effective_height
-        if height > 0:
+        if height is not None and height > 0:
             layer_heights[entity.layer].append((entity.handle, height))
 
     for layer, entries in layer_heights.items():
@@ -306,8 +306,9 @@ def _check_overlapping_entities(
         for key, handles in list(overlap_groups.items())[:5]:
             parts = key.split(",")
             for handle in handles[:3]:
-                entity = index.get_by_handle(handle)
-                if entity:
+                found_entity = index.get_by_handle(handle)
+                if found_entity is not None:
+                    entity = found_entity
                     evidence.append(
                         EvidenceRef(
                             entity_handle=handle,
@@ -501,7 +502,7 @@ def _check_unnamed_zones(context: DrawingContext) -> list[HealthIssue]:
 
     Requires zone_detector — imported lazily to avoid circular dependency.
     """
-    issues = []
+    issues: list[HealthIssue] = []
     try:
         from .zone_detector import detect_zones
     except ImportError:

--- a/src/cad_dxf_agent/core/revision_report.py
+++ b/src/cad_dxf_agent/core/revision_report.py
@@ -92,8 +92,12 @@ def generate_revision_report(
     # Build headline and summary
     headline = _build_headline(changelog, zone_deltas, area_change)
     plain_summary = _build_plain_summary(
-        changelog, change_categories, zone_deltas, area_change,
-        master_context, revision_context,
+        changelog,
+        change_categories,
+        zone_deltas,
+        area_change,
+        master_context,
+        revision_context,
     )
 
     return RevisionReport(
@@ -122,12 +126,14 @@ def _categorize_changes(
     for category, cat_entries in sorted(by_cat.items()):
         layers = sorted({e.layer for e in cat_entries})
         descriptions = [e.description for e in cat_entries[:5]]
-        summaries.append(ChangeCategorySummary(
-            category=category,
-            count=len(cat_entries),
-            layers_affected=layers,
-            sample_descriptions=descriptions,
-        ))
+        summaries.append(
+            ChangeCategorySummary(
+                category=category,
+                count=len(cat_entries),
+                layers_affected=layers,
+                sample_descriptions=descriptions,
+            )
+        )
 
     return summaries
 
@@ -162,21 +168,25 @@ def _compute_zone_deltas(
         if old_count == 0 and new_count > 0:
             # All zones of this type are new
             for area in new_areas:
-                deltas.append(ZoneDelta(
-                    zone_type=zone_type,
-                    status="added",
-                    new_area=round(area, 1),
-                    area_change=round(area, 1),
-                ))
+                deltas.append(
+                    ZoneDelta(
+                        zone_type=zone_type,
+                        status="added",
+                        new_area=round(area, 1),
+                        area_change=round(area, 1),
+                    )
+                )
         elif old_count > 0 and new_count == 0:
             # All zones of this type were removed
             for area in old_areas:
-                deltas.append(ZoneDelta(
-                    zone_type=zone_type,
-                    status="removed",
-                    old_area=round(area, 1),
-                    area_change=round(-area, 1),
-                ))
+                deltas.append(
+                    ZoneDelta(
+                        zone_type=zone_type,
+                        status="removed",
+                        old_area=round(area, 1),
+                        area_change=round(-area, 1),
+                    )
+                )
         else:
             # Compare counts
             matched = min(old_count, new_count)
@@ -185,31 +195,37 @@ def _compute_zone_deltas(
                 new_a = new_areas[i]
                 change = new_a - old_a
                 status = "resized" if abs(change) > 0.1 else "unchanged"
-                deltas.append(ZoneDelta(
-                    zone_type=zone_type,
-                    status=status,
-                    old_area=round(old_a, 1),
-                    new_area=round(new_a, 1),
-                    area_change=round(change, 1),
-                ))
+                deltas.append(
+                    ZoneDelta(
+                        zone_type=zone_type,
+                        status=status,
+                        old_area=round(old_a, 1),
+                        new_area=round(new_a, 1),
+                        area_change=round(change, 1),
+                    )
+                )
 
             # Extra new zones
             for i in range(matched, new_count):
-                deltas.append(ZoneDelta(
-                    zone_type=zone_type,
-                    status="added",
-                    new_area=round(new_areas[i], 1),
-                    area_change=round(new_areas[i], 1),
-                ))
+                deltas.append(
+                    ZoneDelta(
+                        zone_type=zone_type,
+                        status="added",
+                        new_area=round(new_areas[i], 1),
+                        area_change=round(new_areas[i], 1),
+                    )
+                )
 
             # Extra removed zones
             for i in range(matched, old_count):
-                deltas.append(ZoneDelta(
-                    zone_type=zone_type,
-                    status="removed",
-                    old_area=round(old_areas[i], 1),
-                    area_change=round(-old_areas[i], 1),
-                ))
+                deltas.append(
+                    ZoneDelta(
+                        zone_type=zone_type,
+                        status="removed",
+                        old_area=round(old_areas[i], 1),
+                        area_change=round(-old_areas[i], 1),
+                    )
+                )
 
     return deltas
 
@@ -263,9 +279,7 @@ def _build_plain_summary(
     )
 
     if change_categories:
-        cat_strs = [
-            f"{c.count} {c.category}" for c in change_categories
-        ]
+        cat_strs = [f"{c.count} {c.category}" for c in change_categories]
         sentences.append(f"Changes: {', '.join(cat_strs)}.")
 
     added = [d for d in zone_deltas if d.status == "added"]
@@ -285,8 +299,6 @@ def _build_plain_summary(
 
     if abs(area_change) > 0.1:
         sign = "+" if area_change > 0 else ""
-        sentences.append(
-            f"Net area change: {sign}{area_change:.0f} square units."
-        )
+        sentences.append(f"Net area change: {sign}{area_change:.0f} square units.")
 
     return " ".join(sentences)

--- a/src/cad_dxf_agent/core/rfi_generator.py
+++ b/src/cad_dxf_agent/core/rfi_generator.py
@@ -84,22 +84,24 @@ def _check_unlabeled_rooms(
 
     for zone in zones.zones:
         if zone.inferred_type is None:
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.MISSING_LABEL,
-                severity=RFISeverity.MAJOR,
-                question=(
-                    f"What is the intended use of the space at "
-                    f"({zone.centroid.x:.0f}, {zone.centroid.y:.0f})?"
-                ),
-                location_description=(
-                    f"Zone {zone.zone_id[:8]} — area {zone.area:.0f} "
-                    f"sq units, no room label detected"
-                ),
-                zone_id=zone.zone_id,
-                entity_handles=zone.source_handles,
-                suggested_resolution="Add a room name/label text entity inside the space.",
-            ))
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.MISSING_LABEL,
+                    severity=RFISeverity.MAJOR,
+                    question=(
+                        f"What is the intended use of the space at "
+                        f"({zone.centroid.x:.0f}, {zone.centroid.y:.0f})?"
+                    ),
+                    location_description=(
+                        f"Zone {zone.zone_id[:8]} — area {zone.area:.0f} "
+                        f"sq units, no room label detected"
+                    ),
+                    zone_id=zone.zone_id,
+                    entity_handles=zone.source_handles,
+                    suggested_resolution="Add a room name/label text entity inside the space.",
+                )
+            )
 
     return items
 
@@ -113,7 +115,8 @@ def _check_dimensions_near_doors(
     items: list[RFIItem] = []
 
     doors = [
-        e for e in context.entities
+        e
+        for e in context.entities
         if e.entity_type == EntityType.INSERT
         and e.block_name
         and _DOOR_PATTERN.search(e.block_name)
@@ -123,9 +126,9 @@ def _check_dimensions_near_doors(
         return items
 
     dim_entities = [
-        e for e in context.entities
-        if e.entity_type == EntityType.DIMENSION
-        and e.insert_point is not None
+        e
+        for e in context.entities
+        if e.entity_type == EntityType.DIMENSION and e.insert_point is not None
     ]
 
     for door in doors:
@@ -143,26 +146,28 @@ def _check_dimensions_near_doors(
                 break
 
         if not has_nearby_dim:
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.MISSING_DIMENSION,
-                severity=RFISeverity.CRITICAL,
-                question=(
-                    f"What is the clear opening width of door "
-                    f"'{door.block_name}' at "
-                    f"({door.insert_point.x:.0f}, "
-                    f"{door.insert_point.y:.0f})?"
-                ),
-                location_description=(
-                    f"Door block '{door.block_name}' on layer "
-                    f"'{door.layer}' — no dimension entity within "
-                    f"{search_radius:.0f} units"
-                ),
-                entity_handles=[door.handle],
-                suggested_resolution=(
-                    "Add a dimension entity showing door clear opening width."
-                ),
-            ))
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.MISSING_DIMENSION,
+                    severity=RFISeverity.CRITICAL,
+                    question=(
+                        f"What is the clear opening width of door "
+                        f"'{door.block_name}' at "
+                        f"({door.insert_point.x:.0f}, "
+                        f"{door.insert_point.y:.0f})?"
+                    ),
+                    location_description=(
+                        f"Door block '{door.block_name}' on layer "
+                        f"'{door.layer}' — no dimension entity within "
+                        f"{search_radius:.0f} units"
+                    ),
+                    entity_handles=[door.handle],
+                    suggested_resolution=(
+                        "Add a dimension entity showing door clear opening width."
+                    ),
+                )
+            )
 
     return items
 
@@ -175,10 +180,7 @@ def _check_symbols_without_legend(
     """Flag unique block names that don't appear in any text legend."""
     items: list[RFIItem] = []
 
-    inserts = [
-        e for e in context.entities
-        if e.entity_type == EntityType.INSERT and e.block_name
-    ]
+    inserts = [e for e in context.entities if e.entity_type == EntityType.INSERT and e.block_name]
     if not inserts:
         return items
 
@@ -188,34 +190,31 @@ def _check_symbols_without_legend(
     all_text = " ".join(
         e.text_content.upper()
         for e in context.entities
-        if e.entity_type in (EntityType.TEXT, EntityType.MTEXT)
-        and e.text_content
+        if e.entity_type in (EntityType.TEXT, EntityType.MTEXT) and e.text_content
     )
 
     for block_name in sorted(n for n in block_names if n is not None):
         # Check if block name (or simplified form) appears in text
         simplified = re.sub(r"[_\-\s]", "", block_name.upper())
         if block_name.upper() not in all_text and simplified not in all_text:
-            handles = [
-                e.handle for e in inserts
-                if e.block_name == block_name
-            ][:5]
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.AMBIGUOUS_SYMBOL,
-                severity=RFISeverity.MINOR,
-                question=(
-                    f"What does the symbol '{block_name}' represent? "
-                    f"No legend entry found."
-                ),
-                location_description=(
-                    f"Block '{block_name}' appears "
-                    f"{len([e for e in inserts if e.block_name == block_name])} "
-                    f"time(s) but is not referenced in any text/legend"
-                ),
-                entity_handles=handles,
-                suggested_resolution="Add a symbol legend or schedule referencing this block.",
-            ))
+            handles = [e.handle for e in inserts if e.block_name == block_name][:5]
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.AMBIGUOUS_SYMBOL,
+                    severity=RFISeverity.MINOR,
+                    question=(
+                        f"What does the symbol '{block_name}' represent? No legend entry found."
+                    ),
+                    location_description=(
+                        f"Block '{block_name}' appears "
+                        f"{len([e for e in inserts if e.block_name == block_name])} "
+                        f"time(s) but is not referenced in any text/legend"
+                    ),
+                    entity_handles=handles,
+                    suggested_resolution="Add a symbol legend or schedule referencing this block.",
+                )
+            )
 
     return items
 
@@ -232,20 +231,21 @@ def _check_empty_layers(
 
     for layer in context.layers:
         if layer.name not in entity_layers and layer.name != "0":
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.INCOMPLETE_SECTION,
-                severity=RFISeverity.MINOR,
-                question=(
-                    f"Layer '{layer.name}' exists but contains no "
-                    f"entities. Is content missing?"
-                ),
-                location_description=f"Layer '{layer.name}' — 0 entities",
-                suggested_resolution=(
-                    "Verify layer content was included in the export, "
-                    "or remove the layer if unused."
-                ),
-            ))
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.INCOMPLETE_SECTION,
+                    severity=RFISeverity.MINOR,
+                    question=(
+                        f"Layer '{layer.name}' exists but contains no entities. Is content missing?"
+                    ),
+                    location_description=f"Layer '{layer.name}' — 0 entities",
+                    suggested_resolution=(
+                        "Verify layer content was included in the export, "
+                        "or remove the layer if unused."
+                    ),
+                )
+            )
 
     return items
 
@@ -281,23 +281,25 @@ def _check_unclosed_boundaries(
         if tolerance_actual < gap <= tolerance_close:
             pos = entity.insert_point
             loc = f"({pos.x:.0f}, {pos.y:.0f})" if pos else "unknown"
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.COORDINATION,
-                severity=RFISeverity.MAJOR,
-                question=(
-                    f"Polyline on layer '{entity.layer}' at {loc} "
-                    f"has a {gap:.1f}-unit gap. Should this boundary "
-                    f"be closed?"
-                ),
-                location_description=(
-                    f"LWPOLYLINE {entity.handle} on layer "
-                    f"'{entity.layer}' — gap of {gap:.1f} units "
-                    f"between first and last vertex"
-                ),
-                entity_handles=[entity.handle],
-                suggested_resolution="Close the polyline or confirm the gap is intentional.",
-            ))
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.COORDINATION,
+                    severity=RFISeverity.MAJOR,
+                    question=(
+                        f"Polyline on layer '{entity.layer}' at {loc} "
+                        f"has a {gap:.1f}-unit gap. Should this boundary "
+                        f"be closed?"
+                    ),
+                    location_description=(
+                        f"LWPOLYLINE {entity.handle} on layer "
+                        f"'{entity.layer}' — gap of {gap:.1f} units "
+                        f"between first and last vertex"
+                    ),
+                    entity_handles=[entity.handle],
+                    suggested_resolution="Close the polyline or confirm the gap is intentional.",
+                )
+            )
 
     return items
 
@@ -330,27 +332,27 @@ def _check_mixed_text_heights(
         outlier_count = total - dominant_count
 
         if outlier_count >= 2 and outlier_count / total > 0.1:
-            outlier_heights = sorted(
-                h for h in height_counts if h != dominant_height
+            outlier_heights = sorted(h for h in height_counts if h != dominant_height)
+            items.append(
+                RFIItem(
+                    rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
+                    category=RFICategory.COORDINATION,
+                    severity=RFISeverity.MINOR,
+                    question=(
+                        f"Layer '{layer}' has {len(height_counts)} "
+                        f"different text heights. Is this intentional?"
+                    ),
+                    location_description=(
+                        f"Layer '{layer}' — dominant height "
+                        f"{dominant_height}, also has "
+                        f"{', '.join(str(h) for h in outlier_heights[:3])}"
+                    ),
+                    suggested_resolution=(
+                        "Standardize text heights per layer, or confirm "
+                        "variations are intentional (e.g., titles vs labels)."
+                    ),
+                )
             )
-            items.append(RFIItem(
-                rfi_id=f"RFI-{start_id + len(items) + 1:03d}",
-                category=RFICategory.COORDINATION,
-                severity=RFISeverity.MINOR,
-                question=(
-                    f"Layer '{layer}' has {len(height_counts)} "
-                    f"different text heights. Is this intentional?"
-                ),
-                location_description=(
-                    f"Layer '{layer}' — dominant height "
-                    f"{dominant_height}, also has "
-                    f"{', '.join(str(h) for h in outlier_heights[:3])}"
-                ),
-                suggested_resolution=(
-                    "Standardize text heights per layer, or confirm "
-                    "variations are intentional (e.g., titles vs labels)."
-                ),
-            ))
 
     return items
 

--- a/src/cad_dxf_agent/core/rfi_generator.py
+++ b/src/cad_dxf_agent/core/rfi_generator.py
@@ -192,7 +192,7 @@ def _check_symbols_without_legend(
         and e.text_content
     )
 
-    for block_name in sorted(block_names):
+    for block_name in sorted(n for n in block_names if n is not None):
         # Check if block name (or simplified form) appears in text
         simplified = re.sub(r"[_\-\s]", "", block_name.upper())
         if block_name.upper() not in all_text and simplified not in all_text:
@@ -315,8 +315,9 @@ def _check_mixed_text_heights(
     for entity in context.entities:
         if entity.entity_type not in (EntityType.TEXT, EntityType.MTEXT):
             continue
-        if entity.text_geometry and entity.text_geometry.effective_height > 0:
-            height = round(entity.text_geometry.effective_height, 2)
+        eff_height = entity.text_geometry.effective_height if entity.text_geometry else None
+        if eff_height is not None and eff_height > 0:
+            height = round(eff_height, 2)
             layer_heights.setdefault(entity.layer, Counter())[height] += 1
 
     for layer, height_counts in layer_heights.items():

--- a/src/cad_dxf_agent/core/session_store.py
+++ b/src/cad_dxf_agent/core/session_store.py
@@ -240,7 +240,7 @@ class GCSSessionStore(SessionStore):
     def _get_client(self):
         """Lazy-initialize GCS client."""
         if self._client is None:
-            from google.cloud import storage
+            from google.cloud import storage  # type: ignore[attr-defined]
 
             self._client = storage.Client()
         return self._client

--- a/src/cad_dxf_agent/core/takeoff_engine.py
+++ b/src/cad_dxf_agent/core/takeoff_engine.py
@@ -76,15 +76,17 @@ def _count_symbols(context: DrawingContext) -> list[TakeoffReportItem]:
     for block_name, entities in sorted(by_block.items()):
         layers = sorted({e.layer for e in entities})
         handles = [e.handle for e in entities]
-        items.append(TakeoffReportItem(
-            name=block_name,
-            category=TakeoffCategory.SYMBOL,
-            quantity=len(entities),
-            unit="ea",
-            source_layer=layers[0] if layers else None,
-            entity_handles=handles,
-            notes=f"Block inserts across {len(layers)} layer(s)",
-        ))
+        items.append(
+            TakeoffReportItem(
+                name=block_name,
+                category=TakeoffCategory.SYMBOL,
+                quantity=len(entities),
+                unit="ea",
+                source_layer=layers[0] if layers else None,
+                entity_handles=handles,
+                notes=f"Block inserts across {len(layers)} layer(s)",
+            )
+        )
 
     return items
 
@@ -105,15 +107,17 @@ def _measure_linear(context: DrawingContext) -> list[TakeoffReportItem]:
 
     for layer, total_length in sorted(layer_lengths.items()):
         handles = layer_handles.get(layer, [])
-        items.append(TakeoffReportItem(
-            name=f"Linear on '{layer}'",
-            category=TakeoffCategory.LINEAR,
-            quantity=round(total_length, 2),
-            unit="drawing_units",
-            source_layer=layer,
-            entity_handles=handles[:20],
-            notes=f"{len(handles)} segment(s)",
-        ))
+        items.append(
+            TakeoffReportItem(
+                name=f"Linear on '{layer}'",
+                category=TakeoffCategory.LINEAR,
+                quantity=round(total_length, 2),
+                unit="drawing_units",
+                source_layer=layer,
+                entity_handles=handles[:20],
+                notes=f"{len(handles)} segment(s)",
+            )
+        )
 
     return items
 
@@ -124,15 +128,17 @@ def _measure_zone_areas(zones: ZoneDetectionResult) -> list[TakeoffReportItem]:
 
     for zone in zones.zones:
         zone_type = zone.inferred_type or "unknown"
-        items.append(TakeoffReportItem(
-            name=f"{zone_type.replace('_', ' ').title()} ({zone.zone_id[:8]})",
-            category=TakeoffCategory.AREA,
-            quantity=round(zone.area, 2),
-            unit="sq_drawing_units",
-            zone_id=zone.zone_id,
-            entity_handles=zone.source_handles,
-            notes=f"Perimeter: {zone.perimeter:.1f}",
-        ))
+        items.append(
+            TakeoffReportItem(
+                name=f"{zone_type.replace('_', ' ').title()} ({zone.zone_id[:8]})",
+                category=TakeoffCategory.AREA,
+                quantity=round(zone.area, 2),
+                unit="sq_drawing_units",
+                zone_id=zone.zone_id,
+                entity_handles=zone.source_handles,
+                notes=f"Perimeter: {zone.perimeter:.1f}",
+            )
+        )
 
     return items
 
@@ -153,14 +159,16 @@ def _count_by_layer(context: DrawingContext) -> list[TakeoffReportItem]:
         if count < 2:
             continue
         handles = layer_handles.get(layer, [])
-        items.append(TakeoffReportItem(
-            name=f"Entities on '{layer}'",
-            category=TakeoffCategory.COUNT,
-            quantity=count,
-            unit="ea",
-            source_layer=layer,
-            entity_handles=handles[:20],
-        ))
+        items.append(
+            TakeoffReportItem(
+                name=f"Entities on '{layer}'",
+                category=TakeoffCategory.COUNT,
+                quantity=count,
+                unit="ea",
+                source_layer=layer,
+                entity_handles=handles[:20],
+            )
+        )
 
     return items
 

--- a/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
+++ b/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
@@ -1,0 +1,92 @@
+"""Stage handler for regulation-aware compliance validation.
+
+Wraps check_compliance() to provide building code validation
+as a stage in the VALIDATE pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cad_dxf_agent.core.compliance_rules import check_compliance
+from cad_dxf_agent.models.cad_schema import DrawingContext
+from cad_dxf_agent.models.compliance_schema import BUILTIN_PROFILES
+from cad_dxf_agent.models.objective_schema import ObjectiveClassification
+from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
+
+
+class ComplianceHandler:
+    """Stage handler that produces a compliance report against a profile."""
+
+    def execute(
+        self,
+        classification: ObjectiveClassification,
+        context: dict[str, Any],
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Run compliance checks and return report data."""
+        drawing_context = context.get("drawing_context")
+        if drawing_context is None:
+            return {
+                "compliance_report": None,
+                "summary": "No drawing context available for compliance check",
+            }
+
+        if not isinstance(drawing_context, DrawingContext):
+            drawing_context = DrawingContext(**drawing_context)
+
+        # Use pre-computed zones from prior stage if available
+        zones = None
+        raw_zones = context.get("zones")
+        if raw_zones is not None:
+            if isinstance(raw_zones, ZoneDetectionResult):
+                zones = raw_zones
+            elif isinstance(raw_zones, list):
+                zones = ZoneDetectionResult(
+                    zones=raw_zones,
+                    total_area=context.get("total_area", 0.0),
+                    zone_count=context.get("zone_count", 0),
+                    confidence=context.get("zone_confidence", 0.0),
+                    warnings=context.get("zone_warnings", []),
+                )
+
+        # Determine profile from prompt keywords or default to "ibc"
+        profile = _detect_profile(prompt)
+
+        report = check_compliance(drawing_context, profile=profile, zones=zones)
+
+        return {
+            "compliance_report": report.model_dump(),
+            "compliance_profile": report.profile_name,
+            "compliance_score": report.score,
+            "compliance_passed": report.passed,
+            "compliance_findings": [f.model_dump() for f in report.findings],
+            "compliance_violations": report.violation_count,
+            "compliance_warnings": report.warning_count,
+            "compliance_checks_run": report.checks_run,
+            "summary": _build_summary(report),
+        }
+
+
+def _detect_profile(prompt: str) -> str:
+    """Detect compliance profile from prompt keywords."""
+    lower = prompt.lower()
+    if "ada" in lower or "accessib" in lower:
+        return "ada"
+    if "residential" in lower or "irc" in lower:
+        return "residential"
+    # Default to IBC-2021 (most comprehensive)
+    return "ibc-2021"
+
+
+def _build_summary(report) -> str:
+    """Build a human-readable summary of compliance results."""
+    parts = [f"Compliance check ({report.profile_name}):"]
+    if report.passed:
+        parts.append("PASSED")
+    else:
+        parts.append(f"FAILED — {report.violation_count} violation(s)")
+    if report.warning_count:
+        parts.append(f", {report.warning_count} warning(s)")
+    parts.append(f". Score: {report.score:.0f}/100.")
+    return " ".join(parts)

--- a/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
+++ b/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from cad_dxf_agent.core.compliance_rules import check_compliance
 from cad_dxf_agent.models.cad_schema import DrawingContext
-from cad_dxf_agent.models.compliance_schema import BUILTIN_PROFILES
 from cad_dxf_agent.models.objective_schema import ObjectiveClassification
 from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
 

--- a/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
+++ b/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from cad_dxf_agent.core.compliance_rules import check_compliance
 from cad_dxf_agent.models.cad_schema import DrawingContext
+from cad_dxf_agent.models.compliance_schema import ComplianceReport
 from cad_dxf_agent.models.objective_schema import ObjectiveClassification
 from cad_dxf_agent.models.zone_schema import ZoneDetectionResult
 
@@ -68,8 +69,14 @@ class ComplianceHandler:
 
 
 def _detect_profile(prompt: str) -> str:
-    """Detect compliance profile from prompt keywords."""
+    """Detect compliance profile from prompt keywords.
+
+    Order matters: ADA/accessibility is checked first because it is the
+    most stringent profile and should win when the prompt contains keywords
+    for multiple profiles (e.g. "check residential accessibility").
+    """
     lower = prompt.lower()
+    # Most stringent first — ADA wins over residential/commercial
     if "ada" in lower or "accessib" in lower:
         return "ada"
     if "residential" in lower or "irc" in lower:
@@ -78,7 +85,7 @@ def _detect_profile(prompt: str) -> str:
     return "ibc-2021"
 
 
-def _build_summary(report) -> str:
+def _build_summary(report: ComplianceReport) -> str:
     """Build a human-readable summary of compliance results."""
     status = "PASSED" if report.passed else f"FAILED — {report.violation_count} violation(s)"
     warnings = f" with {report.warning_count} warning(s)" if report.warning_count else ""

--- a/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
+++ b/src/cad_dxf_agent/llm/stage_handlers/compliance_handler.py
@@ -81,12 +81,7 @@ def _detect_profile(prompt: str) -> str:
 
 def _build_summary(report) -> str:
     """Build a human-readable summary of compliance results."""
-    parts = [f"Compliance check ({report.profile_name}):"]
-    if report.passed:
-        parts.append("PASSED")
-    else:
-        parts.append(f"FAILED — {report.violation_count} violation(s)")
-    if report.warning_count:
-        parts.append(f", {report.warning_count} warning(s)")
-    parts.append(f". Score: {report.score:.0f}/100.")
-    return " ".join(parts)
+    status = "PASSED" if report.passed else f"FAILED — {report.violation_count} violation(s)"
+    warnings = f" with {report.warning_count} warning(s)" if report.warning_count else ""
+    score = f". Score: {report.score:.0f}/100."
+    return f"Compliance check ({report.profile_name}): {status}{warnings}{score}"

--- a/src/cad_dxf_agent/llm/strategy_registry.py
+++ b/src/cad_dxf_agent/llm/strategy_registry.py
@@ -107,9 +107,9 @@ _TAG_OVERRIDES: dict[tuple[RequestClass, ObjectiveTag], StagePipelineDefinition]
         description="Analyze spatial layout, recommend density/placement improvements",
     ),
     (RequestClass.VALIDATE, ObjectiveTag.COMPLIANCE): StagePipelineDefinition(
-        stages=["analyze", "validate"],
+        stages=["analyze", "detect_zones", "compliance_check"],
         output_mode="direct",
-        description="Check drawing against code compliance indicators",
+        description="Detect rooms/zones, then check against building code compliance",
     ),
     (RequestClass.VALIDATE, ObjectiveTag.MISSING_ITEMS): StagePipelineDefinition(
         stages=["analyze", "validate"],

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -680,8 +680,7 @@ BATCH_DELETE = {
 BATCH_EDIT_TEXT = {
     "name": "batch_edit_text",
     "description": (
-        "Find-and-replace text content across all TEXT/MTEXT entities "
-        "matching the filter criteria."
+        "Find-and-replace text content across all TEXT/MTEXT entities matching the filter criteria."
     ),
     "parameters": {
         "type": "object",

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -705,7 +705,7 @@ class ToolExecutor:
             return {"error": f"No text entities contain '{find_str}'"}
 
         for entity in text_entities:
-            new_text = entity.text_content.replace(find_str, replace_str)
+            new_text = (entity.text_content or "").replace(find_str, replace_str)
             op = EditOperation(
                 op_type=OpType.EDIT_TEXT,
                 target_handle=entity.handle,

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -498,12 +498,9 @@ class ToolExecutor:
             "insert": insert,
         }
 
-
     # --- V3 batch tools ---
 
-    def _resolve_batch_filter(
-        self, args: dict[str, Any]
-    ) -> list[EntityRef] | dict[str, Any]:
+    def _resolve_batch_filter(self, args: dict[str, Any]) -> list[EntityRef] | dict[str, Any]:
         """Apply filter criteria and return matching entities.
 
         Returns list[EntityRef] on success, or error dict if no filters
@@ -516,10 +513,14 @@ class ToolExecutor:
         center_y = args.get("center_y")
         radius = args.get("radius")
 
-        has_filter = any([
-            layer, entity_type, text_contains,
-            (center_x is not None and center_y is not None and radius),
-        ])
+        has_filter = any(
+            [
+                layer,
+                entity_type,
+                text_contains,
+                (center_x is not None and center_y is not None and radius),
+            ]
+        )
         if not has_filter:
             return {
                 "error": (
@@ -529,11 +530,7 @@ class ToolExecutor:
             }
 
         # Spatial filter first if specified
-        if (
-            center_x is not None
-            and center_y is not None
-            and radius is not None
-        ):
+        if center_x is not None and center_y is not None and radius is not None:
             candidates = self._index.find_in_radius(
                 float(center_x),
                 float(center_y),
@@ -542,23 +539,16 @@ class ToolExecutor:
                 layer=layer,
             )
         else:
-            candidates = self._index.filter(
-                layer=layer, entity_type=entity_type
-            )
+            candidates = self._index.filter(layer=layer, entity_type=entity_type)
 
         # Text filter
         if text_contains:
             text_matches = self._index.search_text(text_contains)
             match_handles = {e.handle for e in text_matches}
-            candidates = [
-                e for e in candidates if e.handle in match_handles
-            ]
+            candidates = [e for e in candidates if e.handle in match_handles]
 
         # Exclude protected layers
-        candidates = [
-            e for e in candidates
-            if e.layer.upper() not in self._protected
-        ]
+        candidates = [e for e in candidates if e.layer.upper() not in self._protected]
 
         if not candidates:
             return {"error": "No matching entities found"}
@@ -695,7 +685,8 @@ class ToolExecutor:
 
         # Further filter: only TEXT/MTEXT with the find string
         text_entities = [
-            e for e in result
+            e
+            for e in result
             if e.entity_type.value in ("TEXT", "MTEXT")
             and e.text_content
             and find_str in e.text_content

--- a/src/cad_dxf_agent/models/takeoff_schema.py
+++ b/src/cad_dxf_agent/models/takeoff_schema.py
@@ -57,13 +57,17 @@ class TakeoffReport(BaseModel):
             ["Category", "Name", "Quantity", "Unit", "Layer", "Zone", "Notes"],
         ]
         for item in self.items:
-            rows.append([
-                item.category.value,
-                item.name,
-                f"{item.quantity:.2f}" if isinstance(item.quantity, float) else str(item.quantity),
-                item.unit,
-                item.source_layer or "",
-                item.zone_id or "",
-                item.notes,
-            ])
+            rows.append(
+                [
+                    item.category.value,
+                    item.name,
+                    f"{item.quantity:.2f}"
+                    if isinstance(item.quantity, float)
+                    else str(item.quantity),
+                    item.unit,
+                    item.source_layer or "",
+                    item.zone_id or "",
+                    item.notes,
+                ]
+            )
         return rows

--- a/tests/unit/test_batch_operations.py
+++ b/tests/unit/test_batch_operations.py
@@ -67,16 +67,18 @@ def _executor(ctx, protected=None):
 @pytest.fixture()
 def mixed_drawing():
     """Drawing with lines on STRUCTURAL, text on NOTES, inserts on MARKS."""
-    return _ctx([
-        _ent("L1", EntityType.LINE, "STRUCTURAL", 0, 0),
-        _ent("L2", EntityType.LINE, "STRUCTURAL", 10, 0),
-        _ent("L3", EntityType.LINE, "STRUCTURAL", 20, 0),
-        _ent("T1", EntityType.TEXT, "NOTES", 5, 5, text="Room A"),
-        _ent("T2", EntityType.TEXT, "NOTES", 15, 5, text="Room B"),
-        _ent("T3", EntityType.MTEXT, "NOTES", 25, 5, text="Room C"),
-        _ent("I1", EntityType.INSERT, "MARKS", 50, 50),
-        _ent("I2", EntityType.INSERT, "MARKS", 60, 50),
-    ])
+    return _ctx(
+        [
+            _ent("L1", EntityType.LINE, "STRUCTURAL", 0, 0),
+            _ent("L2", EntityType.LINE, "STRUCTURAL", 10, 0),
+            _ent("L3", EntityType.LINE, "STRUCTURAL", 20, 0),
+            _ent("T1", EntityType.TEXT, "NOTES", 5, 5, text="Room A"),
+            _ent("T2", EntityType.TEXT, "NOTES", 15, 5, text="Room B"),
+            _ent("T3", EntityType.MTEXT, "NOTES", 25, 5, text="Room C"),
+            _ent("I1", EntityType.INSERT, "MARKS", 50, 50),
+            _ent("I2", EntityType.INSERT, "MARKS", 60, 50),
+        ]
+    )
 
 
 # ===================================================================
@@ -95,9 +97,14 @@ class TestBatchFilterResolution:
 
     def test_filter_by_layer(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 5, "dy": 0,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 5,
+                "dy": 0,
+            },
+        )
         assert result["status"] == "queued"
         assert result["matched"] == 3
         assert len(exe.operations) == 3
@@ -106,50 +113,81 @@ class TestBatchFilterResolution:
 
     def test_filter_by_entity_type(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "entity_type": "TEXT", "dx": 0, "dy": 10,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "entity_type": "TEXT",
+                "dx": 0,
+                "dy": 10,
+            },
+        )
         assert result["matched"] == 2  # T1, T2 (not MTEXT T3)
 
     def test_filter_by_text_contains(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "text_contains": "Room", "dx": 1, "dy": 1,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "text_contains": "Room",
+                "dx": 1,
+                "dy": 1,
+            },
+        )
         # All 3 text entities contain "Room"
         assert result["matched"] == 3
 
     def test_filter_by_radius(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "center_x": 55, "center_y": 50, "radius": 10,
-            "dx": 0, "dy": 5,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "center_x": 55,
+                "center_y": 50,
+                "radius": 10,
+                "dx": 0,
+                "dy": 5,
+            },
+        )
         # I1 at (50,50) and I2 at (60,50) are within radius 10 of (55,50)
         assert result["matched"] == 2
 
     def test_combined_filters(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "layer": "NOTES", "entity_type": "TEXT",
-            "dx": 0, "dy": 5,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "NOTES",
+                "entity_type": "TEXT",
+                "dx": 0,
+                "dy": 5,
+            },
+        )
         # Only TEXT on NOTES: T1, T2 (not T3 which is MTEXT)
         assert result["matched"] == 2
 
     def test_no_matches_returns_error(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "layer": "NONEXISTENT", "dx": 1, "dy": 1,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "NONEXISTENT",
+                "dx": 1,
+                "dy": 1,
+            },
+        )
         assert "error" in result
         assert "No matching" in result["error"]
 
     def test_protected_layers_excluded(self, mixed_drawing):
         exe = _executor(mixed_drawing, protected=["TITLE", "NOTES"])
-        result = exe.execute("batch_move", {
-            "layer": "NOTES", "dx": 1, "dy": 1,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "NOTES",
+                "dx": 1,
+                "dy": 1,
+            },
+        )
         # All NOTES entities excluded by protection
         assert "error" in result
         assert "No matching" in result["error"]
@@ -165,9 +203,14 @@ class TestBatchMove:
 
     def test_basic_batch_move(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 10, "dy": -5,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 10,
+                "dy": -5,
+            },
+        )
         assert result["status"] == "queued"
         assert result["matched"] == 3
         assert result["dx"] == 10
@@ -180,9 +223,14 @@ class TestBatchMove:
 
     def test_batch_move_preserves_entity_metadata(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 1, "dy": 1,
-        })
+        exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 1,
+                "dy": 1,
+            },
+        )
         handles = {op.target_handle for op in exe.operations}
         assert handles == {"L1", "L2", "L3"}
 
@@ -197,9 +245,13 @@ class TestBatchRotate:
 
     def test_basic_batch_rotate(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_rotate", {
-            "layer": "STRUCTURAL", "angle": 90,
-        })
+        result = exe.execute(
+            "batch_rotate",
+            {
+                "layer": "STRUCTURAL",
+                "angle": 90,
+            },
+        )
         assert result["matched"] == 3
         assert result["angle"] == 90
 
@@ -209,10 +261,15 @@ class TestBatchRotate:
 
     def test_batch_rotate_with_shared_center(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        exe.execute("batch_rotate", {
-            "layer": "STRUCTURAL", "angle": 45,
-            "cx": 100, "cy": 200,
-        })
+        exe.execute(
+            "batch_rotate",
+            {
+                "layer": "STRUCTURAL",
+                "angle": 45,
+                "cx": 100,
+                "cy": 200,
+            },
+        )
         for op in exe.operations:
             assert op.params["cx"] == 100
             assert op.params["cy"] == 200
@@ -220,9 +277,13 @@ class TestBatchRotate:
     def test_batch_rotate_uses_entity_center(self, mixed_drawing):
         """Without cx/cy, each entity rotates around its own center."""
         exe = _executor(mixed_drawing)
-        exe.execute("batch_rotate", {
-            "layer": "STRUCTURAL", "angle": 30,
-        })
+        exe.execute(
+            "batch_rotate",
+            {
+                "layer": "STRUCTURAL",
+                "angle": 30,
+            },
+        )
         # L1 at (0,0), L2 at (10,0), L3 at (20,0)
         centers = [(op.params["cx"], op.params["cy"]) for op in exe.operations]
         assert (0, 0) in centers
@@ -240,9 +301,13 @@ class TestBatchScale:
 
     def test_basic_batch_scale(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_scale", {
-            "layer": "MARKS", "factor": 2.0,
-        })
+        result = exe.execute(
+            "batch_scale",
+            {
+                "layer": "MARKS",
+                "factor": 2.0,
+            },
+        )
         assert result["matched"] == 2
         assert result["factor"] == 2.0
 
@@ -252,10 +317,15 @@ class TestBatchScale:
 
     def test_batch_scale_with_shared_center(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        exe.execute("batch_scale", {
-            "layer": "MARKS", "factor": 0.5,
-            "cx": 55, "cy": 50,
-        })
+        exe.execute(
+            "batch_scale",
+            {
+                "layer": "MARKS",
+                "factor": 0.5,
+                "cx": 55,
+                "cy": 50,
+            },
+        )
         for op in exe.operations:
             assert op.params["cx"] == 55
             assert op.params["cy"] == 50
@@ -271,9 +341,12 @@ class TestBatchDelete:
 
     def test_basic_batch_delete(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_delete", {
-            "layer": "MARKS",
-        })
+        result = exe.execute(
+            "batch_delete",
+            {
+                "layer": "MARKS",
+            },
+        )
         assert result["matched"] == 2
         assert len(exe.operations) == 2
         for op in exe.operations:
@@ -281,9 +354,12 @@ class TestBatchDelete:
 
     def test_batch_delete_by_type(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_delete", {
-            "entity_type": "INSERT",
-        })
+        result = exe.execute(
+            "batch_delete",
+            {
+                "entity_type": "INSERT",
+            },
+        )
         assert result["matched"] == 2
 
     def test_batch_delete_requires_filter(self, mixed_drawing):
@@ -303,11 +379,14 @@ class TestBatchEditText:
 
     def test_basic_find_replace(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_edit_text", {
-            "layer": "NOTES",
-            "find": "Room",
-            "replace": "Space",
-        })
+        result = exe.execute(
+            "batch_edit_text",
+            {
+                "layer": "NOTES",
+                "find": "Room",
+                "replace": "Space",
+            },
+        )
         assert result["matched"] == 3
         assert result["find"] == "Room"
         assert result["replace"] == "Space"
@@ -319,31 +398,40 @@ class TestBatchEditText:
     def test_find_replace_partial_match(self, mixed_drawing):
         """Only entities containing the find string get edited."""
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_edit_text", {
-            "text_contains": "Room A",
-            "find": "A",
-            "replace": "1",
-        })
+        result = exe.execute(
+            "batch_edit_text",
+            {
+                "text_contains": "Room A",
+                "find": "A",
+                "replace": "1",
+            },
+        )
         assert result["matched"] == 1
         assert exe.operations[0].params["new_text"] == "Room 1"
 
     def test_find_not_found_returns_error(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_edit_text", {
-            "layer": "NOTES",
-            "find": "NONEXISTENT",
-            "replace": "X",
-        })
+        result = exe.execute(
+            "batch_edit_text",
+            {
+                "layer": "NOTES",
+                "find": "NONEXISTENT",
+                "replace": "X",
+            },
+        )
         assert "error" in result
 
     def test_non_text_entities_excluded(self, mixed_drawing):
         """batch_edit_text should only affect TEXT/MTEXT, not LINE etc."""
         exe = _executor(mixed_drawing)
-        result = exe.execute("batch_edit_text", {
-            "layer": "STRUCTURAL",
-            "find": "foo",
-            "replace": "bar",
-        })
+        result = exe.execute(
+            "batch_edit_text",
+            {
+                "layer": "STRUCTURAL",
+                "find": "foo",
+                "replace": "bar",
+            },
+        )
         # No TEXT/MTEXT on STRUCTURAL layer
         assert "error" in result
 
@@ -386,8 +474,11 @@ class TestBatchToolDefinitions:
         from cad_dxf_agent.llm.tool_definitions import get_tool_by_name
 
         for name in [
-            "batch_move", "batch_rotate", "batch_scale",
-            "batch_delete", "batch_edit_text",
+            "batch_move",
+            "batch_rotate",
+            "batch_scale",
+            "batch_delete",
+            "batch_edit_text",
         ]:
             tool = get_tool_by_name(name)
             assert tool is not None, f"Tool {name} not found"
@@ -411,37 +502,61 @@ class TestBatchEdgeCases:
         exe.execute("move_entity", {"handle": "L1", "dx": 1, "dy": 1})
 
         # Then batch op
-        exe.execute("batch_move", {
-            "layer": "NOTES", "dx": 5, "dy": 5,
-        })
+        exe.execute(
+            "batch_move",
+            {
+                "layer": "NOTES",
+                "dx": 5,
+                "dy": 5,
+            },
+        )
 
         # Should have 1 individual + 3 batch = 4 total
         assert len(exe.operations) == 4
 
     def test_multiple_batch_ops_accumulate(self, mixed_drawing):
         exe = _executor(mixed_drawing)
-        exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 1, "dy": 0,
-        })
-        exe.execute("batch_rotate", {
-            "layer": "NOTES", "angle": 45,
-        })
+        exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 1,
+                "dy": 0,
+            },
+        )
+        exe.execute(
+            "batch_rotate",
+            {
+                "layer": "NOTES",
+                "angle": 45,
+            },
+        )
         # 3 moves + 3 rotates = 6
         assert len(exe.operations) == 6
 
     def test_empty_drawing_returns_error(self):
         ctx = _ctx([], layers=["STRUCTURAL"])
         exe = _executor(ctx)
-        result = exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 1, "dy": 1,
-        })
+        result = exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 1,
+                "dy": 1,
+            },
+        )
         assert "error" in result
 
     def test_batch_operations_preserve_space(self, mixed_drawing):
         """Operations should preserve the entity's space attribute."""
         exe = _executor(mixed_drawing)
-        exe.execute("batch_move", {
-            "layer": "STRUCTURAL", "dx": 1, "dy": 0,
-        })
+        exe.execute(
+            "batch_move",
+            {
+                "layer": "STRUCTURAL",
+                "dx": 1,
+                "dy": 0,
+            },
+        )
         for op in exe.operations:
             assert op.target_space == "Model"

--- a/tests/unit/test_compliance_handler.py
+++ b/tests/unit/test_compliance_handler.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from cad_dxf_agent.llm.stage_handlers.compliance_handler import (
     ComplianceHandler,
     _build_summary,

--- a/tests/unit/test_compliance_handler.py
+++ b/tests/unit/test_compliance_handler.py
@@ -282,9 +282,6 @@ class TestComplianceHandler:
             context={"drawing_context": ctx},
             prompt="check compliance",
         )
-        violations = [
-            f for f in result["compliance_findings"]
-            if f["severity"] == "violation"
-        ]
+        violations = [f for f in result["compliance_findings"] if f["severity"] == "violation"]
         assert len(violations) >= 1
         assert any("door" in v["title"].lower() for v in violations)

--- a/tests/unit/test_compliance_handler.py
+++ b/tests/unit/test_compliance_handler.py
@@ -1,0 +1,292 @@
+"""Tests for the compliance stage handler (EPIC-CAD-21)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.stage_handlers.compliance_handler import (
+    ComplianceHandler,
+    _build_summary,
+    _detect_profile,
+)
+from cad_dxf_agent.models.cad_schema import (
+    DrawingContext,
+    EntityRef,
+    EntityType,
+    LayerRule,
+    Point2D,
+)
+from cad_dxf_agent.models.compliance_schema import ComplianceReport
+from cad_dxf_agent.models.objective_schema import (
+    ObjectiveClassification,
+    ObjectiveTag,
+    RequestClass,
+)
+from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
+
+# --- Helpers ---
+
+
+def _make_context(entities=None, layers=None):
+    layer_rules = [LayerRule(name=n) for n in (layers or ["0"])]
+    return DrawingContext(
+        file_path="test.dxf",
+        entities=entities or [],
+        layers=layer_rules,
+    )
+
+
+def _make_classification():
+    return ObjectiveClassification(
+        request_class=RequestClass.VALIDATE,
+        objective_tag=ObjectiveTag.COMPLIANCE,
+        confidence=0.9,
+    )
+
+
+# --- Profile detection ---
+
+
+class TestDetectProfile:
+    def test_ada_keyword(self):
+        assert _detect_profile("check ADA compliance") == "ada"
+
+    def test_accessibility_keyword(self):
+        assert _detect_profile("is this accessible?") == "ada"
+
+    def test_residential_keyword(self):
+        assert _detect_profile("residential code check") == "residential"
+
+    def test_irc_keyword(self):
+        assert _detect_profile("IRC compliance") == "residential"
+
+    def test_default_is_ibc(self):
+        assert _detect_profile("check compliance") == "ibc-2021"
+
+    def test_empty_prompt_defaults_to_ibc(self):
+        assert _detect_profile("") == "ibc-2021"
+
+
+# --- Summary builder ---
+
+
+class TestBuildSummary:
+    def test_passed_report(self):
+        report = ComplianceReport(
+            profile_name="ADA",
+            findings=[],
+            checks_run=["door_widths"],
+            violation_count=0,
+            warning_count=0,
+            pass_count=3,
+            zone_count=2,
+            entity_count=10,
+        )
+        summary = _build_summary(report)
+        assert "PASSED" in summary
+        assert "ADA" in summary
+
+    def test_failed_report(self):
+        report = ComplianceReport(
+            profile_name="IBC-2021",
+            findings=[],
+            checks_run=["door_widths"],
+            violation_count=2,
+            warning_count=1,
+            pass_count=0,
+            zone_count=0,
+            entity_count=5,
+        )
+        summary = _build_summary(report)
+        assert "FAILED" in summary
+        assert "2 violation" in summary
+        assert "1 warning" in summary
+
+
+# --- Handler execution ---
+
+
+class TestComplianceHandler:
+    def test_no_drawing_context(self):
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={},
+            prompt="check compliance",
+        )
+        assert result["compliance_report"] is None
+        assert "No drawing context" in result["summary"]
+
+    def test_with_empty_drawing(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="check compliance",
+        )
+        assert result["compliance_report"] is not None
+        assert "compliance_score" in result
+        assert "compliance_passed" in result
+        assert "compliance_findings" in result
+        assert isinstance(result["compliance_checks_run"], list)
+
+    def test_with_dict_drawing_context(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx.model_dump()},
+            prompt="check ADA compliance",
+        )
+        assert result["compliance_report"] is not None
+        assert result["compliance_profile"] == "ada"
+
+    def test_profile_from_prompt_ada(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="check ADA accessibility",
+        )
+        assert result["compliance_profile"] == "ada"
+
+    def test_profile_from_prompt_residential(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="residential code check",
+        )
+        assert result["compliance_profile"] == "residential"
+
+    def test_uses_precomputed_zones(self):
+        """Handler should use zones from prior detect_zones stage."""
+        ctx = _make_context()
+        zone = DetectedZone(
+            zone_id="z1",
+            boundary=[
+                Point2D(x=0, y=0),
+                Point2D(x=100, y=0),
+                Point2D(x=100, y=50),
+                Point2D(x=0, y=50),
+            ],
+            area=5000.0,
+            perimeter=300.0,
+            centroid=Point2D(x=50, y=25),
+            inferred_type="hallway",
+            source_handles=["H1"],
+            confidence=1.0,
+        )
+        zones_result = ZoneDetectionResult(
+            zones=[zone],
+            total_area=5000.0,
+            zone_count=1,
+            confidence=1.0,
+            warnings=[],
+        )
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={
+                "drawing_context": ctx,
+                "zones": zones_result,
+            },
+            prompt="check compliance",
+        )
+        # Should have run checks including corridor checks
+        assert result["compliance_report"] is not None
+
+    def test_uses_precomputed_zones_list(self):
+        """Handler should reconstruct ZoneDetectionResult from zone list."""
+        ctx = _make_context()
+        zone = DetectedZone(
+            zone_id="z1",
+            boundary=[
+                Point2D(x=0, y=0),
+                Point2D(x=100, y=0),
+                Point2D(x=100, y=50),
+                Point2D(x=0, y=50),
+            ],
+            area=5000.0,
+            perimeter=300.0,
+            centroid=Point2D(x=50, y=25),
+            inferred_type="room",
+            source_handles=["H1"],
+            confidence=1.0,
+        )
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={
+                "drawing_context": ctx,
+                "zones": [zone],
+                "total_area": 5000.0,
+                "zone_count": 1,
+                "zone_confidence": 1.0,
+                "zone_warnings": [],
+            },
+            prompt="check compliance",
+        )
+        assert result["compliance_report"] is not None
+        assert result["compliance_checks_run"]
+
+    def test_result_keys(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="check compliance",
+        )
+        expected_keys = {
+            "compliance_report",
+            "compliance_profile",
+            "compliance_score",
+            "compliance_passed",
+            "compliance_findings",
+            "compliance_violations",
+            "compliance_warnings",
+            "compliance_checks_run",
+            "summary",
+        }
+        assert expected_keys <= set(result.keys())
+
+    def test_score_is_numeric(self):
+        ctx = _make_context()
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="check compliance",
+        )
+        assert isinstance(result["compliance_score"], (int, float))
+        assert 0 <= result["compliance_score"] <= 100
+
+    def test_door_violation_detected(self):
+        """Narrow door should produce a violation."""
+        entities = [
+            EntityRef(
+                handle="D1",
+                entity_type=EntityType.INSERT,
+                layer="DOORS",
+                block_name="DOOR_24",
+                insert_point=Point2D(x=50, y=50),
+                attributes={"width": "24"},
+            ),
+        ]
+        ctx = _make_context(entities=entities, layers=["DOORS"])
+        handler = ComplianceHandler()
+        result = handler.execute(
+            classification=_make_classification(),
+            context={"drawing_context": ctx},
+            prompt="check compliance",
+        )
+        violations = [
+            f for f in result["compliance_findings"]
+            if f["severity"] == "violation"
+        ]
+        assert len(violations) >= 1
+        assert any("door" in v["title"].lower() for v in violations)

--- a/tests/unit/test_compliance_rules.py
+++ b/tests/unit/test_compliance_rules.py
@@ -81,8 +81,11 @@ def _make_zone(
         boundary=boundary,
         area=area,
         perimeter=sum(
-            ((boundary[i].x - boundary[(i + 1) % len(boundary)].x) ** 2
-             + (boundary[i].y - boundary[(i + 1) % len(boundary)].y) ** 2) ** 0.5
+            (
+                (boundary[i].x - boundary[(i + 1) % len(boundary)].x) ** 2
+                + (boundary[i].y - boundary[(i + 1) % len(boundary)].y) ** 2
+            )
+            ** 0.5
             for i in range(len(boundary))
         ),
         centroid=Point2D(
@@ -255,7 +258,9 @@ class TestCheckCompliance:
 
         # Drawing with a small bedroom zone and a door
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=5, y=5),
             block_name="DOOR_36",
             attributes={"width": 36.0},
@@ -305,7 +310,9 @@ class TestDoorWidthChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_widths
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_30",
             attributes={"width": 30.0},
@@ -327,7 +334,9 @@ class TestDoorWidthChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_widths
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_36",
             attributes={"width": 36.0},
@@ -356,7 +365,9 @@ class TestDoorWidthChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_widths
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_STANDARD",
             attributes={},
@@ -373,7 +384,9 @@ class TestDoorWidthChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_widths
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DR-1",
             attributes={"x_scale": 32.0},
@@ -391,15 +404,30 @@ class TestDoorWidthChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_widths
 
         doors = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=0, y=0),
-                         block_name="DOOR_30", attributes={"width": 30.0}),
-            _make_entity("d2", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=50, y=0),
-                         block_name="DOOR_36", attributes={"width": 36.0}),
-            _make_entity("d3", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=100, y=0),
-                         block_name="ENTRY_42", attributes={"width": 42.0}),
+            _make_entity(
+                "d1",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=0, y=0),
+                block_name="DOOR_30",
+                attributes={"width": 30.0},
+            ),
+            _make_entity(
+                "d2",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=50, y=0),
+                block_name="DOOR_36",
+                attributes={"width": 36.0},
+            ),
+            _make_entity(
+                "d3",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=100, y=0),
+                block_name="ENTRY_42",
+                attributes={"width": 42.0},
+            ),
         ]
         context = _make_context(entities=doors)
         thresholds = ComplianceThresholds(min_door_width=36.0)
@@ -541,7 +569,9 @@ class TestRoomAreaChecks:
         from cad_dxf_agent.core.compliance_rules import _check_room_areas
 
         hallway = _make_zone(
-            zone_id="h1", area=500.0, inferred_type="hallway",
+            zone_id="h1",
+            area=500.0,
+            inferred_type="hallway",
         )
         context = _make_context()
         zones = _make_zones_result([hallway])
@@ -581,12 +611,16 @@ class TestEgressChecks:
         from cad_dxf_agent.core.compliance_rules import _check_egress
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=5, y=5),
             block_name="DOOR_36",
         )
         room = _make_zone(
-            zone_id="r1", area=200.0, inferred_type="bedroom",
+            zone_id="r1",
+            area=200.0,
+            inferred_type="bedroom",
             boundary=[
                 Point2D(x=0, y=0),
                 Point2D(x=20, y=0),
@@ -608,7 +642,9 @@ class TestEgressChecks:
 
         # Room with no doors or windows anywhere
         room = _make_zone(
-            zone_id="r1", area=200.0, inferred_type="bedroom",
+            zone_id="r1",
+            area=200.0,
+            inferred_type="bedroom",
             boundary=[
                 Point2D(x=0, y=0),
                 Point2D(x=20, y=0),
@@ -629,12 +665,16 @@ class TestEgressChecks:
         from cad_dxf_agent.core.compliance_rules import _check_egress
 
         window = _make_entity(
-            "w1", EntityType.INSERT, "WINDOWS",
+            "w1",
+            EntityType.INSERT,
+            "WINDOWS",
             insert_point=Point2D(x=10, y=0),
             block_name="WINDOW_36x48",
         )
         room = _make_zone(
-            zone_id="r1", area=200.0, inferred_type="bedroom",
+            zone_id="r1",
+            area=200.0,
+            inferred_type="bedroom",
             boundary=[
                 Point2D(x=0, y=0),
                 Point2D(x=20, y=0),
@@ -687,7 +727,9 @@ class TestDoorCountChecks:
         from cad_dxf_agent.core.compliance_rules import _check_door_count
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_36",
         )
@@ -781,14 +823,10 @@ class TestBlockDetection:
         )
 
         entities = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         block_name="DOOR_36"),
-            _make_entity("d2", EntityType.INSERT, "DOORS",
-                         block_name="DR-SINGLE"),
-            _make_entity("d3", EntityType.INSERT, "DOORS",
-                         block_name="ENTRY_MAIN"),
-            _make_entity("w1", EntityType.INSERT, "WINDOWS",
-                         block_name="WINDOW_48"),
+            _make_entity("d1", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS", block_name="DR-SINGLE"),
+            _make_entity("d3", EntityType.INSERT, "DOORS", block_name="ENTRY_MAIN"),
+            _make_entity("w1", EntityType.INSERT, "WINDOWS", block_name="WINDOW_48"),
             _make_entity("l1", EntityType.LINE, "WALLS"),
         ]
         context = _make_context(entities=entities)
@@ -805,14 +843,10 @@ class TestBlockDetection:
         )
 
         entities = [
-            _make_entity("w1", EntityType.INSERT, "WINDOWS",
-                         block_name="WINDOW_36x48"),
-            _make_entity("w2", EntityType.INSERT, "WINDOWS",
-                         block_name="WNDW-DH"),
-            _make_entity("w3", EntityType.INSERT, "WINDOWS",
-                         block_name="GLAZING_PANEL"),
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         block_name="DOOR_36"),
+            _make_entity("w1", EntityType.INSERT, "WINDOWS", block_name="WINDOW_36x48"),
+            _make_entity("w2", EntityType.INSERT, "WINDOWS", block_name="WNDW-DH"),
+            _make_entity("w3", EntityType.INSERT, "WINDOWS", block_name="GLAZING_PANEL"),
+            _make_entity("d1", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
         ]
         context = _make_context(entities=entities)
 
@@ -826,8 +860,7 @@ class TestBlockDetection:
         )
 
         entities = [
-            _make_entity("t1", EntityType.TEXT, "NOTES",
-                         text_content="DOOR SCHEDULE"),
+            _make_entity("t1", EntityType.TEXT, "NOTES", text_content="DOOR SCHEDULE"),
             _make_entity("l1", EntityType.LINE, "WALLS"),
         ]
         context = _make_context(entities=entities)
@@ -908,7 +941,9 @@ class TestFullProfileChecks:
 
         # Small door + narrow hallway
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_30",
             attributes={"width": 30.0},
@@ -938,7 +973,9 @@ class TestFullProfileChecks:
 
         # Good door + good hallway + good room
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=5),
             block_name="DOOR_36",
             attributes={"width": 36.0},
@@ -979,7 +1016,9 @@ class TestFullProfileChecks:
         from cad_dxf_agent.core.compliance_rules import check_compliance
 
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=10, y=10),
             block_name="DOOR_32",
             attributes={"width": 32.0},
@@ -993,8 +1032,8 @@ class TestFullProfileChecks:
         assert report.profile_name == "residential"
         # 32" door meets residential 32" minimum
         door_violations = [
-            f for f in report.findings
-            if f.rule_id == "DOOR-WIDTH-001"
-            and f.severity == ComplianceSeverity.VIOLATION
+            f
+            for f in report.findings
+            if f.rule_id == "DOOR-WIDTH-001" and f.severity == ComplianceSeverity.VIOLATION
         ]
         assert len(door_violations) == 0

--- a/tests/unit/test_cross_drawing_checker.py
+++ b/tests/unit/test_cross_drawing_checker.py
@@ -247,9 +247,7 @@ class TestLayerNamingConsistency:
         report = check_consistency([sheet_a, sheet_b])
 
         layer_findings = [
-            f
-            for f in report.findings
-            if f.category == ConsistencyCategory.LAYER_NAMING
+            f for f in report.findings if f.category == ConsistencyCategory.LAYER_NAMING
         ]
         assert len(layer_findings) >= 1
         assert any("case" in f.description.lower() for f in layer_findings)
@@ -268,9 +266,7 @@ class TestLayerNamingConsistency:
         report = check_consistency([sheet_a, sheet_b])
 
         layer_findings = [
-            f
-            for f in report.findings
-            if f.category == ConsistencyCategory.LAYER_NAMING
+            f for f in report.findings if f.category == ConsistencyCategory.LAYER_NAMING
         ]
         # Should note layers unique to one sheet
         assert len(layer_findings) >= 1
@@ -329,9 +325,7 @@ class TestBlockConsistency:
         report = check_consistency([sheet_a, sheet_b, sheet_c])
 
         block_findings = [
-            f
-            for f in report.findings
-            if f.category == ConsistencyCategory.BLOCK_CONSISTENCY
+            f for f in report.findings if f.category == ConsistencyCategory.BLOCK_CONSISTENCY
         ]
         assert len(block_findings) >= 1
 
@@ -439,9 +433,7 @@ class TestCoordinateAlignment:
         report = check_consistency([sheet_a, sheet_b])
 
         coord_findings = [
-            f
-            for f in report.findings
-            if f.category == ConsistencyCategory.COORDINATE_ALIGNMENT
+            f for f in report.findings if f.category == ConsistencyCategory.COORDINATE_ALIGNMENT
         ]
         assert len(coord_findings) >= 1
 
@@ -532,10 +524,12 @@ class TestCheckConsistencyIntegration:
     def test_report_checks_run_populated(self):
         from cad_dxf_agent.core.cross_drawing_checker import check_consistency
 
-        report = check_consistency([
-            _make_context("a.dxf", entities=[_line_entity("h1")]),
-            _make_context("b.dxf", entities=[_line_entity("h2")]),
-        ])
+        report = check_consistency(
+            [
+                _make_context("a.dxf", entities=[_line_entity("h1")]),
+                _make_context("b.dxf", entities=[_line_entity("h2")]),
+            ]
+        )
 
         assert "room_labels" in report.checks_run
         assert "layer_naming" in report.checks_run

--- a/tests/unit/test_drawing_summarizer.py
+++ b/tests/unit/test_drawing_summarizer.py
@@ -142,8 +142,7 @@ class TestSummarizeDrawing:
         entities = [
             _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
             _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
-            _make_entity("t1", EntityType.TEXT, "NOTES",
-                         text_content="BEDROOM"),
+            _make_entity("t1", EntityType.TEXT, "NOTES", text_content="BEDROOM"),
         ]
         bedroom = _make_zone("z1", area=1500.0, inferred_type="bedroom")
         kitchen = _make_zone("z2", area=1000.0, inferred_type="kitchen")
@@ -161,9 +160,12 @@ class TestSummarizeDrawing:
         assert "Kitchen" in room_names
 
     def test_headline_includes_drawing_type(self):
-        context = _make_context(entities=[
-            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
-        ], layers=["STRUCTURAL"])
+        context = _make_context(
+            entities=[
+                _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+            ],
+            layers=["STRUCTURAL"],
+        )
         zones = _make_zones_result()
 
         summary = summarize_drawing(context, zones=zones)
@@ -174,12 +176,9 @@ class TestSummarizeDrawing:
 
     def test_key_features_include_symbols(self):
         entities = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         block_name="DOOR_36"),
-            _make_entity("d2", EntityType.INSERT, "DOORS",
-                         block_name="DOOR_36"),
-            _make_entity("w1", EntityType.INSERT, "WINDOWS",
-                         block_name="WIN_48"),
+            _make_entity("d1", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
+            _make_entity("d2", EntityType.INSERT, "DOORS", block_name="DOOR_36"),
+            _make_entity("w1", EntityType.INSERT, "WINDOWS", block_name="WIN_48"),
         ]
         context = _make_context(entities=entities, layers=["DOORS", "WINDOWS"])
         zones = _make_zones_result()
@@ -192,10 +191,8 @@ class TestSummarizeDrawing:
 
     def test_key_features_include_text_count(self):
         entities = [
-            _make_entity("t1", EntityType.TEXT, "NOTES",
-                         text_content="Note 1"),
-            _make_entity("t2", EntityType.MTEXT, "NOTES",
-                         text_content="Note 2"),
+            _make_entity("t1", EntityType.TEXT, "NOTES", text_content="Note 1"),
+            _make_entity("t2", EntityType.MTEXT, "NOTES", text_content="Note 2"),
         ]
         context = _make_context(entities=entities, layers=["NOTES"])
         zones = _make_zones_result()
@@ -252,9 +249,11 @@ class TestSummarizeDrawing:
             _make_zone("z2", area=1000.0, inferred_type="kitchen"),
             _make_zone("z3", area=500.0, inferred_type="bathroom"),
         ]
-        context = _make_context(entities=[
-            _make_entity("l1", EntityType.LINE, "0"),
-        ])
+        context = _make_context(
+            entities=[
+                _make_entity("l1", EntityType.LINE, "0"),
+            ]
+        )
         zones = _make_zones_result(zones_list)
 
         summary = summarize_drawing(context, zones=zones)
@@ -289,10 +288,13 @@ class TestSummarizeHandler:
             objective_tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
             confidence=0.9,
         )
-        context = _make_context(entities=[
-            _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
-            _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
-        ], layers=["STRUCTURAL"])
+        context = _make_context(
+            entities=[
+                _make_entity("l1", EntityType.LINE, "STRUCTURAL"),
+                _make_entity("l2", EntityType.LINE, "STRUCTURAL"),
+            ],
+            layers=["STRUCTURAL"],
+        )
         zones = _make_zones_result()
 
         result = handler.execute(
@@ -313,9 +315,11 @@ class TestSummarizeHandler:
             objective_tag=ObjectiveTag.CUSTOMER_COMMUNICATION,
             confidence=0.9,
         )
-        context = _make_context(entities=[
-            _make_entity("l1", EntityType.LINE, "0"),
-        ])
+        context = _make_context(
+            entities=[
+                _make_entity("l1", EntityType.LINE, "0"),
+            ]
+        )
         bedroom = _make_zone("z1", area=1500.0, inferred_type="bedroom")
         zones = _make_zones_result([bedroom])
 

--- a/tests/unit/test_health_checker.py
+++ b/tests/unit/test_health_checker.py
@@ -71,10 +71,7 @@ def _make_context(
     """Build a DrawingContext with optional entity and layer lists."""
     ents = entities or []
     layer_names = layers or list({e.layer for e in ents})
-    layer_infos = [
-        LayerRule(name=n, color=1)
-        for n in layer_names
-    ]
+    layer_infos = [LayerRule(name=n, color=1) for n in layer_names]
     return DrawingContext(
         file_path="test.dxf",
         entities=ents,
@@ -156,9 +153,7 @@ class TestHealthSchema:
         assert report.info_count == 1
 
     def test_health_report_summary_no_issues(self):
-        report = HealthReport(
-            score=100.0, issues=[], checks_run=["a"], entity_count=10
-        )
+        report = HealthReport(score=100.0, issues=[], checks_run=["a"], entity_count=10)
         assert "no issues found" in report.summary
 
     def test_health_report_summary_with_issues(self):
@@ -304,31 +299,35 @@ class TestComputeScore:
 
     def test_max_deductions_floor_at_zero(self):
         """Score never goes below 0."""
-        issues = [
-            HealthIssue(
-                severity=HealthSeverity.CRITICAL,
-                category=HealthCategory.GENERAL,
-                title=f"c{i}",
-                description="d",
-            )
-            for i in range(4)  # -60
-        ] + [
-            HealthIssue(
-                severity=HealthSeverity.WARNING,
-                category=HealthCategory.TEXT,
-                title=f"w{i}",
-                description="d",
-            )
-            for i in range(7)  # -30
-        ] + [
-            HealthIssue(
-                severity=HealthSeverity.INFO,
-                category=HealthCategory.LAYER,
-                title=f"i{i}",
-                description="d",
-            )
-            for i in range(15)  # -10
-        ]
+        issues = (
+            [
+                HealthIssue(
+                    severity=HealthSeverity.CRITICAL,
+                    category=HealthCategory.GENERAL,
+                    title=f"c{i}",
+                    description="d",
+                )
+                for i in range(4)  # -60
+            ]
+            + [
+                HealthIssue(
+                    severity=HealthSeverity.WARNING,
+                    category=HealthCategory.TEXT,
+                    title=f"w{i}",
+                    description="d",
+                )
+                for i in range(7)  # -30
+            ]
+            + [
+                HealthIssue(
+                    severity=HealthSeverity.INFO,
+                    category=HealthCategory.LAYER,
+                    title=f"i{i}",
+                    description="d",
+                )
+                for i in range(15)  # -10
+            ]
+        )
         # Total deductions: 60 + 30 + 10 = 100
         assert _compute_score(issues, entity_count=10) == 0.0
 
@@ -380,10 +379,7 @@ class TestCheckUnclosedPolylines:
 
     def test_evidence_capped_at_5(self):
         """Only first 5 polylines appear in evidence."""
-        ents = [
-            _make_entity(str(i), EntityType.LWPOLYLINE)
-            for i in range(10)
-        ]
+        ents = [_make_entity(str(i), EntityType.LWPOLYLINE) for i in range(10)]
         ctx = _make_context(entities=ents)
         idx = EntityIndex(ctx)
         issues = _check_polylines_missing_geometry(ctx, idx)
@@ -399,12 +395,20 @@ class TestCheckInconsistentTextHeights:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, layer="NOTES",
-                    x=0, y=0, text_height=3.0,
+                    "1",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=0,
+                    y=0,
+                    text_height=3.0,
                 ),
                 _make_entity(
-                    "2", EntityType.TEXT, layer="NOTES",
-                    x=10, y=0, text_height=3.0,
+                    "2",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=10,
+                    y=0,
+                    text_height=3.0,
                 ),
             ]
         )
@@ -417,12 +421,20 @@ class TestCheckInconsistentTextHeights:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, layer="NOTES",
-                    x=0, y=0, text_height=3.0,
+                    "1",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=0,
+                    y=0,
+                    text_height=3.0,
                 ),
                 _make_entity(
-                    "2", EntityType.TEXT, layer="NOTES",
-                    x=10, y=0, text_height=5.0,
+                    "2",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=10,
+                    y=0,
+                    text_height=5.0,
                 ),
             ]
         )
@@ -435,20 +447,36 @@ class TestCheckInconsistentTextHeights:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, layer="NOTES",
-                    x=0, y=0, text_height=3.0,
+                    "1",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=0,
+                    y=0,
+                    text_height=3.0,
                 ),
                 _make_entity(
-                    "2", EntityType.TEXT, layer="NOTES",
-                    x=10, y=0, text_height=3.0,
+                    "2",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=10,
+                    y=0,
+                    text_height=3.0,
                 ),
                 _make_entity(
-                    "3", EntityType.TEXT, layer="NOTES",
-                    x=20, y=0, text_height=5.0,
+                    "3",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=20,
+                    y=0,
+                    text_height=5.0,
                 ),
                 _make_entity(
-                    "4", EntityType.TEXT, layer="NOTES",
-                    x=30, y=0, text_height=8.0,
+                    "4",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=30,
+                    y=0,
+                    text_height=8.0,
                 ),
             ]
         )
@@ -476,12 +504,20 @@ class TestCheckInconsistentTextHeights:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, layer="NOTES",
-                    x=0, y=0, text_height=0.0,
+                    "1",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=0,
+                    y=0,
+                    text_height=0.0,
                 ),
                 _make_entity(
-                    "2", EntityType.TEXT, layer="NOTES",
-                    x=10, y=0, text_height=3.0,
+                    "2",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=10,
+                    y=0,
+                    text_height=3.0,
                 ),
             ]
         )
@@ -589,8 +625,7 @@ class TestCheckOverlappingEntities:
         ctx = _make_context(
             entities=[
                 _make_entity("1", EntityType.LINE, layer="A", x=10, y=10),
-                _make_entity("2", EntityType.TEXT, layer="A", x=10, y=10,
-                             text_content="X"),
+                _make_entity("2", EntityType.TEXT, layer="A", x=10, y=10, text_content="X"),
             ],
             layers=["A"],
         )
@@ -663,7 +698,10 @@ class TestCheckMissingTextContent:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, x=0, y=0,
+                    "1",
+                    EntityType.TEXT,
+                    x=0,
+                    y=0,
                     text_content="Hello World",
                 ),
             ]
@@ -677,7 +715,10 @@ class TestCheckMissingTextContent:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.TEXT, x=0, y=0,
+                    "1",
+                    EntityType.TEXT,
+                    x=0,
+                    y=0,
                     text_content="",
                 ),
             ]
@@ -693,7 +734,10 @@ class TestCheckMissingTextContent:
         ctx = _make_context(
             entities=[
                 _make_entity(
-                    "1", EntityType.MTEXT, x=0, y=0,
+                    "1",
+                    EntityType.MTEXT,
+                    x=0,
+                    y=0,
                     text_content="   \n  ",
                 ),
             ]
@@ -738,7 +782,10 @@ class TestCheckMissingTextContent:
         """Only first 10 empty texts appear in evidence."""
         ents = [
             _make_entity(
-                str(i), EntityType.TEXT, x=i * 10.0, y=0,
+                str(i),
+                EntityType.TEXT,
+                x=i * 10.0,
+                y=0,
                 text_content="",
             )
             for i in range(15)
@@ -754,12 +801,8 @@ class TestCheckDimensionCoverage:
 
     def test_drawing_with_dimensions_ok(self):
         """Drawing with geometry and dimensions = no issue."""
-        ents = [
-            _make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0)
-            for i in range(15)
-        ] + [
-            _make_entity(f"d{i}", EntityType.DIMENSION, x=i * 10.0, y=-5)
-            for i in range(5)
+        ents = [_make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0) for i in range(15)] + [
+            _make_entity(f"d{i}", EntityType.DIMENSION, x=i * 10.0, y=-5) for i in range(5)
         ]
         ctx = _make_context(entities=ents)
         idx = EntityIndex(ctx)
@@ -768,10 +811,7 @@ class TestCheckDimensionCoverage:
 
     def test_no_dimensions_with_geometry_warning(self):
         """10+ geometric entities and 0 dimensions = WARNING."""
-        ents = [
-            _make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0)
-            for i in range(12)
-        ]
+        ents = [_make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0) for i in range(12)]
         ctx = _make_context(entities=ents)
         idx = EntityIndex(ctx)
         issues = _check_dimension_coverage(ctx, idx)
@@ -782,10 +822,7 @@ class TestCheckDimensionCoverage:
 
     def test_few_geometry_entities_no_issue(self):
         """Less than 10 geometric entities = no dimension check."""
-        ents = [
-            _make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0)
-            for i in range(5)
-        ]
+        ents = [_make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0) for i in range(5)]
         ctx = _make_context(entities=ents)
         idx = EntityIndex(ctx)
         issues = _check_dimension_coverage(ctx, idx)
@@ -793,10 +830,7 @@ class TestCheckDimensionCoverage:
 
     def test_low_dimension_ratio_info(self):
         """20+ geometry with <5% dimensions = INFO."""
-        ents = [
-            _make_entity(str(i), EntityType.LINE, x=i * 5.0, y=0)
-            for i in range(25)
-        ]
+        ents = [_make_entity(str(i), EntityType.LINE, x=i * 5.0, y=0) for i in range(25)]
         # Add 0 dimensions (less than 5% of 25 = 1.25, so 0 triggers WARNING)
         # Add 1 dimension = 4% < 5% → triggers INFO
         ents.append(_make_entity("d0", EntityType.DIMENSION, x=0, y=-5))
@@ -809,10 +843,7 @@ class TestCheckDimensionCoverage:
 
     def test_polylines_count_as_geometry(self):
         """LWPOLYLINE entities should count toward geometry total."""
-        ents = [
-            _make_entity(str(i), EntityType.LWPOLYLINE, x=i * 5.0, y=0)
-            for i in range(12)
-        ]
+        ents = [_make_entity(str(i), EntityType.LWPOLYLINE, x=i * 5.0, y=0) for i in range(12)]
         ctx = _make_context(entities=ents)
         idx = EntityIndex(ctx)
         issues = _check_dimension_coverage(ctx, idx)
@@ -837,8 +868,7 @@ class TestCheckEntityTypeDistribution:
         ctx = _make_context(
             entities=[
                 _make_entity("1", EntityType.LINE, x=0, y=0),
-                _make_entity("2", EntityType.TEXT, x=10, y=0,
-                             text_content="Note"),
+                _make_entity("2", EntityType.TEXT, x=10, y=0, text_content="Note"),
             ]
         )
         idx = EntityIndex(ctx)
@@ -849,7 +879,10 @@ class TestCheckEntityTypeDistribution:
         """All text, no geometry, 5+ entities = INFO."""
         ents = [
             _make_entity(
-                str(i), EntityType.TEXT, x=i * 10.0, y=0,
+                str(i),
+                EntityType.TEXT,
+                x=i * 10.0,
+                y=0,
                 text_content=f"Text {i}",
             )
             for i in range(8)
@@ -865,7 +898,10 @@ class TestCheckEntityTypeDistribution:
         """Text-only but <= 5 entities shouldn't flag."""
         ents = [
             _make_entity(
-                str(i), EntityType.TEXT, x=i * 10.0, y=0,
+                str(i),
+                EntityType.TEXT,
+                x=i * 10.0,
+                y=0,
                 text_content="X",
             )
             for i in range(3)
@@ -891,7 +927,10 @@ class TestCheckEntityTypeDistribution:
         """MTEXT should count toward text total."""
         ents = [
             _make_entity(
-                str(i), EntityType.MTEXT, x=i * 10.0, y=0,
+                str(i),
+                EntityType.MTEXT,
+                x=i * 10.0,
+                y=0,
                 text_content=f"Note {i}",
             )
             for i in range(8)
@@ -914,19 +953,21 @@ class TestCheckDrawingHealth:
     def test_clean_drawing_perfect_score(self):
         """A well-formed drawing should get a high score."""
         # Lines + text + dimensions = healthy
-        ents = [
-            _make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0)
-            for i in range(15)
-        ] + [
-            _make_entity(
-                f"t{i}", EntityType.TEXT, x=i * 10.0, y=10,
-                text_content=f"Label {i}", text_height=3.0,
-            )
-            for i in range(5)
-        ] + [
-            _make_entity(f"d{i}", EntityType.DIMENSION, x=i * 10.0, y=-5)
-            for i in range(5)
-        ]
+        ents = (
+            [_make_entity(str(i), EntityType.LINE, x=i * 10.0, y=0) for i in range(15)]
+            + [
+                _make_entity(
+                    f"t{i}",
+                    EntityType.TEXT,
+                    x=i * 10.0,
+                    y=10,
+                    text_content=f"Label {i}",
+                    text_height=3.0,
+                )
+                for i in range(5)
+            ]
+            + [_make_entity(f"d{i}", EntityType.DIMENSION, x=i * 10.0, y=-5) for i in range(5)]
+        )
         ctx = _make_context(entities=ents, layers=["STRUCTURAL"])
         report = check_drawing_health(ctx, include_zones=False)
 
@@ -949,7 +990,10 @@ class TestCheckDrawingHealth:
             # Empty text entities (WARNING)
             [
                 _make_entity(
-                    f"e{i}", EntityType.TEXT, x=i * 10.0, y=0,
+                    f"e{i}",
+                    EntityType.TEXT,
+                    x=i * 10.0,
+                    y=0,
                     text_content="",
                 )
                 for i in range(5)
@@ -957,16 +1001,17 @@ class TestCheckDrawingHealth:
             # Inconsistent text heights (WARNING)
             + [
                 _make_entity(
-                    f"h{i}", EntityType.TEXT, layer="NOTES",
-                    x=i * 10.0, y=20, text_height=float(i + 1),
+                    f"h{i}",
+                    EntityType.TEXT,
+                    layer="NOTES",
+                    x=i * 10.0,
+                    y=20,
+                    text_height=float(i + 1),
                 )
                 for i in range(4)
             ]
             # Lines but no dimensions (WARNING)
-            + [
-                _make_entity(f"l{i}", EntityType.LINE, x=i * 10.0, y=40)
-                for i in range(15)
-            ]
+            + [_make_entity(f"l{i}", EntityType.LINE, x=i * 10.0, y=40) for i in range(15)]
         )
         ctx = _make_context(
             entities=ents,
@@ -1010,8 +1055,7 @@ class TestCheckDrawingHealth:
         ctx = _make_context(
             entities=[
                 _make_entity("1", EntityType.LINE, x=0, y=0),
-                _make_entity("2", EntityType.TEXT, x=10, y=0,
-                             text_content=""),
+                _make_entity("2", EntityType.TEXT, x=10, y=0, text_content=""),
             ]
         )
         report = check_drawing_health(ctx, include_zones=False)

--- a/tests/unit/test_revision_report.py
+++ b/tests/unit/test_revision_report.py
@@ -161,9 +161,11 @@ class TestComputeZoneDeltas:
 
     def test_room_added(self):
         old_zones = _make_zones_result()
-        new_zones = _make_zones_result([
-            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
-        ])
+        new_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+            ]
+        )
         deltas = _compute_zone_deltas(old_zones, new_zones)
 
         assert len(deltas) == 1
@@ -172,9 +174,11 @@ class TestComputeZoneDeltas:
         assert deltas[0].new_area == 1500.0
 
     def test_room_removed(self):
-        old_zones = _make_zones_result([
-            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
-        ])
+        old_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+            ]
+        )
         new_zones = _make_zones_result()
         deltas = _compute_zone_deltas(old_zones, new_zones)
 
@@ -184,12 +188,16 @@ class TestComputeZoneDeltas:
         assert deltas[0].area_change == -1500.0
 
     def test_room_resized(self):
-        old_zones = _make_zones_result([
-            _make_zone("z1", area=1000.0, inferred_type="kitchen"),
-        ])
-        new_zones = _make_zones_result([
-            _make_zone("z1", area=1200.0, inferred_type="kitchen"),
-        ])
+        old_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1000.0, inferred_type="kitchen"),
+            ]
+        )
+        new_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1200.0, inferred_type="kitchen"),
+            ]
+        )
         deltas = _compute_zone_deltas(old_zones, new_zones)
 
         assert len(deltas) == 1
@@ -206,14 +214,18 @@ class TestComputeZoneDeltas:
         assert deltas[0].status == "unchanged"
 
     def test_mixed_changes(self):
-        old_zones = _make_zones_result([
-            _make_zone("z1", area=1000.0, inferred_type="bedroom"),
-            _make_zone("z2", area=500.0, inferred_type="bathroom"),
-        ])
-        new_zones = _make_zones_result([
-            _make_zone("z1", area=1200.0, inferred_type="bedroom"),
-            _make_zone("z3", area=800.0, inferred_type="kitchen"),
-        ])
+        old_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1000.0, inferred_type="bedroom"),
+                _make_zone("z2", area=500.0, inferred_type="bathroom"),
+            ]
+        )
+        new_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1200.0, inferred_type="bedroom"),
+                _make_zone("z3", area=800.0, inferred_type="kitchen"),
+            ]
+        )
         deltas = _compute_zone_deltas(old_zones, new_zones)
 
         statuses = {d.status for d in deltas}
@@ -233,8 +245,7 @@ class TestBuildHeadline:
     def test_headline_with_changes(self):
         changelog = ChangeLog(entries=[_make_entry(), _make_entry()])
         deltas = [
-            ZoneDelta(zone_type="bedroom", status="added",
-                      new_area=1500.0, area_change=1500.0),
+            ZoneDelta(zone_type="bedroom", status="added", new_area=1500.0, area_change=1500.0),
         ]
         headline = _build_headline(changelog, deltas, 1500.0)
 
@@ -250,8 +261,7 @@ class TestBuildHeadline:
     def test_headline_negative_area(self):
         changelog = ChangeLog(entries=[_make_entry()])
         deltas = [
-            ZoneDelta(zone_type="closet", status="removed",
-                      old_area=50.0, area_change=-50.0),
+            ZoneDelta(zone_type="closet", status="removed", old_area=50.0, area_change=-50.0),
         ]
         headline = _build_headline(changelog, deltas, -50.0)
         assert "-50" in headline
@@ -273,7 +283,9 @@ class TestGenerateRevisionReport:
         revision_zones = _make_zones_result()
 
         report = generate_revision_report(
-            master, revision, changelog,
+            master,
+            revision,
+            changelog,
             master_zones=master_zones,
             revision_zones=revision_zones,
         )
@@ -286,21 +298,29 @@ class TestGenerateRevisionReport:
     def test_report_with_changes_and_zones(self):
         master = _make_context(file_path="master.dxf")
         revision = _make_context(file_path="revision.dxf")
-        changelog = ChangeLog(entries=[
-            _make_entry("added", description="New wall added"),
-            _make_entry("modified", description="Wall moved"),
-            _make_entry("removed", description="Old fixture removed"),
-        ])
-        master_zones = _make_zones_result([
-            _make_zone("z1", area=1000.0, inferred_type="bedroom"),
-        ])
-        revision_zones = _make_zones_result([
-            _make_zone("z1", area=1200.0, inferred_type="bedroom"),
-            _make_zone("z2", area=800.0, inferred_type="kitchen"),
-        ])
+        changelog = ChangeLog(
+            entries=[
+                _make_entry("added", description="New wall added"),
+                _make_entry("modified", description="Wall moved"),
+                _make_entry("removed", description="Old fixture removed"),
+            ]
+        )
+        master_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1000.0, inferred_type="bedroom"),
+            ]
+        )
+        revision_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1200.0, inferred_type="bedroom"),
+                _make_zone("z2", area=800.0, inferred_type="kitchen"),
+            ]
+        )
 
         report = generate_revision_report(
-            master, revision, changelog,
+            master,
+            revision,
+            changelog,
             master_zones=master_zones,
             revision_zones=revision_zones,
         )
@@ -314,16 +334,22 @@ class TestGenerateRevisionReport:
     def test_plain_summary_readable(self):
         master = _make_context(file_path="floor_plan_v1.dxf")
         revision = _make_context(file_path="floor_plan_v2.dxf")
-        changelog = ChangeLog(entries=[
-            _make_entry("added", description="New bedroom wall"),
-        ])
+        changelog = ChangeLog(
+            entries=[
+                _make_entry("added", description="New bedroom wall"),
+            ]
+        )
         master_zones = _make_zones_result()
-        revision_zones = _make_zones_result([
-            _make_zone("z1", area=1500.0, inferred_type="bedroom"),
-        ])
+        revision_zones = _make_zones_result(
+            [
+                _make_zone("z1", area=1500.0, inferred_type="bedroom"),
+            ]
+        )
 
         report = generate_revision_report(
-            master, revision, changelog,
+            master,
+            revision,
+            changelog,
             master_zones=master_zones,
             revision_zones=revision_zones,
         )

--- a/tests/unit/test_rfi_generator.py
+++ b/tests/unit/test_rfi_generator.py
@@ -170,7 +170,9 @@ class TestDimensionsNearDoors:
 
     def test_door_without_dimension_flagged(self):
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=100, y=100),
             block_name="DOOR_36",
         )
@@ -184,12 +186,16 @@ class TestDimensionsNearDoors:
 
     def test_door_with_nearby_dimension_not_flagged(self):
         door = _make_entity(
-            "d1", EntityType.INSERT, "DOORS",
+            "d1",
+            EntityType.INSERT,
+            "DOORS",
             insert_point=Point2D(x=100, y=100),
             block_name="DOOR_36",
         )
         dim = _make_entity(
-            "dim1", EntityType.DIMENSION, "DIM",
+            "dim1",
+            EntityType.DIMENSION,
+            "DIM",
             insert_point=Point2D(x=105, y=100),
         )
         context = _make_context(entities=[door, dim])
@@ -200,7 +206,9 @@ class TestDimensionsNearDoors:
 
     def test_non_door_inserts_ignored(self):
         insert = _make_entity(
-            "i1", EntityType.INSERT, "FIXTURES",
+            "i1",
+            EntityType.INSERT,
+            "FIXTURES",
             insert_point=Point2D(x=100, y=100),
             block_name="TOILET",
         )
@@ -221,7 +229,9 @@ class TestSymbolsWithoutLegend:
 
     def test_symbol_without_legend_flagged(self):
         insert = _make_entity(
-            "i1", EntityType.INSERT, "SYMBOLS",
+            "i1",
+            EntityType.INSERT,
+            "SYMBOLS",
             block_name="FIRE_EXT_A",
         )
         context = _make_context(entities=[insert])
@@ -234,11 +244,15 @@ class TestSymbolsWithoutLegend:
 
     def test_symbol_with_legend_not_flagged(self):
         insert = _make_entity(
-            "i1", EntityType.INSERT, "SYMBOLS",
+            "i1",
+            EntityType.INSERT,
+            "SYMBOLS",
             block_name="OUTLET",
         )
         legend_text = _make_entity(
-            "t1", EntityType.TEXT, "NOTES",
+            "t1",
+            EntityType.TEXT,
+            "NOTES",
             text_content="OUTLET - Standard 120V duplex receptacle",
         )
         context = _make_context(entities=[insert, legend_text])
@@ -248,9 +262,11 @@ class TestSymbolsWithoutLegend:
         assert len(items) == 0
 
     def test_no_inserts_no_findings(self):
-        context = _make_context(entities=[
-            _make_entity("l1", EntityType.LINE, "WALLS"),
-        ])
+        context = _make_context(
+            entities=[
+                _make_entity("l1", EntityType.LINE, "WALLS"),
+            ]
+        )
         zones = _make_zones_result()
 
         items = _check_symbols_without_legend(context, zones, 0)
@@ -307,7 +323,9 @@ class TestUnclosedBoundaries:
 
     def test_nearly_closed_polyline_flagged(self):
         poly = _make_entity(
-            "p1", EntityType.LWPOLYLINE, "WALLS",
+            "p1",
+            EntityType.LWPOLYLINE,
+            "WALLS",
             insert_point=Point2D(x=0, y=0),
             attributes={
                 "vertices": [[0, 0], [100, 0], [100, 100], [2, 0]],
@@ -323,7 +341,9 @@ class TestUnclosedBoundaries:
 
     def test_clearly_open_polyline_not_flagged(self):
         poly = _make_entity(
-            "p1", EntityType.LWPOLYLINE, "WALLS",
+            "p1",
+            EntityType.LWPOLYLINE,
+            "WALLS",
             insert_point=Point2D(x=0, y=0),
             attributes={
                 "vertices": [[0, 0], [100, 0], [100, 100], [50, 100]],
@@ -339,7 +359,9 @@ class TestUnclosedBoundaries:
 
     def test_closed_polyline_not_flagged(self):
         poly = _make_entity(
-            "p1", EntityType.LWPOLYLINE, "WALLS",
+            "p1",
+            EntityType.LWPOLYLINE,
+            "WALLS",
             attributes={
                 "vertices": [[0, 0], [100, 0], [100, 100], [0, 100]],
                 "is_closed": True,
@@ -371,11 +393,14 @@ class TestGenerateRFI:
 
     def test_drawing_with_issues(self):
         entities = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=50, y=50),
-                         block_name="DOOR_36"),
-            _make_entity("i1", EntityType.INSERT, "FIXTURES",
-                         block_name="CUSTOM_WIDGET"),
+            _make_entity(
+                "d1",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=50, y=50),
+                block_name="DOOR_36",
+            ),
+            _make_entity("i1", EntityType.INSERT, "FIXTURES", block_name="CUSTOM_WIDGET"),
             _make_entity("l1", EntityType.LINE, "WALLS"),
         ]
         context = _make_context(
@@ -395,12 +420,20 @@ class TestGenerateRFI:
 
     def test_rfi_ids_sequential(self):
         entities = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=50, y=50),
-                         block_name="DOOR_36"),
-            _make_entity("d2", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=150, y=50),
-                         block_name="DR-SINGLE"),
+            _make_entity(
+                "d1",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=50, y=50),
+                block_name="DOOR_36",
+            ),
+            _make_entity(
+                "d2",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=150, y=50),
+                block_name="DR-SINGLE",
+            ),
         ]
         context = _make_context(entities=entities)
         zones = _make_zones_result()
@@ -414,9 +447,13 @@ class TestGenerateRFI:
     def test_severity_counts_accurate(self):
         context = _make_context(
             entities=[
-                _make_entity("d1", EntityType.INSERT, "DOORS",
-                             insert_point=Point2D(x=50, y=50),
-                             block_name="EXIT_DOOR"),
+                _make_entity(
+                    "d1",
+                    EntityType.INSERT,
+                    "DOORS",
+                    insert_point=Point2D(x=50, y=50),
+                    block_name="EXIT_DOOR",
+                ),
             ],
             layers=["DOORS", "UNUSED_LAYER"],
         )

--- a/tests/unit/test_takeoff_engine.py
+++ b/tests/unit/test_takeoff_engine.py
@@ -116,16 +116,22 @@ class TestTakeoffSchema:
         report = TakeoffReport(
             items=[
                 TakeoffReportItem(
-                    name="Door", category=TakeoffCategory.SYMBOL,
-                    quantity=3, unit="ea",
+                    name="Door",
+                    category=TakeoffCategory.SYMBOL,
+                    quantity=3,
+                    unit="ea",
                 ),
                 TakeoffReportItem(
-                    name="Wall", category=TakeoffCategory.LINEAR,
-                    quantity=120.0, unit="ft",
+                    name="Wall",
+                    category=TakeoffCategory.LINEAR,
+                    quantity=120.0,
+                    unit="ft",
                 ),
                 TakeoffReportItem(
-                    name="Door2", category=TakeoffCategory.SYMBOL,
-                    quantity=2, unit="ea",
+                    name="Door2",
+                    category=TakeoffCategory.SYMBOL,
+                    quantity=2,
+                    unit="ea",
                 ),
             ],
             total_items=3,
@@ -138,8 +144,11 @@ class TestTakeoffSchema:
         report = TakeoffReport(
             items=[
                 TakeoffReportItem(
-                    name="DOOR_36", category=TakeoffCategory.SYMBOL,
-                    quantity=5, unit="ea", source_layer="DOORS",
+                    name="DOOR_36",
+                    category=TakeoffCategory.SYMBOL,
+                    quantity=5,
+                    unit="ea",
+                    source_layer="DOORS",
                 ),
             ],
             total_items=1,
@@ -210,7 +219,9 @@ class TestMeasureLinear:
 
     def test_line_length(self):
         line = _make_entity(
-            "l1", EntityType.LINE, "WALLS",
+            "l1",
+            EntityType.LINE,
+            "WALLS",
             insert_point=Point2D(x=0, y=0),
             attributes={"end_point": [30, 40]},
         )
@@ -219,7 +230,9 @@ class TestMeasureLinear:
 
     def test_polyline_length(self):
         poly = _make_entity(
-            "p1", EntityType.LWPOLYLINE, "WALLS",
+            "p1",
+            EntityType.LWPOLYLINE,
+            "WALLS",
             attributes={
                 "vertices": [[0, 0], [10, 0], [10, 10]],
                 "is_closed": False,
@@ -230,7 +243,9 @@ class TestMeasureLinear:
 
     def test_closed_polyline_includes_closing_segment(self):
         poly = _make_entity(
-            "p1", EntityType.LWPOLYLINE, "WALLS",
+            "p1",
+            EntityType.LWPOLYLINE,
+            "WALLS",
             attributes={
                 "vertices": [[0, 0], [10, 0], [10, 10], [0, 10]],
                 "is_closed": True,
@@ -241,15 +256,27 @@ class TestMeasureLinear:
 
     def test_measure_linear_per_layer(self):
         entities = [
-            _make_entity("l1", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=0, y=0),
-                         attributes={"end_point": [10, 0]}),
-            _make_entity("l2", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=10, y=0),
-                         attributes={"end_point": [20, 0]}),
-            _make_entity("l3", EntityType.LINE, "PIPES",
-                         insert_point=Point2D(x=0, y=0),
-                         attributes={"end_point": [5, 0]}),
+            _make_entity(
+                "l1",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=0, y=0),
+                attributes={"end_point": [10, 0]},
+            ),
+            _make_entity(
+                "l2",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=10, y=0),
+                attributes={"end_point": [20, 0]},
+            ),
+            _make_entity(
+                "l3",
+                EntityType.LINE,
+                "PIPES",
+                insert_point=Point2D(x=0, y=0),
+                attributes={"end_point": [5, 0]},
+            ),
         ]
         context = _make_context(entities=entities)
         items = _measure_linear(context)
@@ -272,7 +299,9 @@ class TestMeasureLinear:
 
     def test_line_without_endpoint_zero_length(self):
         line = _make_entity(
-            "l1", EntityType.LINE, "WALLS",
+            "l1",
+            EntityType.LINE,
+            "WALLS",
             insert_point=Point2D(x=0, y=0),
         )
         assert _entity_length(line) == 0.0
@@ -386,19 +415,35 @@ class TestGenerateTakeoff:
     def test_full_drawing(self):
         entities = [
             # Doors (symbols)
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=10, y=0),
-                         block_name="DOOR_36"),
-            _make_entity("d2", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=50, y=0),
-                         block_name="DOOR_36"),
+            _make_entity(
+                "d1",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=10, y=0),
+                block_name="DOOR_36",
+            ),
+            _make_entity(
+                "d2",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=50, y=0),
+                block_name="DOOR_36",
+            ),
             # Walls (lines)
-            _make_entity("l1", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=0, y=0),
-                         attributes={"end_point": [100, 0]}),
-            _make_entity("l2", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=100, y=0),
-                         attributes={"end_point": [100, 50]}),
+            _make_entity(
+                "l1",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=0, y=0),
+                attributes={"end_point": [100, 0]},
+            ),
+            _make_entity(
+                "l2",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=100, y=0),
+                attributes={"end_point": [100, 50]},
+            ),
             # Text
             _make_entity("t1", EntityType.TEXT, "NOTES"),
             _make_entity("t2", EntityType.TEXT, "NOTES"),
@@ -436,9 +481,13 @@ class TestGenerateTakeoff:
 
     def test_csv_export_integration(self):
         entities = [
-            _make_entity("d1", EntityType.INSERT, "DOORS",
-                         insert_point=Point2D(x=10, y=0),
-                         block_name="DOOR_36"),
+            _make_entity(
+                "d1",
+                EntityType.INSERT,
+                "DOORS",
+                insert_point=Point2D(x=10, y=0),
+                block_name="DOOR_36",
+            ),
         ]
         context = _make_context(entities=entities)
         zones = _make_zones_result()
@@ -447,39 +496,44 @@ class TestGenerateTakeoff:
         rows = report.to_csv_rows()
 
         assert len(rows) >= 2  # header + at least 1 data row
-        assert rows[0] == ["Category", "Name", "Quantity", "Unit",
-                           "Layer", "Zone", "Notes"]
+        assert rows[0] == ["Category", "Name", "Quantity", "Unit", "Layer", "Zone", "Notes"]
 
     def test_polyline_linear_measurement(self):
         entities = [
-            _make_entity("p1", EntityType.LWPOLYLINE, "WALLS",
-                         attributes={
-                             "vertices": [[0, 0], [100, 0], [100, 50]],
-                             "is_closed": False,
-                         }),
+            _make_entity(
+                "p1",
+                EntityType.LWPOLYLINE,
+                "WALLS",
+                attributes={
+                    "vertices": [[0, 0], [100, 0], [100, 50]],
+                    "is_closed": False,
+                },
+            ),
         ]
         context = _make_context(entities=entities)
         zones = _make_zones_result()
 
         report = generate_takeoff(context, zones=zones)
-        linear_items = [i for i in report.items
-                        if i.category == TakeoffCategory.LINEAR]
+        linear_items = [i for i in report.items if i.category == TakeoffCategory.LINEAR]
 
         assert len(linear_items) == 1
         assert abs(linear_items[0].quantity - 150.0) < 0.01
 
     def test_diagonal_line_measurement(self):
         entities = [
-            _make_entity("l1", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=0, y=0),
-                         attributes={"end_point": [30, 40]}),
+            _make_entity(
+                "l1",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=0, y=0),
+                attributes={"end_point": [30, 40]},
+            ),
         ]
         context = _make_context(entities=entities)
         zones = _make_zones_result()
 
         report = generate_takeoff(context, zones=zones)
-        linear_items = [i for i in report.items
-                        if i.category == TakeoffCategory.LINEAR]
+        linear_items = [i for i in report.items if i.category == TakeoffCategory.LINEAR]
 
         assert len(linear_items) == 1
         assert abs(linear_items[0].quantity - 50.0) < 0.01  # 3-4-5
@@ -487,9 +541,13 @@ class TestGenerateTakeoff:
     def test_report_entity_handles_limited(self):
         """Verify entity handle lists are bounded to prevent huge payloads."""
         entities = [
-            _make_entity(f"l{i}", EntityType.LINE, "WALLS",
-                         insert_point=Point2D(x=i * 10, y=0),
-                         attributes={"end_point": [i * 10 + 10, 0]})
+            _make_entity(
+                f"l{i}",
+                EntityType.LINE,
+                "WALLS",
+                insert_point=Point2D(x=i * 10, y=0),
+                attributes={"end_point": [i * 10 + 10, 0]},
+            )
             for i in range(50)
         ]
         context = _make_context(entities=entities)

--- a/tests/web/test_api_v1.py
+++ b/tests/web/test_api_v1.py
@@ -184,10 +184,7 @@ class TestV1Health:
         resp = _upload(client, "/api/v1/health", dxf)
         data = resp.json()
 
-        layer_issues = [
-            i for i in data["issues"]
-            if i["category"] == "layer"
-        ]
+        layer_issues = [i for i in data["issues"] if i["category"] == "layer"]
         assert len(layer_issues) > 0
 
 

--- a/tests/web/test_compliance_endpoint.py
+++ b/tests/web/test_compliance_endpoint.py
@@ -1,0 +1,177 @@
+"""Tests for POST /api/drawing-compliance and GET /api/compliance-profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+starlette = pytest.importorskip("starlette", reason="web tests require fastapi/starlette")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from tests.helpers.dxf_factory import create_structural_drawing  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    """Create a test client with dev mode enabled."""
+    import os
+
+    old = os.environ.get("CAD_WEB_DEV_MODE")
+    os.environ["CAD_WEB_DEV_MODE"] = "1"
+    from web.backend.main import app
+
+    with TestClient(app) as c:
+        yield c
+    if old is None:
+        os.environ.pop("CAD_WEB_DEV_MODE", None)
+    else:
+        os.environ["CAD_WEB_DEV_MODE"] = old
+
+
+@pytest.fixture()
+def session_with_dxf(client: TestClient, tmp_path: Path):
+    """Upload a DXF and return the session_id."""
+    dxf_path = create_structural_drawing(tmp_path)
+    with open(dxf_path, "rb") as f:
+        resp = client.post("/api/upload", files={"file": ("test.dxf", f)})
+    assert resp.status_code == 200
+    return resp.json()["session_id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/compliance-profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestComplianceProfilesList:
+    def test_profiles_returns_200(self, client):
+        resp = client.get("/api/compliance-profiles")
+        assert resp.status_code == 200
+
+    def test_profiles_has_builtin_entries(self, client):
+        resp = client.get("/api/compliance-profiles")
+        data = resp.json()
+        assert "ada" in data
+        assert "ibc-2021" in data
+        assert "residential" in data
+
+    def test_profile_has_name_and_description(self, client):
+        resp = client.get("/api/compliance-profiles")
+        ada = resp.json()["ada"]
+        assert "name" in ada
+        assert "description" in ada
+        assert "enabled_categories" in ada
+
+    def test_profile_categories_are_list(self, client):
+        resp = client.get("/api/compliance-profiles")
+        ibc = resp.json()["ibc-2021"]
+        assert isinstance(ibc["enabled_categories"], list)
+        assert len(ibc["enabled_categories"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/drawing-compliance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestComplianceEndpoint:
+    def test_compliance_returns_200(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        assert resp.status_code == 200
+
+    def test_compliance_default_profile_is_ibc(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        assert resp.json()["profile"] == "ibc-2021"
+
+    def test_compliance_ada_profile(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf, "profile": "ada"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"] == "ada"
+
+    def test_compliance_residential_profile(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf, "profile": "residential"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"] == "residential"
+
+    def test_compliance_unknown_profile_returns_422(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf, "profile": "nonexistent"},
+        )
+        assert resp.status_code == 422
+
+    def test_compliance_response_structure(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        data = resp.json()
+        assert "profile" in data
+        assert "passed" in data
+        assert "score" in data
+        assert "findings" in data
+        assert "checks_run" in data
+        assert "violation_count" in data
+        assert "warning_count" in data
+        assert "pass_count" in data
+
+    def test_compliance_score_is_numeric(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        score = resp.json()["score"]
+        assert isinstance(score, (int, float))
+        assert 0 <= score <= 100
+
+    def test_compliance_findings_are_list(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        findings = resp.json()["findings"]
+        assert isinstance(findings, list)
+
+    def test_compliance_checks_run_non_empty(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        assert len(resp.json()["checks_run"]) > 0
+
+    def test_compliance_invalid_session_returns_404(self, client):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": "nonexistent-session"},
+        )
+        assert resp.status_code == 404
+
+    def test_compliance_passed_is_boolean(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        assert isinstance(resp.json()["passed"], bool)
+
+    def test_compliance_entity_count_matches_drawing(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/drawing-compliance",
+            json={"session_id": session_with_dxf},
+        )
+        assert resp.json()["entity_count"] > 0

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -302,6 +302,80 @@ async def drawing_health_check(
         }
 
 
+class DrawingComplianceRequest(BaseModel):
+    session_id: str
+    profile: str = "ibc-2021"
+
+
+@app.post("/api/drawing-compliance")
+async def drawing_compliance_check(
+    req: DrawingComplianceRequest,
+    user=Depends(get_licensed_user),
+):
+    """Run regulation-aware compliance validation on the uploaded DXF.
+
+    Checks the drawing against a compliance profile (ada, ibc, residential)
+    and returns a structured report with findings, code references, and score.
+    """
+    with otel_span("api.drawing_compliance") as span:
+        try:
+            session = session_mgr.get(req.session_id, user["uid"])
+        except (KeyError, PermissionError) as e:
+            raise HTTPException(404, str(e))
+
+        span.set_attribute("cad.session_id", req.session_id)
+        span.set_attribute("cad.compliance.profile", req.profile)
+
+        dxf_path = session.original_path
+        if dxf_path is None or not dxf_path.exists():
+            raise HTTPException(400, "No DXF file in session")
+
+        from cad_dxf_agent.core.compliance_rules import check_compliance
+        from cad_dxf_agent.core.dxf_reader import load_dxf
+        from cad_dxf_agent.models.compliance_schema import BUILTIN_PROFILES
+
+        if req.profile not in BUILTIN_PROFILES:
+            raise HTTPException(
+                422,
+                f"Unknown profile: {req.profile}. "
+                f"Available: {', '.join(BUILTIN_PROFILES)}",
+            )
+
+        context = load_dxf(str(dxf_path))
+        report = check_compliance(context, profile=req.profile)
+
+        span.set_attribute("cad.compliance.score", report.score)
+        span.set_attribute("cad.compliance.violations", report.violation_count)
+
+        return {
+            "profile": report.profile_name,
+            "passed": report.passed,
+            "score": report.score,
+            "findings": [f.model_dump() for f in report.findings],
+            "checks_run": report.checks_run,
+            "violation_count": report.violation_count,
+            "warning_count": report.warning_count,
+            "pass_count": report.pass_count,
+            "zone_count": report.zone_count,
+            "entity_count": report.entity_count,
+        }
+
+
+@app.get("/api/compliance-profiles")
+async def list_compliance_profiles():
+    """List available compliance profiles and their descriptions."""
+    from cad_dxf_agent.models.compliance_schema import BUILTIN_PROFILES
+
+    return {
+        name: {
+            "name": p.name,
+            "description": p.description,
+            "enabled_categories": [c.value for c in p.enabled_categories],
+        }
+        for name, p in BUILTIN_PROFILES.items()
+    }
+
+
 @app.get("/api/profiles")
 async def get_profiles():
     """List available comparison profiles (builtins only)."""
@@ -2146,11 +2220,13 @@ def _get_stage_executor():
     """Create a StagePipelineExecutor with all registered handlers."""
     from cad_dxf_agent.llm.stage_executor import StagePipelineExecutor
     from cad_dxf_agent.llm.stage_handlers.analyze_handler import AnalyzeHandler
+    from cad_dxf_agent.llm.stage_handlers.compliance_handler import ComplianceHandler
     from cad_dxf_agent.llm.stage_handlers.detect_zones_handler import DetectZonesHandler
 
     executor = StagePipelineExecutor()
     executor.register("analyze", AnalyzeHandler())
     executor.register("detect_zones", DetectZonesHandler())
+    executor.register("compliance_check", ComplianceHandler())
     return executor
 
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -340,7 +340,10 @@ async def drawing_compliance_check(
                 f"Unknown profile: {req.profile}. Available: {', '.join(BUILTIN_PROFILES)}",
             )
 
-        context = load_dxf(str(dxf_path))
+        # Cache parsed DrawingContext on session for repeated compliance checks
+        if session.context is None:
+            session.context = load_dxf(str(dxf_path))
+        context = session.context
         report = check_compliance(context, profile=req.profile)
 
         span.set_attribute("cad.compliance.score", report.score)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -337,8 +337,7 @@ async def drawing_compliance_check(
         if req.profile not in BUILTIN_PROFILES:
             raise HTTPException(
                 422,
-                f"Unknown profile: {req.profile}. "
-                f"Available: {', '.join(BUILTIN_PROFILES)}",
+                f"Unknown profile: {req.profile}. Available: {', '.join(BUILTIN_PROFILES)}",
             )
 
         context = load_dxf(str(dxf_path))

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -320,8 +320,8 @@ async def drawing_compliance_check(
     with otel_span("api.drawing_compliance") as span:
         try:
             session = session_mgr.get(req.session_id, user["uid"])
-        except (KeyError, PermissionError) as e:
-            raise HTTPException(404, str(e))
+        except (KeyError, PermissionError):
+            raise HTTPException(404, "Session not found or access denied")
 
         span.set_attribute("cad.session_id", req.session_id)
         span.set_attribute("cad.compliance.profile", req.profile)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -220,10 +220,10 @@ async def get_user(request: Request) -> dict:
 
 
 def _build_typed_compare_response(
-    result: "ComparisonResult",  # noqa: F821 — forward ref, imported at call site
-    outputs: "ComparisonOutputs",  # noqa: F821
+    result: ComparisonResult,  # noqa: F821 — forward ref, imported at call site
+    outputs: ComparisonOutputs,  # noqa: F821
     *,
-    audit: "AuditMetadata | None" = None,  # noqa: F821
+    audit: AuditMetadata | None = None,  # noqa: F821
 ) -> dict:
     """Build a PlatformResponse dict for a comparison result.
 
@@ -272,7 +272,7 @@ async def drawing_health_check(
         try:
             session = session_mgr.get(req.session_id, user["uid"])
         except (KeyError, PermissionError) as e:
-            raise HTTPException(404, str(e))
+            raise HTTPException(404, str(e)) from None
 
         span.set_attribute("cad.session_id", req.session_id)
 
@@ -321,7 +321,7 @@ async def drawing_compliance_check(
         try:
             session = session_mgr.get(req.session_id, user["uid"])
         except (KeyError, PermissionError):
-            raise HTTPException(404, "Session not found or access denied")
+            raise HTTPException(404, "Session not found or access denied") from None
 
         span.set_attribute("cad.session_id", req.session_id)
         span.set_attribute("cad.compliance.profile", req.profile)
@@ -1271,7 +1271,8 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
                 # Build structured EditPlan for preview/apply workflow (EPIC-CAD-08)
                 try:
-                    from cad_dxf_agent.llm.plan_builder import EditPlanBuilder, PlanRequest as PlanReq
+                    from cad_dxf_agent.llm.plan_builder import EditPlanBuilder
+                    from cad_dxf_agent.llm.plan_builder import PlanRequest as PlanReq
 
                     plan_req = PlanReq(
                         prompt=body.prompt,
@@ -2265,8 +2266,8 @@ def _enrich_with_objective(
 
 
 def _enrich_with_precision(
-    changeset: "ChangeSet",
-    context: "DrawingContext",
+    changeset: ChangeSet,
+    context: DrawingContext,
     validation: Any,
     client_metadata: dict | None,
 ) -> tuple[list[dict] | None, list[dict] | None]:


### PR DESCRIPTION
## Epic
EPIC-CAD-21: Regulation-aware compliance validation

## Summary
- New `ComplianceHandler` stage handler wrapping `check_compliance()` for the VALIDATE pipeline, with prompt-based profile auto-detection
- `POST /api/drawing-compliance` endpoint — accepts session_id + profile (ada, ibc-2021, residential), returns structured report with findings, code references, and score
- `GET /api/compliance-profiles` endpoint — lists available compliance profiles
- Wired `compliance_check` handler into stage executor and updated VALIDATE+COMPLIANCE pipeline to `[analyze, detect_zones, compliance_check]`

## Test plan
- [x] 18 unit tests for ComplianceHandler (profile detection, summary builder, handler execution, precomputed zones, door violations)
- [x] 16 web tests for endpoints (profiles list, compliance check with all profiles, error cases, response structure)
- [x] 3,566 total tests pass, 0 failures

## Docs
- No new docs — compliance_schema.py and compliance_rules.py already documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)