### PR TITLE
feat: EPIC-CAD-27 session undo/redo + named snapshots

### DIFF
--- a/src/cad_dxf_agent/core/compliance_rules.py
+++ b/src/cad_dxf_agent/core/compliance_rules.py
@@ -32,7 +32,6 @@ from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
 
 logger = logging.getLogger(__name__)
 
-# Type alias for check functions
 _CheckFn = Callable[
     [DrawingContext, ZoneDetectionResult, EntityIndex, ComplianceThresholds],
     list[ComplianceFinding],
@@ -498,7 +497,6 @@ def _check_dead_end_corridors(
 
 # --- Check registry ---
 
-# Check registry: list of (function, category, name) tuples
 _ALL_CHECKS: list[tuple[_CheckFn, ComplianceCategory, str]] = [
     (_check_door_widths, ComplianceCategory.DOOR, "door_widths"),
     (_check_door_count, ComplianceCategory.DOOR, "door_count"),

--- a/src/cad_dxf_agent/core/edit_history.py
+++ b/src/cad_dxf_agent/core/edit_history.py
@@ -114,6 +114,16 @@ class EditHistory:
             return "initial"
         return self._labels[self._cursor]
 
+    @property
+    def labels(self) -> list[str]:
+        """All snapshot labels (read-only copy)."""
+        return list(self._labels)
+
+    @property
+    def cursor(self) -> int:
+        """Current cursor position (-1 = initial state)."""
+        return self._cursor
+
     def get_current_doc(self) -> ezdxf.document.Drawing:
         """Return the document at the current cursor position."""
         if self._cursor < 0:

--- a/src/cad_dxf_agent/core/health_checker.py
+++ b/src/cad_dxf_agent/core/health_checker.py
@@ -297,13 +297,14 @@ def _check_overlapping_entities(
             for handle in handles[:3]:
                 found = index.get_by_handle(handle)
                 if found is not None:
+                    entity = found
                     evidence.append(
                         EvidenceRef(
                             entity_handle=handle,
-                            layer=found.layer,
-                            entity_type=found.entity_type.value,
-                            location=(found.insert_point.x, found.insert_point.y)
-                            if found.insert_point
+                            layer=entity.layer,
+                            entity_type=entity.entity_type.value,
+                            location=(entity.insert_point.x, entity.insert_point.y)
+                            if entity.insert_point
                             else None,
                             description=(
                                 f"Overlaps with {len(handles) - 1} other "

--- a/src/cad_dxf_agent/core/rfi_generator.py
+++ b/src/cad_dxf_agent/core/rfi_generator.py
@@ -317,9 +317,9 @@ def _check_mixed_text_heights(
     for entity in context.entities:
         if entity.entity_type not in (EntityType.TEXT, EntityType.MTEXT):
             continue
-        eff_height = entity.text_geometry.effective_height if entity.text_geometry else None
-        if eff_height is not None and eff_height > 0:
-            height = round(eff_height, 2)
+        height = entity.text_geometry.effective_height if entity.text_geometry else None
+        if height is not None and height > 0:
+            height = round(height, 2)
             layer_heights.setdefault(entity.layer, Counter())[height] += 1
 
     for layer, height_counts in layer_heights.items():

--- a/tests/web/test_edit_history_endpoints.py
+++ b/tests/web/test_edit_history_endpoints.py
@@ -1,0 +1,272 @@
+"""Tests for undo/redo/snapshot/history endpoints (EPIC-CAD-27)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+starlette = pytest.importorskip("starlette", reason="web tests require fastapi/starlette")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from tests.helpers.dxf_factory import create_structural_drawing  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    """Create a test client with dev mode enabled."""
+    import os
+
+    old = os.environ.get("CAD_WEB_DEV_MODE")
+    os.environ["CAD_WEB_DEV_MODE"] = "1"
+    from web.backend.main import app
+
+    with TestClient(app) as c:
+        yield c
+    if old is None:
+        os.environ.pop("CAD_WEB_DEV_MODE", None)
+    else:
+        os.environ["CAD_WEB_DEV_MODE"] = old
+
+
+@pytest.fixture()
+def session_with_dxf(client: TestClient, tmp_path: Path):
+    """Upload a DXF and return the session_id."""
+    dxf_path = create_structural_drawing(tmp_path)
+    with open(dxf_path, "rb") as f:
+        resp = client.post("/api/upload", files={"file": ("test.dxf", f)})
+    assert resp.status_code == 200
+    return resp.json()["session_id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestHistoryEndpoint:
+    def test_history_returns_200(self, client, session_with_dxf):
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        assert resp.status_code == 200
+
+    def test_history_initial_state(self, client, session_with_dxf):
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["current_index"] == -1
+        assert data["can_undo"] is False
+        assert data["can_redo"] is False
+        assert len(data["entries"]) == 1  # Just "initial"
+        assert data["entries"][0]["label"] == "initial"
+
+    def test_history_invalid_session(self, client):
+        resp = client.get("/api/history", params={"session_id": "nonexistent"})
+        assert resp.status_code == 404
+
+    def test_history_depth_zero_at_start(self, client, session_with_dxf):
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        assert resp.json()["depth"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/undo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestUndoEndpoint:
+    def test_undo_at_initial_returns_nothing_to_undo(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/undo",
+            json={"session_id": session_with_dxf},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["undone"] is False
+        assert "nothing to undo" in data["message"].lower()
+
+    def test_undo_invalid_session(self, client):
+        resp = client.post("/api/undo", json={"session_id": "nonexistent"})
+        assert resp.status_code == 404
+
+    def test_undo_has_state_fields(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/undo",
+            json={"session_id": session_with_dxf},
+        )
+        data = resp.json()
+        assert "can_undo" in data
+        assert "can_redo" in data
+        assert "current_label" in data
+        assert "depth" in data
+
+
+# ---------------------------------------------------------------------------
+# POST /api/redo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestRedoEndpoint:
+    def test_redo_at_latest_returns_nothing_to_redo(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/redo",
+            json={"session_id": session_with_dxf},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["redone"] is False
+        assert "nothing to redo" in data["message"].lower()
+
+    def test_redo_invalid_session(self, client):
+        resp = client.post("/api/redo", json={"session_id": "nonexistent"})
+        assert resp.status_code == 404
+
+    def test_redo_has_state_fields(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/redo",
+            json={"session_id": session_with_dxf},
+        )
+        data = resp.json()
+        assert "can_undo" in data
+        assert "can_redo" in data
+        assert "current_label" in data
+        assert "depth" in data
+
+
+# ---------------------------------------------------------------------------
+# POST /api/snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestSnapshotEndpoint:
+    def test_snapshot_creates_entry(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf, "label": "before-walls"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["label"] == "before-walls"
+        assert data["depth"] == 1
+
+    def test_snapshot_default_label(self, client, session_with_dxf):
+        resp = client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf},
+        )
+        data = resp.json()
+        assert "snapshot" in data["label"]
+
+    def test_snapshot_appears_in_history(self, client, session_with_dxf):
+        client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf, "label": "my-save"},
+        )
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["depth"] == 1
+        labels = [e["label"] for e in data["entries"]]
+        assert "my-save" in labels
+
+    def test_snapshot_enables_undo(self, client, session_with_dxf):
+        client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf, "label": "checkpoint"},
+        )
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        assert resp.json()["can_undo"] is True
+
+    def test_snapshot_invalid_session(self, client):
+        resp = client.post(
+            "/api/snapshot",
+            json={"session_id": "nonexistent", "label": "test"},
+        )
+        assert resp.status_code == 404
+
+    def test_multiple_snapshots(self, client, session_with_dxf):
+        for label in ["alpha", "beta", "gamma"]:
+            client.post(
+                "/api/snapshot",
+                json={"session_id": session_with_dxf, "label": label},
+            )
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["depth"] == 3
+        labels = [e["label"] for e in data["entries"]]
+        assert "alpha" in labels
+        assert "beta" in labels
+        assert "gamma" in labels
+
+
+# ---------------------------------------------------------------------------
+# Undo/Redo round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestUndoRedoRoundTrip:
+    def test_snapshot_then_undo_then_redo(self, client, session_with_dxf):
+        # Create a snapshot
+        client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf, "label": "v1"},
+        )
+
+        # Undo should succeed
+        resp = client.post("/api/undo", json={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["undone"] is True
+        assert data["current_label"] == "initial"
+        assert data["can_undo"] is False
+        assert data["can_redo"] is True
+
+        # Redo should succeed
+        resp = client.post("/api/redo", json={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["redone"] is True
+        assert data["current_label"] == "v1"
+        assert data["can_undo"] is True
+        assert data["can_redo"] is False
+
+    def test_undo_redo_preserves_history_depth(self, client, session_with_dxf):
+        for label in ["a", "b", "c"]:
+            client.post(
+                "/api/snapshot",
+                json={"session_id": session_with_dxf, "label": label},
+            )
+
+        # Undo twice
+        client.post("/api/undo", json={"session_id": session_with_dxf})
+        client.post("/api/undo", json={"session_id": session_with_dxf})
+
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        data = resp.json()
+        assert data["current_label"] == "a"
+        assert data["can_undo"] is True
+        assert data["can_redo"] is True
+
+    def test_new_snapshot_after_undo_truncates_redo(self, client, session_with_dxf):
+        for label in ["a", "b", "c"]:
+            client.post(
+                "/api/snapshot",
+                json={"session_id": session_with_dxf, "label": label},
+            )
+
+        # Undo to "b"
+        client.post("/api/undo", json={"session_id": session_with_dxf})
+
+        # Create new snapshot — should truncate "c"
+        client.post(
+            "/api/snapshot",
+            json={"session_id": session_with_dxf, "label": "d"},
+        )
+
+        resp = client.get("/api/history", params={"session_id": session_with_dxf})
+        data = resp.json()
+        labels = [e["label"] for e in data["entries"]]
+        assert "c" not in labels
+        assert "d" in labels
+        assert data["can_redo"] is False

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -783,7 +783,7 @@ async def upload(
         session.edit_history = EditHistory(
             session.working_path, max_snapshots=cad_settings.max_undo_snapshots
         )
-    except Exception as hist_err:
+    except (ImportError, OSError) as hist_err:
         logger.warning("Edit history init failed (non-fatal): %s", hist_err)
 
     # Load and analyze
@@ -1688,8 +1688,7 @@ async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
     doc = history.undo()
     if doc is not None:
         # Save the restored document as the current edited file
-        session_dir = Path("/tmp/cad-sessions") / session.session_id
-        restored_path = session_dir / "edited.dxf"
+        restored_path = session.session_dir / "edited.dxf"
         doc.saveas(str(restored_path))
         session.edited_path = restored_path
 
@@ -1719,8 +1718,7 @@ async def redo(body: UndoRedoRequest, user: dict = Depends(get_user)):
 
     doc = history.redo()
     if doc is not None:
-        session_dir = Path("/tmp/cad-sessions") / session.session_id
-        restored_path = session_dir / "edited.dxf"
+        restored_path = session.session_dir / "edited.dxf"
         doc.saveas(str(restored_path))
         session.edited_path = restored_path
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -778,7 +778,11 @@ async def upload(
     try:
         from cad_dxf_agent.core.edit_history import EditHistory
 
-        session.edit_history = EditHistory(session.working_path, max_snapshots=20)
+        from cad_dxf_agent.settings import settings as cad_settings
+
+        session.edit_history = EditHistory(
+            session.working_path, max_snapshots=cad_settings.max_undo_snapshots
+        )
     except Exception as hist_err:
         logger.warning("Edit history init failed (non-fatal): %s", hist_err)
 
@@ -1646,20 +1650,31 @@ class SnapshotRequest(BaseModel):
     label: str = ""
 
 
-@app.post("/api/undo")
-async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
-    """Undo the last edit operation, restoring the previous DXF state."""
+def _get_session_history(
+    session_id: str, user: dict, *, require: bool = True,
+) -> tuple:
+    """Shared helper: resolve session + edit history, raise on error.
+
+    Returns (session, history). If require=True and no history exists,
+    raises 400. If require=False, history may be None.
+    """
+    from cad_dxf_agent.core.edit_history import EditHistory
+
     try:
-        session = session_mgr.get(body.session_id, user["uid"])
+        session = session_mgr.get(session_id, user["uid"])
     except (KeyError, PermissionError) as e:
         raise HTTPException(status_code=404, detail=str(e)) from None
 
-    if session.edit_history is None:
+    history: EditHistory | None = session.edit_history
+    if require and history is None:
         raise HTTPException(status_code=400, detail="No edit history in session.")
+    return session, history
 
-    from cad_dxf_agent.core.edit_history import EditHistory
 
-    history: EditHistory = session.edit_history
+@app.post("/api/undo")
+async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
+    """Undo the last edit operation, restoring the previous DXF state."""
+    session, history = _get_session_history(body.session_id, user)
     if not history.can_undo:
         return {
             "undone": False,
@@ -1691,17 +1706,7 @@ async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
 @app.post("/api/redo")
 async def redo(body: UndoRedoRequest, user: dict = Depends(get_user)):
     """Redo the previously undone edit operation."""
-    try:
-        session = session_mgr.get(body.session_id, user["uid"])
-    except (KeyError, PermissionError) as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
-
-    if session.edit_history is None:
-        raise HTTPException(status_code=400, detail="No edit history in session.")
-
-    from cad_dxf_agent.core.edit_history import EditHistory
-
-    history: EditHistory = session.edit_history
+    session, history = _get_session_history(body.session_id, user)
     if not history.can_redo:
         return {
             "redone": False,
@@ -1732,17 +1737,7 @@ async def redo(body: UndoRedoRequest, user: dict = Depends(get_user)):
 @app.post("/api/snapshot")
 async def create_snapshot(body: SnapshotRequest, user: dict = Depends(get_user)):
     """Create a named snapshot of the current DXF state."""
-    try:
-        session = session_mgr.get(body.session_id, user["uid"])
-    except (KeyError, PermissionError) as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
-
-    if session.edit_history is None:
-        raise HTTPException(status_code=400, detail="No edit history in session.")
-
-    from cad_dxf_agent.core.edit_history import EditHistory
-
-    history: EditHistory = session.edit_history
+    _session, history = _get_session_history(body.session_id, user)
 
     # Get the current document
     doc = history.get_current_doc()
@@ -1761,12 +1756,9 @@ async def create_snapshot(body: SnapshotRequest, user: dict = Depends(get_user))
 @app.get("/api/history")
 async def get_history(session_id: str = Query(...), user: dict = Depends(get_user)):
     """Get edit history timeline for a session."""
-    try:
-        session = session_mgr.get(session_id, user["uid"])
-    except (KeyError, PermissionError) as e:
-        raise HTTPException(status_code=404, detail=str(e)) from None
+    _session, history = _get_session_history(session_id, user, require=False)
 
-    if session.edit_history is None:
+    if history is None:
         return {
             "entries": [],
             "current_index": -1,
@@ -1774,20 +1766,17 @@ async def get_history(session_id: str = Query(...), user: dict = Depends(get_use
             "can_redo": False,
         }
 
-    from cad_dxf_agent.core.edit_history import EditHistory
-
-    history: EditHistory = session.edit_history
-
     entries = [{"index": -1, "label": "initial"}]
+    labels = history.labels
     for i in range(history.depth):
         entries.append({
             "index": i,
-            "label": history._labels[i],
+            "label": labels[i],
         })
 
     return {
         "entries": entries,
-        "current_index": history._cursor,
+        "current_index": history.cursor,
         "current_label": history.current_label,
         "can_undo": history.can_undo,
         "can_redo": history.can_redo,

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -47,11 +47,12 @@ from pydantic import BaseModel
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
+from cad_dxf_agent.core.edit_history import EditHistory  # noqa: E402
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 
-from .api_v1 import router as v1_router
-from .auth import get_licensed_user
-from .session import SessionManager
+from .api_v1 import router as v1_router  # noqa: E402
+from .auth import get_licensed_user  # noqa: E402
+from .session import Session, SessionManager  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -119,12 +120,18 @@ async def log_requests(request: Request, call_next):
     if response.status_code >= 400:
         logger.warning(
             "%s %s → %d (%.0fms)",
-            request.method, request.url.path, response.status_code, elapsed_ms,
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
         )
     else:
         logger.info(
             "%s %s → %d (%.0fms)",
-            request.method, request.url.path, response.status_code, elapsed_ms,
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
         )
     return response
 
@@ -460,9 +467,9 @@ async def upload_document(
                 "document_count": len(docs),
                 "max_documents": MAX_DOCUMENTS_PER_USER,
                 "max_file_size_bytes": MAX_FILE_SIZE_BYTES,
-                "usage_percent": round(
-                    used_bytes / MAX_TOTAL_STORAGE_BYTES * 100, 2
-                ) if MAX_TOTAL_STORAGE_BYTES else 0.0,
+                "usage_percent": round(used_bytes / MAX_TOTAL_STORAGE_BYTES * 100, 2)
+                if MAX_TOTAL_STORAGE_BYTES
+                else 0.0,
             },
         ) from e
 
@@ -776,14 +783,12 @@ async def upload(
 
     # Initialize edit history for undo/redo (EPIC-CAD-27)
     try:
-        from cad_dxf_agent.core.edit_history import EditHistory
-
         from cad_dxf_agent.settings import settings as cad_settings
 
         session.edit_history = EditHistory(
             session.working_path, max_snapshots=cad_settings.max_undo_snapshots
         )
-    except (ImportError, OSError) as hist_err:
+    except OSError as hist_err:
         logger.warning("Edit history init failed (non-fatal): %s", hist_err)
 
     # Load and analyze
@@ -829,7 +834,8 @@ async def upload(
     else:
         logger.info(
             "Skipping render for large drawing (%d entities > %d limit)",
-            context.entity_count, RENDER_ENTITY_LIMIT,
+            context.entity_count,
+            RENDER_ENTITY_LIMIT,
         )
 
     response: dict = {
@@ -963,7 +969,9 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
         # Pass DrawingContext so family detection runs on real drawing data
         objective_cls = ObjectiveClassifier()
         objective = objective_cls.classify_with_family(
-            body.prompt, intent.family, context=session.context,
+            body.prompt,
+            intent.family,
+            context=session.context,
         )
 
         audit = AuditMetadata(
@@ -980,9 +988,12 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
         registry = CapabilityRegistry()
         if not registry.is_implemented(intent.family):
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-            return _enrich(ResponseBuilder.unsupported_operation(
-                family=intent.family, audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.unsupported_operation(
+                    family=intent.family,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle needs_clarification
         if intent.family == TaskFamily.NEEDS_CLARIFICATION:
@@ -997,7 +1008,9 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             region = _parse_selected_region(body.selected_regions)
             ctx_start = _time.monotonic()
             result = pipeline.answer(
-                prompt=body.prompt, context=session.context, region=region,
+                prompt=body.prompt,
+                context=session.context,
+                region=region,
             )
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
@@ -1008,11 +1021,13 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
         if intent.family == TaskFamily.COMPARE:
             if session.revision_path is None or not session.revision_path.exists():
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return _enrich(ResponseBuilder.needs_clarification(
-                    message="Upload a revision file first to compare drawings.",
-                    family=TaskFamily.COMPARE,
-                    audit=audit,
-                ).model_dump())
+                return _enrich(
+                    ResponseBuilder.needs_clarification(
+                        message="Upload a revision file first to compare drawings.",
+                        family=TaskFamily.COMPARE,
+                        audit=audit,
+                    ).model_dump()
+                )
 
             # Use cached comparison result if available, else run pipeline
             if session.comparison_result is not None and session.comparison_changelog is not None:
@@ -1026,16 +1041,18 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                     revision_path=session.revision_path,
                 )
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return _enrich(_build_typed_compare_response(
-                    session.comparison_result, outputs, audit=audit
-                ))
+                return _enrich(
+                    _build_typed_compare_response(session.comparison_result, outputs, audit=audit)
+                )
 
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-            return _enrich(ResponseBuilder.needs_clarification(
-                message="Use /api/compare for full comparison workflow.",
-                family=TaskFamily.COMPARE,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.needs_clarification(
+                    message="Use /api/compare for full comparison workflow.",
+                    family=TaskFamily.COMPARE,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle markup_interpretation — deterministic redline report, no LLM
         if intent.family == TaskFamily.MARKUP_INTERPRETATION:
@@ -1046,27 +1063,35 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return _enrich(ResponseBuilder.markup_redline(
-                message=(
-                    f"{result.total_clouds} revision cloud(s) found, "
-                    f"{result.total_affected_entities} affected entity(ies)."
-                ),
-                data=result.model_dump(),
-                confidence=result.aggregate_confidence,
-                ambiguity_flags=result.ambiguity_flags,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.markup_redline(
+                    message=(
+                        f"{result.total_clouds} revision cloud(s) found, "
+                        f"{result.total_affected_entities} affected entity(ies)."
+                    ),
+                    data=result.model_dump(),
+                    confidence=result.aggregate_confidence,
+                    ambiguity_flags=result.ambiguity_flags,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle repeated_condition — deterministic, no LLM
         if intent.family == TaskFamily.REPEATED_CONDITION:
             from cad_dxf_agent.core.repeated_condition import ConditionDetector
 
-            exemplar_handles = body.selected_regions[0].get("handles", []) if body.selected_regions else []
+            exemplar_handles = (
+                body.selected_regions[0].get("handles", []) if body.selected_regions else []
+            )
             prompt_lower = body.prompt.lower()
             is_batch = not exemplar_handles and any(
-                kw in prompt_lower for kw in (
-                    "batch", "all conditions", "condition report",
-                    "condition plan", "find all patterns",
+                kw in prompt_lower
+                for kw in (
+                    "batch",
+                    "all conditions",
+                    "condition report",
+                    "condition plan",
+                    "find all patterns",
                 )
             )
 
@@ -1078,24 +1103,28 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-                return _enrich(ResponseBuilder.repeated_condition(
-                    message=(
-                        f"{result.total_groups} condition group(s), "
-                        f"{result.total_instances} total instance(s)."
-                    ),
-                    data=result.model_dump(),
-                    confidence=result.aggregate_confidence,
-                    ambiguity_flags=result.ambiguity_flags,
-                    audit=audit,
-                ).model_dump())
+                return _enrich(
+                    ResponseBuilder.repeated_condition(
+                        message=(
+                            f"{result.total_groups} condition group(s), "
+                            f"{result.total_instances} total instance(s)."
+                        ),
+                        data=result.model_dump(),
+                        confidence=result.aggregate_confidence,
+                        ambiguity_flags=result.ambiguity_flags,
+                        audit=audit,
+                    ).model_dump()
+                )
 
             if not exemplar_handles:
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-                return _enrich(ResponseBuilder.needs_clarification(
-                    message="Select entities to use as the exemplar for repeated-condition search.",
-                    family=TaskFamily.REPEATED_CONDITION,
-                    audit=audit,
-                ).model_dump())
+                return _enrich(
+                    ResponseBuilder.needs_clarification(
+                        message="Select entities to use as the exemplar for repeated-condition search.",
+                        family=TaskFamily.REPEATED_CONDITION,
+                        audit=audit,
+                    ).model_dump()
+                )
 
             ctx_start = _time.monotonic()
             detector = ConditionDetector(session.context)
@@ -1103,14 +1132,16 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return _enrich(ResponseBuilder.repeated_condition(
-                message=result.summary,
-                data=result.model_dump(),
-                evidence=[ev.model_dump() for c in result.candidates for ev in c.evidence[:3]],
-                confidence=result.candidates[0].confidence if result.candidates else 0.0,
-                ambiguity_flags=result.ambiguity_flags,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.repeated_condition(
+                    message=result.summary,
+                    data=result.model_dump(),
+                    evidence=[ev.model_dump() for c in result.candidates for ev in c.evidence[:3]],
+                    confidence=result.candidates[0].confidence if result.candidates else 0.0,
+                    ambiguity_flags=result.ambiguity_flags,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle design_assist — deterministic layout analysis, no LLM
         if intent.family == TaskFamily.DESIGN_ASSIST:
@@ -1127,9 +1158,12 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
             # Field summary sub-dispatch
             is_field = any(
-                kw in prompt_lower for kw in (
-                    "field summary", "field report",
-                    "construction summary", "site report",
+                kw in prompt_lower
+                for kw in (
+                    "field summary",
+                    "field report",
+                    "construction summary",
+                    "site report",
                 )
             )
             if is_field:
@@ -1149,8 +1183,12 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
             # Grid summary sub-dispatch
             elif any(
-                kw in prompt_lower for kw in (
-                    "grid", "bay", "column grid", "structural grid",
+                kw in prompt_lower
+                for kw in (
+                    "grid",
+                    "bay",
+                    "column grid",
+                    "structural grid",
                 )
             ):
                 from cad_dxf_agent.core.construction_ops import GridAnalyzer
@@ -1182,12 +1220,13 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 flags = result.ambiguity_flags
             else:
                 result = LayoutRecommender().recommend(
-                    session.context, body.prompt, region,
+                    session.context,
+                    body.prompt,
+                    region,
                 )
                 data = result.model_dump()
                 message = (
-                    f"{result.total_recommendations} recommendation(s). "
-                    f"{result.drawing_summary}"
+                    f"{result.total_recommendations} recommendation(s). {result.drawing_summary}"
                 )
                 confidence = result.aggregate_confidence
                 flags = result.ambiguity_flags
@@ -1195,13 +1234,15 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return _enrich(ResponseBuilder.design_assist(
-                message=message,
-                data=data,
-                confidence=confidence,
-                ambiguity_flags=flags,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.design_assist(
+                    message=message,
+                    data=data,
+                    confidence=confidence,
+                    ambiguity_flags=flags,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle summary — deterministic revision summary, no LLM
         if intent.family == TaskFamily.SUMMARY:
@@ -1216,15 +1257,18 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-            return _enrich(ResponseBuilder.summary_result(
-                message=result.headline,
-                data=result.model_dump(),
-                confidence=min(
-                    (e.confidence for e in result.key_changes), default=0.5,
-                ),
-                ambiguity_flags=result.ambiguity_flags,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.summary_result(
+                    message=result.headline,
+                    data=result.model_dump(),
+                    confidence=min(
+                        (e.confidence for e in result.key_changes),
+                        default=0.5,
+                    ),
+                    ambiguity_flags=result.ambiguity_flags,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle takeoff_estimate — deterministic counting, no LLM
         if intent.family == TaskFamily.TAKEOFF_ESTIMATE:
@@ -1238,7 +1282,9 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 region = RegionContextBuilder().build(session.context, parsed_region)
 
             result = TakeoffGenerator().generate(
-                session.context, body.prompt, region,
+                session.context,
+                body.prompt,
+                region,
             )
             audit.context_build_time_ms = (_time.monotonic() - ctx_start) * 1000
             audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
@@ -1249,16 +1295,18 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 "low": 0.4,
                 "estimate_only": 0.2,
             }
-            return _enrich(ResponseBuilder.takeoff_result(
-                message=(
-                    f"{result.total_items} takeoff item(s), "
-                    f"{result.total_quantity_items} total quantity."
-                ),
-                data=result.model_dump(),
-                confidence=_conf_labels.get(result.aggregate_confidence.value, 0.5),
-                ambiguity_flags=result.ambiguity_flags,
-                audit=audit,
-            ).model_dump())
+            return _enrich(
+                ResponseBuilder.takeoff_result(
+                    message=(
+                        f"{result.total_items} takeoff item(s), "
+                        f"{result.total_quantity_items} total quantity."
+                    ),
+                    data=result.model_dump(),
+                    confidence=_conf_labels.get(result.aggregate_confidence.value, 0.5),
+                    ambiguity_flags=result.ambiguity_flags,
+                    audit=audit,
+                ).model_dump()
+            )
 
         # Handle edit_plan — dispatch to existing planner
         if intent.family == TaskFamily.EDIT_PLAN:
@@ -1294,10 +1342,9 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                         drawing_context=session.context,
                         request_id=getattr(body, "request_id", ""),
                         target_handles=[
-                            op.target_handle
-                            for op in changeset.operations
-                            if op.target_handle
-                        ] or None,
+                            op.target_handle for op in changeset.operations if op.target_handle
+                        ]
+                        or None,
                     )
                     edit_plan = EditPlanBuilder().build(plan_req)
                     session.edit_plan = edit_plan
@@ -1340,38 +1387,45 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
                 precision_action_details = None
                 try:
                     precision_candidates, precision_action_details = _enrich_with_precision(
-                        changeset, session.context, validation, body.client_metadata,
+                        changeset,
+                        session.context,
+                        validation,
+                        body.client_metadata,
                     )
                     if precision_action_details is not None:
                         # Re-serialize operations from potentially modified changeset
                         operations = []
                         for op in changeset.operations:
-                            operations.append({
-                                "op_type": op.op_type.value
-                                if hasattr(op.op_type, "value")
-                                else str(op.op_type),
-                                "target_handle": op.target_handle,
-                                "target_layer": op.target_layer,
-                                "description": _describe_op(op),
-                                "params": op.params,
-                            })
+                            operations.append(
+                                {
+                                    "op_type": op.op_type.value
+                                    if hasattr(op.op_type, "value")
+                                    else str(op.op_type),
+                                    "target_handle": op.target_handle,
+                                    "target_layer": op.target_layer,
+                                    "description": _describe_op(op),
+                                    "params": op.params,
+                                }
+                            )
                 except (ValueError, KeyError, TypeError) as prec_err:
                     logger.warning("Precision enrichment failed (non-fatal): %s", prec_err)
 
                 audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
 
-                return _enrich(ResponseBuilder.plan_only(
-                    operations=operations,
-                    message=llm_message or summary,
-                    validation={
-                        "blockers": [{"message": b.message} for b in validation.blockers],
-                        "warnings": [{"message": w.message} for w in validation.warnings],
-                        "is_valid": len(validation.blockers) == 0,
-                    },
-                    audit=audit,
-                    ambiguity_candidates=precision_candidates,
-                    precision_actions=precision_action_details,
-                ).model_dump())
+                return _enrich(
+                    ResponseBuilder.plan_only(
+                        operations=operations,
+                        message=llm_message or summary,
+                        validation={
+                            "blockers": [{"message": b.message} for b in validation.blockers],
+                            "warnings": [{"message": w.message} for w in validation.warnings],
+                            "is_valid": len(validation.blockers) == 0,
+                        },
+                        audit=audit,
+                        ambiguity_candidates=precision_candidates,
+                        precision_actions=precision_action_details,
+                    ).model_dump()
+                )
 
             except Exception as e:
                 logger.error("v2 plan failed: %s", e, exc_info=True)
@@ -1379,9 +1433,12 @@ async def v2_prompt(body: PromptRequest, user: dict = Depends(get_user)):
 
         # Catch-all for families that are "implemented" but not yet wired
         audit.total_request_time_ms = (_time.monotonic() - total_start) * 1000
-        return _enrich(ResponseBuilder.unsupported_operation(
-            family=intent.family, audit=audit,
-        ).model_dump())
+        return _enrich(
+            ResponseBuilder.unsupported_operation(
+                family=intent.family,
+                audit=audit,
+            ).model_dump()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1651,15 +1708,16 @@ class SnapshotRequest(BaseModel):
 
 
 def _get_session_history(
-    session_id: str, user: dict, *, require: bool = True,
-) -> tuple:
+    session_id: str,
+    user: dict,
+    *,
+    require: bool = True,
+) -> tuple[Session, EditHistory | None]:
     """Shared helper: resolve session + edit history, raise on error.
 
     Returns (session, history). If require=True and no history exists,
     raises 400. If require=False, history may be None.
     """
-    from cad_dxf_agent.core.edit_history import EditHistory
-
     try:
         session = session_mgr.get(session_id, user["uid"])
     except (KeyError, PermissionError) as e:
@@ -1669,6 +1727,16 @@ def _get_session_history(
     if require and history is None:
         raise HTTPException(status_code=400, detail="No edit history in session.")
     return session, history
+
+
+def _save_restored_dxf(session: Session, doc: object) -> None:
+    """Save a restored ezdxf document as the current edited file.
+
+    Called after undo/redo to persist the restored state to disk.
+    """
+    restored_path = session.session_dir / "edited.dxf"
+    doc.saveas(str(restored_path))  # type: ignore[union-attr]
+    session.edited_path = restored_path
 
 
 @app.post("/api/undo")
@@ -1687,10 +1755,7 @@ async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
 
     doc = history.undo()
     if doc is not None:
-        # Save the restored document as the current edited file
-        restored_path = session.session_dir / "edited.dxf"
-        doc.saveas(str(restored_path))
-        session.edited_path = restored_path
+        _save_restored_dxf(session, doc)
 
     return {
         "undone": True,
@@ -1718,9 +1783,7 @@ async def redo(body: UndoRedoRequest, user: dict = Depends(get_user)):
 
     doc = history.redo()
     if doc is not None:
-        restored_path = session.session_dir / "edited.dxf"
-        doc.saveas(str(restored_path))
-        session.edited_path = restored_path
+        _save_restored_dxf(session, doc)
 
     return {
         "redone": True,
@@ -1767,10 +1830,12 @@ async def get_history(session_id: str = Query(...), user: dict = Depends(get_use
     entries = [{"index": -1, "label": "initial"}]
     labels = history.labels
     for i in range(history.depth):
-        entries.append({
-            "index": i,
-            "label": labels[i],
-        })
+        entries.append(
+            {
+                "index": i,
+                "label": labels[i],
+            }
+        )
 
     return {
         "entries": entries,

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -774,6 +774,14 @@ async def upload(
     session.working_path = session_dir / "working.dxf"
     shutil.copy2(str(dxf_path), str(session.working_path))
 
+    # Initialize edit history for undo/redo (EPIC-CAD-27)
+    try:
+        from cad_dxf_agent.core.edit_history import EditHistory
+
+        session.edit_history = EditHistory(session.working_path, max_snapshots=20)
+    except Exception as hist_err:
+        logger.warning("Edit history init failed (non-fatal): %s", hist_err)
+
     # Load and analyze
     try:
         from cad_dxf_agent.core.dxf_reader import load_dxf
@@ -1492,6 +1500,17 @@ async def v2_apply(body: V2ApplyRequest, user: dict = Depends(get_user)):
     if result.output_path:
         session.edited_path = Path(result.output_path)
 
+    # Push edit snapshot for undo/redo (EPIC-CAD-27)
+    if result.output_path and session.edit_history is not None:
+        try:
+            import ezdxf
+
+            doc = ezdxf.readfile(str(result.output_path))
+            label = session.edit_plan.summary if hasattr(session.edit_plan, "summary") else "edit"
+            session.edit_history.push(doc, label=label)
+        except Exception as hist_err:
+            logger.warning("Edit history push failed (non-fatal): %s", hist_err)
+
     # Render edited preview
     try:
         from cad_dxf_agent.core.renderer import render_dxf_to_png
@@ -1562,6 +1581,14 @@ async def apply_changes(body: ApplyRequest, user: dict = Depends(get_user)):
         session.edited_path = session_dir / "edited.dxf"
         engine.save(session.edited_path)
 
+        # Push edit snapshot for undo/redo (EPIC-CAD-27)
+        if session.edit_history is not None:
+            try:
+                label = changeset.prompt or "edit"
+                session.edit_history.push(engine.doc, label=label)
+            except Exception as hist_err:
+                logger.warning("Edit history push failed (non-fatal): %s", hist_err)
+
         # Render edited preview
         try:
             from cad_dxf_agent.core.renderer import render_dxf_to_png
@@ -1603,6 +1630,169 @@ async def clear_history(body: ClearHistoryRequest, user: dict = Depends(get_user
     session.conversation_history = []
     session.changeset = None
     return {"message": "Conversation cleared."}
+
+
+# ---------------------------------------------------------------------------
+# Edit History endpoints — undo/redo/snapshot (EPIC-CAD-27)
+# ---------------------------------------------------------------------------
+
+
+class UndoRedoRequest(BaseModel):
+    session_id: str
+
+
+class SnapshotRequest(BaseModel):
+    session_id: str
+    label: str = ""
+
+
+@app.post("/api/undo")
+async def undo(body: UndoRedoRequest, user: dict = Depends(get_user)):
+    """Undo the last edit operation, restoring the previous DXF state."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_history is None:
+        raise HTTPException(status_code=400, detail="No edit history in session.")
+
+    from cad_dxf_agent.core.edit_history import EditHistory
+
+    history: EditHistory = session.edit_history
+    if not history.can_undo:
+        return {
+            "undone": False,
+            "message": "Already at initial state — nothing to undo.",
+            "can_undo": False,
+            "can_redo": history.can_redo,
+            "current_label": history.current_label,
+            "depth": history.depth,
+        }
+
+    doc = history.undo()
+    if doc is not None:
+        # Save the restored document as the current edited file
+        session_dir = Path("/tmp/cad-sessions") / session.session_id
+        restored_path = session_dir / "edited.dxf"
+        doc.saveas(str(restored_path))
+        session.edited_path = restored_path
+
+    return {
+        "undone": True,
+        "message": f"Undone. Now at: {history.current_label}",
+        "can_undo": history.can_undo,
+        "can_redo": history.can_redo,
+        "current_label": history.current_label,
+        "depth": history.depth,
+    }
+
+
+@app.post("/api/redo")
+async def redo(body: UndoRedoRequest, user: dict = Depends(get_user)):
+    """Redo the previously undone edit operation."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_history is None:
+        raise HTTPException(status_code=400, detail="No edit history in session.")
+
+    from cad_dxf_agent.core.edit_history import EditHistory
+
+    history: EditHistory = session.edit_history
+    if not history.can_redo:
+        return {
+            "redone": False,
+            "message": "Already at latest state — nothing to redo.",
+            "can_undo": history.can_undo,
+            "can_redo": False,
+            "current_label": history.current_label,
+            "depth": history.depth,
+        }
+
+    doc = history.redo()
+    if doc is not None:
+        session_dir = Path("/tmp/cad-sessions") / session.session_id
+        restored_path = session_dir / "edited.dxf"
+        doc.saveas(str(restored_path))
+        session.edited_path = restored_path
+
+    return {
+        "redone": True,
+        "message": f"Redone. Now at: {history.current_label}",
+        "can_undo": history.can_undo,
+        "can_redo": history.can_redo,
+        "current_label": history.current_label,
+        "depth": history.depth,
+    }
+
+
+@app.post("/api/snapshot")
+async def create_snapshot(body: SnapshotRequest, user: dict = Depends(get_user)):
+    """Create a named snapshot of the current DXF state."""
+    try:
+        session = session_mgr.get(body.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_history is None:
+        raise HTTPException(status_code=400, detail="No edit history in session.")
+
+    from cad_dxf_agent.core.edit_history import EditHistory
+
+    history: EditHistory = session.edit_history
+
+    # Get the current document
+    doc = history.get_current_doc()
+    label = body.label or f"snapshot-{history.depth + 1}"
+    history.push(doc, label=label)
+
+    return {
+        "message": f"Snapshot created: {label}",
+        "label": label,
+        "depth": history.depth,
+        "can_undo": history.can_undo,
+        "can_redo": history.can_redo,
+    }
+
+
+@app.get("/api/history")
+async def get_history(session_id: str = Query(...), user: dict = Depends(get_user)):
+    """Get edit history timeline for a session."""
+    try:
+        session = session_mgr.get(session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+    if session.edit_history is None:
+        return {
+            "entries": [],
+            "current_index": -1,
+            "can_undo": False,
+            "can_redo": False,
+        }
+
+    from cad_dxf_agent.core.edit_history import EditHistory
+
+    history: EditHistory = session.edit_history
+
+    entries = [{"index": -1, "label": "initial"}]
+    for i in range(history.depth):
+        entries.append({
+            "index": i,
+            "label": history._labels[i],
+        })
+
+    return {
+        "entries": entries,
+        "current_index": history._cursor,
+        "current_label": history.current_label,
+        "can_undo": history.can_undo,
+        "can_redo": history.can_redo,
+        "depth": history.depth,
+    }
 
 
 @app.post("/api/compare")

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -69,6 +69,11 @@ class Session:
     # EPIC-CAD-15: Document library binding
     document_id: str = ""
 
+    @property
+    def session_dir(self) -> Path:
+        """Directory for this session's files."""
+        return DEFAULT_SESSION_DIR / self.session_id
+
     def to_metadata(self) -> SessionMetadata:
         """Extract durable metadata from this runtime session."""
         return SessionMetadata(

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -64,6 +64,8 @@ class Session:
     edit_approval: object | None = None
     edit_apply_result: object | None = None
     audit_events: list = field(default_factory=list)
+    # EPIC-CAD-27: Edit history for undo/redo + named snapshots
+    edit_history: object | None = None  # EditHistory instance (transient)
     # EPIC-CAD-15: Document library binding
     document_id: str = ""
 


### PR DESCRIPTION
## Epic
EPIC-CAD-27: Session undo/redo + named snapshots

## Summary
- Wires existing `EditHistory` engine into web session lifecycle with auto-snapshot on apply
- 4 new endpoints: `POST /api/undo`, `POST /api/redo`, `POST /api/snapshot`, `GET /api/history`
- `Session.edit_history` field tracks transient undo/redo state per session
- Full navigation state returned from every endpoint for frontend timeline rendering

## Test plan
- [x] 19 web tests covering: initial state, undo/redo boundaries, snapshot creation, round-trip navigation, redo truncation on new snapshot
- [x] All 3,551+ tests pass, 0 failures

## Docs
- No new docs — `EditHistory` already documented in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)