### PR TITLE
feat: EPIC-CAD-30 user accounts, workspaces & persistent work progress

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -79,6 +79,7 @@ jobs:
             CAD_LLM_PROVIDER=gemini
             CAD_GCP_PROJECT=${{ env.GCP_PROJECT }}
             CAD_WEB_CORS_ORIGIN=https://cad-dxf-agent.web.app
+            CAD_ALLOWED_EMAILS=michaelmcquaig@gmail.com,scott@heyflora.ai
             OTEL_ENABLED=1
             OTEL_EXPORTER=gcp-trace
           flags: |

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ test-results/
 # Mutation testing cache
 mutants/
 .mutmut-cache/
+
+# Large test fixtures (not for version control)
+000-docs/*.pdf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-Local-first DXF layout editor that uses LLM-assisted planning to edit 2D CAD drawings via natural-language prompts. The LLM returns structured JSON operations (never raw DXF) which are validated and applied deterministically. Original files are never modified (save-as workflow).
+Drawing Intelligence Platform built on DXF. Started as a local-first DXF layout editor with LLM-assisted planning; now a multi-capability platform that handles edits, compliance checks, quantity takeoffs, health reports, drawing summaries, RFI generation, and zone detection — all via natural-language prompts. The LLM returns structured JSON operations (never raw DXF) which are validated and applied deterministically. Original files are never modified (save-as workflow).
 
 ## Commands
 
@@ -27,6 +27,10 @@ make security      # bandit -r src/ -ll && pip-audit
 # Run single test
 pytest tests/unit/test_validators.py -v
 pytest tests/unit/test_validators.py::test_name -v
+
+# Eval scorecard (intent classification accuracy)
+make scorecard          # mock mode
+make scorecard-live     # real Gemini
 
 # Launch desktop app (requires PySide6: pip install -e ".[gui]")
 make run           # python -m cad_dxf_agent.app
@@ -89,55 +93,144 @@ CAD_GCP_PROJECT=cad-dxf-agent pytest tests/live/ -v -m live_api -s
 
 ## Architecture
 
-### Pipeline Flow
+### Request Flow (v0.8.0)
 
 ```
-User Prompt → Planner → ChangeSet → Validator → Preview → EditEngine → Save-As DXF
-                                                                    ↘ RevisionNotes
+User Prompt
+  → ObjectiveClassifier (2-axis: RequestClass × ObjectiveTag)
+  → StrategyRegistry (maps classification → StagePipelineDefinition)
+  → StageExecutor (runs ordered stages: deterministic + LLM)
+  → ResponseBuilder (PlatformResponse envelope)
 ```
+
+For **edit requests**, the stage pipeline includes the original edit flow:
+
+```
+Planner → ChangeSet → Validator → Preview → EditEngine → Save-As DXF
+                                                       ↘ RevisionNotes
+```
+
+For **analysis requests** (compliance, health, takeoff, summary, RFI), the pipeline runs deterministic extractors without the edit flow.
+
+### Two-Axis Intent Classification
+
+Every prompt is classified on two independent axes:
+
+1. **RequestClass** — *what* the user wants done: `edit`, `analyze`, `compare`, `query`, `generate`
+2. **ObjectiveTag** — *why* they want it: `compliance`, `coordination`, `documentation`, `estimation`, `quality`, `general`
+
+The `StrategyRegistry` maps each (RequestClass, ObjectiveTag) pair to a `StagePipelineDefinition` — an ordered list of `StageHandler` implementations. This replaces the original one-shot planner model with composable multi-stage pipelines.
+
+### Agent-Mode (Tool-Use Loop)
+
+For complex requests, the `AgentProvider` (`llm/agent_provider.py`) runs an iterative tool-use loop:
+
+1. Sends prompt + drawing context + tool definitions to Gemini
+2. Gemini returns tool calls (query tools: list entities, find by layer; edit tools: move, delete, add)
+3. `ToolExecutor` (`llm/tool_executor.py`) dispatches each call, enforcing protected-layer rules at the executor level
+4. Results feed back to Gemini for next iteration (max 10 turns)
+5. Final ChangeSet extracted from accumulated tool calls
+
+Tool definitions in `llm/tool_definitions.py` — 20+ tools split into query (read-only) and edit (state-changing) categories.
+
+### Core Pipeline Steps
 
 1. **dxf_reader** loads DXF via `ezdxf` into a `DrawingContext` (Pydantic model with `EntityRef` list)
-2. **semantic_model** builds a JSON-serializable context summary for the planner (no raw DXF exposed)
-3. **planner** routes to a `PlannerProvider` (Gemini in prod/dev, mock in CI) which returns a `ChangeSet`
-4. **validators** check every operation against `RuleConfig` — protected layers block edits, move distances warn
-5. **preview_model** generates human-readable descriptions of proposed changes
-6. **edit_engine** applies validated ops to a working copy of the DXF via `ezdxf`
-7. **revision_notes** inserts deterministic (never LLM-generated) notes on the `AI_REV_NOTES` layer
+2. **semantic_model** builds a JSON-serializable context summary; `build_enriched_context()` adds family detection, primitive extraction, and zone data
+3. **objective_classifier** classifies prompt intent on 2 axes → `ObjectiveClassification`
+4. **strategy_registry** selects a `StagePipelineDefinition` for the classification
+5. **stage_executor** runs each stage handler in order, with `StageGate` checkpoints between stages
+6. For edit pipelines: **validators** check ops against `RuleConfig`, **edit_engine** applies to working copy, **revision_notes** adds deterministic notes
+7. **response_builder** wraps outputs in `PlatformResponse` envelope (includes `TaskFamily`, `ResponseType`, `RiskLevel`, `AuditMetadata`)
 8. **dxf_writer** saves to a new file path (original untouched)
 
 ### Key Architectural Rules
 
-- **LLM never touches DXF directly** (see `000-docs/005-AT-ADEC-llm-plans-not-dxf.md`). It returns structured `EditOperation` objects with `OpType` enum: `move_entity`, `edit_text`, `delete_entity`, `add_block`. Invalid/unsupported ops reject the entire changeset.
-- **Protected layers** (TITLE, TITLEBLOCK, SEAL, REVISION) cannot be edited. The validator blocks any operation targeting entities on these layers.
+- **LLM never touches DXF directly** (see `000-docs/005-AT-ADEC-llm-plans-not-dxf.md`). It returns structured `EditOperation` objects with `OpType` enum: `move_entity`, `edit_text`, `delete_entity`, `add_block`, `rotate_entity`, `copy_entity`, `scale_entity`, `mirror_entity`, `add_line`, `add_polyline`, `add_circle`, `add_arc`, `add_text`. Invalid/unsupported ops reject the entire changeset.
+- **Protected layers** (TITLE, TITLEBLOCK, SEAL, REVISION) cannot be edited. Enforced at both validator and ToolExecutor levels.
 - **Revision notes are deterministic** — generated from operation metadata, never from freeform LLM output.
-- **V1 entity types**: LINE, LWPOLYLINE, TEXT, MTEXT, INSERT only. All other types are skipped during load.
+- **Supported entity types**: LINE, LWPOLYLINE, TEXT, MTEXT, INSERT, CIRCLE, ARC. Other types are skipped during load.
+- **Response contracts** — every API response wraps in `PlatformResponse` with `TaskFamily` (11 categories), `ResponseType` (7 kinds), and `AuditMetadata` for traceability.
 
 ### Source Layout
 
 ```
 src/cad_dxf_agent/
-  models/         # Pydantic schemas: cad_schema, ops_schema, config_schema, changes_schema
-  core/           # DXF I/O, validation, editing, preview, revision notes, entity index
-    comparison/   # Revision diff engine: alignment, matching, changelog, bundle, overlay
-  llm/            # Planner orchestrator, provider ABC, mock/gemini providers, prompt templates
-  cli/            # Revision CLI (cad-revision diff/align/apply/bundle/explain)
-  ui/             # PySide6 desktop shell (MainWindow)
-  settings.py     # Env-based config (all CAD_* prefixed)
-  app.py          # Desktop entry point
+  models/              # 27 Pydantic schemas
+    cad_schema         #   DrawingContext, EntityRef, LayerInfo, BlockInfo
+    ops_schema         #   EditOperation, OpType enum, ChangeSet
+    objective_schema   #   RequestClass, ObjectiveTag, ObjectiveClassification
+    response_schema    #   PlatformResponse, TaskFamily, ResponseType, RiskLevel
+    compliance_schema  #   ComplianceProfile, ComplianceFinding
+    takeoff_schema     #   TakeoffResult, quantity extraction models
+    health_schema      #   HealthReport, quality metrics
+    zone_schema        #   Zone, room/area detection models
+    document_schema    #   UserDocument metadata for persistence
+    config_schema      #   RuleConfig, ValidationResult
+    ...                #   + comparison, region, qna, precision, rfi, stats, etc.
+
+  core/                # 41 modules — DXF I/O, validation, editing, platform services
+    dxf_reader         #   Load DXF → DrawingContext
+    dxf_writer         #   Save working copy to new path
+    edit_engine        #   Apply validated ops to DXF
+    entity_index       #   R-tree spatial index (nearest, find_in_radius)
+    semantic_model     #   Drawing context → planner-ready summary
+    validators         #   RuleConfig enforcement (blockers + warnings)
+    preview_builder    #   Human-readable change descriptions
+    revision_notes     #   Deterministic notes on AI_REV_NOTES layer
+    family_detector    #   20 architectural families, 150+ signal patterns
+    primitive_extractors  # Symbol detection, label extraction, layer classification
+    zone_detector      #   Closed-loop room/zone detection, area calc
+    compliance_rules   #   Deterministic ADA/IBC/custom compliance checker
+    takeoff_engine     #   Automated quantity extraction
+    health_checker     #   Drawing quality metrics
+    drawing_summarizer #   Structured narrative summaries
+    rfi_generator      #   Request For Information generation
+    session_store      #   ABC + InMemory + GCS (2h TTL ephemeral sessions)
+    document_store     #   ABC + InMemory + GCS (persistent user documents)
+    edit_history       #   Undo/redo + named snapshots
+    comparison/        #   Revision diff engine (alignment, matching, changelog, bundle, overlay)
+
+  llm/                 # 22 modules — intent classification, planning, agent loop
+    planner            #   Orchestrator: prompt → ChangeSet
+    providers          #   PlannerProvider ABC
+    gemini_provider    #   Vertex AI tool-use with vision
+    mock_provider      #   Keyword-matching (CI/tests only)
+    agent_provider     #   Iterative tool-use loop (max 10 turns)
+    tool_executor      #   Dispatches 20+ tools with safety enforcement
+    tool_definitions   #   Query + edit tool schemas for Gemini function calling
+    objective_classifier  # 2-axis intent classification
+    strategy_registry  #   (RequestClass, ObjectiveTag) → StagePipelineDefinition
+    stage_executor     #   Runs ordered stage handlers with gate checkpoints
+    stage_handlers/    #   analyze, summarize, compliance, health, detect_zones
+    response_builder   #   Builds PlatformResponse envelopes
+    intent_router      #   Routes prompts to intent families
+    capability_registry   # Declares tool capabilities per RequestClass
+    prompt_templates   #   System prompts + AGENT_SYSTEM_PROMPT
+
+  cli/                 # Revision CLI (cad-revision diff/align/apply/bundle/explain)
+  ui/                  # PySide6 desktop shell (MainWindow, pipeline_worker)
+  settings.py          # Env-based config (all CAD_* prefixed)
+  app.py               # Desktop entry point
+  otel.py              # OpenTelemetry bootstrap
+
+web/
+  backend/             # FastAPI on Cloud Run
+    main.py            #   App + 20+ endpoints (upload, plan, apply, compare, documents)
+    api_v1.py          #   /api/v1 router
+    session.py         #   SessionManager for ephemeral work
+    auth.py            #   Firebase auth validation
+  frontend/            # React + Vite SPA on Firebase Hosting
 ```
-
-### Data Models (Pydantic)
-
-- `DrawingContext` — normalized view of a loaded DXF (entities, layers, blocks, metadata)
-- `EntityRef` — single entity with handle, type, layer, position, text content, block name, attributes
-- `EditOperation` — one op with `OpType`, target handle, layer, params dict
-- `ChangeSet` — batch of operations from a single prompt
-- `ValidationResult` — blockers (prevent apply) and warnings (informational)
-- `RuleConfig` — protected layers, max move distance, coordinate tolerance
 
 ### Provider Pattern
 
-`PlannerProvider` ABC in `llm/providers.py` → implement `plan(prompt, drawing_context) → ChangeSet`. Two providers: `GeminiProvider` (Vertex AI tool-use with vision, used in dev and prod) and `MockProvider` (keyword-matching, CI/tests only). Set via `CAD_LLM_PROVIDER=gemini|mock`.
+`PlannerProvider` ABC in `llm/providers.py` → implement `plan(prompt, drawing_context) → ChangeSet`. Three providers:
+- `GeminiProvider` — Vertex AI tool-use with vision (dev and prod)
+- `AgentProvider` — iterative tool-use loop for complex multi-step requests
+- `MockProvider` — keyword-matching (CI/tests only)
+
+Set via `CAD_LLM_PROVIDER=gemini|mock`.
 
 ## Configuration
 
@@ -146,9 +239,12 @@ All settings via environment variables (`.env` file, `.gitignore`d):
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `CAD_LLM_PROVIDER` | `mock` | Planner backend (`gemini` for dev/prod, `mock` for CI only) |
+| `CAD_GCP_PROJECT` | _(unset)_ | GCP project for Vertex AI (`cad-dxf-agent`) |
 | `CAD_PROTECTED_LAYERS` | `TITLE,TITLEBLOCK,SEAL,REVISION` | Comma-separated protected layers |
 | `CAD_REVISION_NOTES_ENABLED` | `true` | Insert revision notes after edits |
 | `CAD_REVISION_NOTES_LAYER` | `AI_REV_NOTES` | Layer name for revision notes |
+| `CAD_WEB_DEV_MODE` | _(unset)_ | Skip Firebase auth for local backend testing |
+| `CAD_ALLOWED_EMAILS` | _(unset)_ | Comma-separated emails allowed to auto-provision (also checks Firestore `allowlist` collection) |
 | `OTEL_ENABLED` | _(unset)_ | Enable OpenTelemetry tracing (`1`, `true`, `yes`) |
 | `OTEL_EXPORTER` | `console` | Span exporter: `console`, `otlp`, or `gcp-trace` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP collector endpoint (e.g., `http://localhost:4317`) |
@@ -163,16 +259,18 @@ Optional tracing via `otel.py` bootstrap module. Off by default, CI-safe (no net
 
 | Tier | Location | Count | What |
 |------|----------|-------|------|
-| Unit | `tests/unit/` | ~1069 | Schemas, validators, reader, writer, engine, preview, settings, semantic model, snapshots, comparison |
-| Integration | `tests/integration/` | ~78 | Full pipeline, undo/redo, agent loop with ScriptedAgentProvider |
-| Web | `tests/web/` | ~123 | FastAPI backend endpoints (TestClient) |
-| Benchmark | `tests/benchmark/` | ~15 | Performance micro-benchmarks (pytest-benchmark) |
+| Unit | `tests/unit/` | ~3570 | Schemas, validators, reader, writer, engine, preview, semantic model, snapshots, comparison, compliance, takeoff, zones, families |
+| Integration | `tests/integration/` | ~102 | Full pipeline, undo/redo, agent loop with ScriptedAgentProvider |
+| Web | `tests/web/` | ~362 | FastAPI backend endpoints (TestClient), document library, session management |
+| Eval | `tests/eval/` | ~42 | Intent classification accuracy scorecard |
+| Live | `tests/live/` | ~42 | Real Gemini API tests (require ADC + `cad-dxf-agent` GCP project) |
+| E2E | `tests/e2e/` | ~33 | End-to-end tests with real DXF files |
+| Benchmark | `tests/benchmark/` | ~19 | Performance micro-benchmarks (pytest-benchmark) |
 | GUI | `tests/gui/` | ~10 | PySide6 UI tests (require `QT_QPA_PLATFORM=offscreen`) |
 | Property | `tests/property/` | ~7 | Fuzz/property tests (randomized, bounded runtime) |
 | Smoke | `tests/smoke/` + `scripts/smoke_test.py` | ~7 | End-to-end pipeline via mock planner |
-| Live | `tests/live/` | varies | Real Gemini API tests (require ADC + `cad-dxf-agent` GCP project) |
 
-Total: ~1351 tests collected.
+Total: ~4194 tests collected.
 
 ### LLM Testing Patterns
 
@@ -193,11 +291,14 @@ make test              # All tests
 make test-unit         # Unit tests only
 make test-integration  # Integration tests only
 make test-web          # Web backend API tests only
+make test-e2e          # E2E tests (need scripts/download_e2e_fixtures.sh first)
 make test-live         # Live Gemini API tests (require ADC)
 make test-cov          # All tests with coverage report
+make scorecard         # Eval scorecard (mock mode)
+make scorecard-live    # Eval scorecard (real Gemini)
 ```
 
-- Pytest markers: `@pytest.mark.smoke`, `@pytest.mark.slow`, `@pytest.mark.integration`
+- Pytest markers: `@pytest.mark.smoke`, `@pytest.mark.slow`, `@pytest.mark.integration`, `@pytest.mark.web`, `@pytest.mark.live_api`, `@pytest.mark.e2e`, `@pytest.mark.benchmark`, `@pytest.mark.property`, `@pytest.mark.gui`
 - Coverage threshold: 65% (`fail_under` in pyproject.toml)
 
 ## CI
@@ -263,21 +364,35 @@ This project uses `bd` (beads) for issue tracking. Run `bd ready` to find availa
 
 ### Epic Registry
 
-| Epic | Bead | Title | Phase |
-|------|------|-------|-------|
-| EPIC-CAD-01 | cad-uns | Capability Audit + Architecture Baseline | 1 |
-| EPIC-CAD-02 | cad-d9a | Core Contracts + Routing Foundation | 1 |
-| EPIC-CAD-03 | cad-wd2 | Selection + Markup Interpretation Foundation | 1 |
-| EPIC-CAD-04 | cad-grx | Region Q&A Vertical Slice | 2 |
-| EPIC-CAD-05 | cad-ccd | Repeated-Condition Detection | 2 |
-| EPIC-CAD-06 | cad-3e4 | Compare + Diff Service Hardening | 2 |
-| ARCH-REVIEW-01 | cad-sfw | Post-EPIC-06 Architecture Review | — |
-| EPIC-CAD-07 | cad-9ug | Structured Edit Planning | 3 |
-| EPIC-CAD-08 | cad-6zz | Preview + Apply Workflow | 3 |
-| EPIC-CAD-09 | cad-ady | Design Operations Workflow Pack | 4 |
-| EPIC-CAD-10 | cad-8p2 | Construction Drawing Workflow Pack | 4 |
-| EPIC-CAD-11 | cad-36p | Session Durability + Scale Readiness | 5 |
-| EPIC-CAD-12 | cad-m7d | Evaluation Harness + Quality Governance | 5 |
-| EPIC-CAD-13 | cad-dxf-agent-lk9 | Objective Intelligence | 6 |
-| EPIC-CAD-14 | cad-dxf-agent-bmw | Professional Precision Controls | 6 |
-| EPIC-CAD-15 | cad-dxf-agent-aqw | Document Persistence | 6 |
+| Epic | Bead | Title | Phase | Status |
+|------|------|-------|-------|--------|
+| EPIC-CAD-01 | cad-uns | Capability Audit + Architecture Baseline | 1 | Done |
+| EPIC-CAD-02 | cad-d9a | Core Contracts + Routing Foundation | 1 | Done |
+| EPIC-CAD-03 | cad-wd2 | Selection + Markup Interpretation Foundation | 1 | Done |
+| EPIC-CAD-04 | cad-grx | Region Q&A Vertical Slice | 2 | Done |
+| EPIC-CAD-05 | cad-ccd | Repeated-Condition Detection | 2 | Done |
+| EPIC-CAD-06 | cad-3e4 | Compare + Diff Service Hardening | 2 | Done |
+| ARCH-REVIEW-01 | cad-sfw | Post-EPIC-06 Architecture Review | — | Done |
+| EPIC-CAD-07 | cad-9ug | Structured Edit Planning | 3 | Done |
+| EPIC-CAD-08 | cad-6zz | Preview + Apply Workflow | 3 | Done |
+| EPIC-CAD-09 | cad-ady | Design Operations Workflow Pack | 4 | Done |
+| EPIC-CAD-10 | cad-8p2 | Construction Drawing Workflow Pack | 4 | Done |
+| EPIC-CAD-11 | cad-36p | Session Durability + Scale Readiness | 5 | Done |
+| EPIC-CAD-12 | cad-m7d | Evaluation Harness + Quality Governance | 5 | Done |
+| EPIC-CAD-13 | cad-dxf-agent-lk9 | Objective Intelligence | 6 | Done |
+| EPIC-CAD-14 | cad-dxf-agent-bmw | Professional Precision Controls | 6 | Done |
+| EPIC-CAD-15 | cad-dxf-agent-aqw | Document Persistence | 6 | Done |
+| EPIC-CAD-16 | cad-dxf-agent-5ds | Drafting Vocabulary Foundation | 7 | Done |
+| EPIC-CAD-17 | cad-dxf-agent-ofi | Entity Creation Pipeline | 7 | Done |
+| EPIC-CAD-18 | cad-dxf-agent-omx | Scale + Entity Cap | 7 | Done |
+| EPIC-CAD-19 | cad-dxf-agent-xz4 | Drawing Health Report | 8 | Done |
+| EPIC-CAD-20 | cad-dxf-agent-50c | Intelligent Batch Operations | 8 | Done |
+| EPIC-CAD-21 | cad-dxf-agent-ons | Compliance Validation Engine | 8 | Done |
+| EPIC-CAD-22 | cad-dxf-agent-76v | Cross-Drawing Consistency Checker | 8 | Done |
+| EPIC-CAD-23 | cad-dxf-agent-bqt | Automated Takeoff Engine | 8 | Done |
+| EPIC-CAD-24 | cad-dxf-agent-a6b | Plain-English Drawing Summary | 8 | Done |
+| EPIC-CAD-25 | cad-dxf-agent-owv | RFI Generator | 8 | Done |
+| EPIC-CAD-26 | cad-dxf-agent-4xc | Revision Summary Report | 8 | Done |
+| EPIC-CAD-27 | cad-dxf-agent-xvs | Session Undo/Redo + Snapshots | 8 | Done |
+| EPIC-CAD-29 | cad-dxf-agent-9cd | Agent-Mode API v1 | 8 | Done |
+| EPIC-CAD-30 | cad-dxf-agent-qvf | User Accounts, Workspaces & Persistent Work Progress | 9 | Done |

--- a/src/cad_dxf_agent/core/document_store.py
+++ b/src/cad_dxf_agent/core/document_store.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import abc
 import logging
+from pathlib import Path
 from threading import Lock
 from typing import Any
 
 from cad_dxf_agent.models.document_schema import UserDocument
+from cad_dxf_agent.models.work_progress_schema import WorkProgress
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +63,33 @@ class DocumentStore(abc.ABC):
         """Update last_accessed timestamp. Returns True if document exists."""
         return False  # Default no-op; subclasses override for persistence
 
+    def save_work_progress(
+        self,
+        user_id: str,
+        doc_id: str,
+        progress: WorkProgress,
+        working_dxf_path: Path | None = None,
+    ) -> None:
+        """Save work-in-progress state for a document.
+
+        Also marks ``has_work_progress`` on the document metadata.
+        If *working_dxf_path* is provided, the DXF bytes are persisted
+        so they can be restored into a future session.
+        """
+        return  # Default no-op; subclasses override
+
+    def get_work_progress(self, user_id: str, doc_id: str) -> WorkProgress | None:
+        """Load saved work progress, or None if nothing saved."""
+        return None
+
+    def get_working_dxf(self, user_id: str, doc_id: str) -> bytes | None:
+        """Retrieve the saved working DXF bytes, or None."""
+        return None
+
+    def clear_work_progress(self, user_id: str, doc_id: str) -> bool:
+        """Remove saved work progress. Returns True if there was something to clear."""
+        return False
+
     def _check_limits(
         self,
         user_id: str,
@@ -98,6 +127,9 @@ class InMemoryDocumentStore(DocumentStore):
     def __init__(self) -> None:
         self._documents: dict[str, dict[str, UserDocument]] = {}  # user_id -> {doc_id -> doc}
         self._file_data: dict[str, bytes] = {}  # doc_id -> bytes
+        # (user_id, doc_id) -> WorkProgress / bytes
+        self._work_progress: dict[tuple[str, str], WorkProgress] = {}
+        self._working_dxf: dict[tuple[str, str], bytes] = {}
         self._lock = Lock()
 
     def save_document(
@@ -163,6 +195,44 @@ class InMemoryDocumentStore(DocumentStore):
             return None
         with self._lock:
             return self._file_data.get(doc_id)
+
+    def save_work_progress(
+        self,
+        user_id: str,
+        doc_id: str,
+        progress: WorkProgress,
+        working_dxf_path: Path | None = None,
+    ) -> None:
+        key = (user_id, doc_id)
+        with self._lock:
+            self._work_progress[key] = progress
+            if working_dxf_path and working_dxf_path.exists():
+                self._working_dxf[key] = working_dxf_path.read_bytes()
+            # Mark on document metadata
+            user_docs = self._documents.get(user_id, {})
+            doc = user_docs.get(doc_id)
+            if doc:
+                doc.has_work_progress = True
+
+    def get_work_progress(self, user_id: str, doc_id: str) -> WorkProgress | None:
+        with self._lock:
+            return self._work_progress.get((user_id, doc_id))
+
+    def get_working_dxf(self, user_id: str, doc_id: str) -> bytes | None:
+        with self._lock:
+            return self._working_dxf.get((user_id, doc_id))
+
+    def clear_work_progress(self, user_id: str, doc_id: str) -> bool:
+        key = (user_id, doc_id)
+        with self._lock:
+            had = key in self._work_progress
+            self._work_progress.pop(key, None)
+            self._working_dxf.pop(key, None)
+            user_docs = self._documents.get(user_id, {})
+            doc = user_docs.get(doc_id)
+            if doc:
+                doc.has_work_progress = False
+            return had
 
 
 # ---------------------------------------------------------------------------
@@ -315,3 +385,91 @@ class GCSDocumentStore(DocumentStore):
         except Exception as exc:
             logger.warning("Failed to download document %s from GCS: %s", doc_id, exc)
             return None
+
+    def save_work_progress(
+        self,
+        user_id: str,
+        doc_id: str,
+        progress: WorkProgress,
+        working_dxf_path: Path | None = None,
+    ) -> None:
+        try:
+            bucket = self._bucket()
+            prefix = self._doc_prefix(user_id, doc_id)
+
+            # Save progress JSON
+            prog_blob = bucket.blob(f"{prefix}work_progress.json")
+            prog_blob.upload_from_string(
+                progress.model_dump_json(),
+                content_type="application/json",
+            )
+
+            # Save working DXF if provided
+            if working_dxf_path and working_dxf_path.exists():
+                dxf_blob = bucket.blob(f"{prefix}working.dxf")
+                dxf_blob.upload_from_filename(str(working_dxf_path))
+
+            # Update has_work_progress on document metadata
+            doc = self.get_document(user_id, doc_id)
+            if doc:
+                doc.has_work_progress = True
+                meta_blob = bucket.blob(f"{prefix}metadata.json")
+                meta_blob.upload_from_string(
+                    doc.model_dump_json(),
+                    content_type="application/json",
+                )
+
+            logger.info("Saved work progress for doc %s user %s", doc_id, user_id)
+        except Exception as exc:
+            logger.warning("Failed to save work progress for doc %s: %s", doc_id, exc)
+
+    def get_work_progress(self, user_id: str, doc_id: str) -> WorkProgress | None:
+        try:
+            prefix = self._doc_prefix(user_id, doc_id)
+            blob = self._bucket().blob(f"{prefix}work_progress.json")
+            if not blob.exists():
+                return None
+            return WorkProgress.model_validate_json(blob.download_as_text())
+        except Exception as exc:
+            logger.warning("Failed to load work progress for doc %s: %s", doc_id, exc)
+            return None
+
+    def get_working_dxf(self, user_id: str, doc_id: str) -> bytes | None:
+        try:
+            prefix = self._doc_prefix(user_id, doc_id)
+            blob = self._bucket().blob(f"{prefix}working.dxf")
+            if not blob.exists():
+                return None
+            return bytes(blob.download_as_bytes())
+        except Exception as exc:
+            logger.warning("Failed to load working DXF for doc %s: %s", doc_id, exc)
+            return None
+
+    def clear_work_progress(self, user_id: str, doc_id: str) -> bool:
+        try:
+            bucket = self._bucket()
+            prefix = self._doc_prefix(user_id, doc_id)
+
+            prog_blob = bucket.blob(f"{prefix}work_progress.json")
+            had: bool = bool(prog_blob.exists())
+            if had:
+                prog_blob.delete()
+
+            dxf_blob = bucket.blob(f"{prefix}working.dxf")
+            if dxf_blob.exists():
+                dxf_blob.delete()
+
+            # Update metadata
+            doc = self.get_document(user_id, doc_id)
+            if doc:
+                doc.has_work_progress = False
+                meta_blob = bucket.blob(f"{prefix}metadata.json")
+                meta_blob.upload_from_string(
+                    doc.model_dump_json(),
+                    content_type="application/json",
+                )
+
+            return had
+        except Exception as exc:
+            logger.warning("Failed to clear work progress for doc %s: %s", doc_id, exc)
+            return False

--- a/src/cad_dxf_agent/core/session_store.py
+++ b/src/cad_dxf_agent/core/session_store.py
@@ -48,6 +48,7 @@ class SessionMetadata:
     audit_events: list = field(default_factory=list)
     # Paths stored as strings for serialization
     document_id: str = ""  # Links session to a stored document (EPIC-CAD-15)
+    tenant_id: str = ""  # Workspace tenant scope (EPIC-CAD-30)
     original_path: str = ""
     working_path: str = ""
     edited_path: str = ""

--- a/src/cad_dxf_agent/models/document_schema.py
+++ b/src/cad_dxf_agent/models/document_schema.py
@@ -28,6 +28,8 @@ class UserDocument(BaseModel):
     gcs_path: str = ""
     file_size_bytes: int = 0
     status: Literal["active", "deleted"] = "active"
+    tenant_id: str = ""
+    has_work_progress: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def touch(self) -> None:

--- a/src/cad_dxf_agent/models/tenant_schema.py
+++ b/src/cad_dxf_agent/models/tenant_schema.py
@@ -1,0 +1,28 @@
+"""Tenant model for multi-tenant workspace isolation.
+
+Every resource is scoped to a tenant. For beta, each user auto-gets a personal
+tenant (1:1). Later, an org admin creates a shared tenant and invites members.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class Tenant(BaseModel):
+    """A workspace tenant — the top-level isolation boundary.
+
+    Personal tenants are auto-provisioned on first login.
+    Team/enterprise tenants are created by org admins (future).
+    """
+
+    tenant_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
+    name: str
+    owner_uid: str
+    plan: Literal["personal", "team", "enterprise"] = "personal"
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    settings: dict[str, Any] = Field(default_factory=dict)

--- a/src/cad_dxf_agent/models/user_schema.py
+++ b/src/cad_dxf_agent/models/user_schema.py
@@ -1,0 +1,30 @@
+"""User profile model for persistent user identity.
+
+Stored in Firestore at ``users/{uid}``. Links the Firebase Auth identity
+to a tenant and tracks display preferences.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class UserProfile(BaseModel):
+    """Persistent user profile linked to a tenant workspace."""
+
+    uid: str
+    email: str
+    display_name: str = ""
+    company: str = ""
+    tenant_id: str
+    role: Literal["owner", "editor", "viewer"] = "owner"
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    last_login_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    settings: dict[str, Any] = Field(default_factory=dict)
+
+    def touch_login(self) -> None:
+        """Update last_login_at to now."""
+        self.last_login_at = datetime.now(UTC).isoformat()

--- a/src/cad_dxf_agent/models/work_progress_schema.py
+++ b/src/cad_dxf_agent/models/work_progress_schema.py
@@ -1,0 +1,32 @@
+"""Work progress model for persistent session state.
+
+Saved alongside documents in GCS so users can resume where they left off
+after session expiry or browser close.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WorkProgress(BaseModel):
+    """Snapshot of work-in-progress state for a document.
+
+    Stored at ``documents/{tenant_id}/{user_id}/{doc_id}/work_progress.json``.
+    Captures conversation history, audit trail, and edit state so that
+    a new session can restore context after the previous one expired.
+    """
+
+    user_id: str
+    doc_id: str
+    tenant_id: str = ""
+    saved_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    conversation_history: list[dict[str, Any]] = Field(default_factory=list)
+    edit_count: int = 0
+    last_prompt: str = ""
+    has_working_dxf: bool = False
+    audit_events: list[dict[str, Any]] = Field(default_factory=list)
+    snapshot_labels: list[str] = Field(default_factory=list)

--- a/tests/unit/test_document_store_progress.py
+++ b/tests/unit/test_document_store_progress.py
@@ -1,0 +1,283 @@
+"""Tests for work-progress methods on InMemoryDocumentStore."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cad_dxf_agent.core.document_store import InMemoryDocumentStore
+from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+SAMPLE_DXF = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+WORKING_DXF = b"0\nSECTION\n2\nHEADER\n9\n$ACADVER\n1\nAC1015\n0\nENDSEC\n0\nEOF\n"
+
+
+@pytest.fixture
+def store() -> InMemoryDocumentStore:
+    return InMemoryDocumentStore()
+
+
+def _make_progress(user_id: str = "u1", doc_id: str = "doc-abc") -> WorkProgress:
+    return WorkProgress(
+        user_id=user_id,
+        doc_id=doc_id,
+        edit_count=3,
+        last_prompt="move the door",
+        conversation_history=[{"role": "user", "content": "move the door"}],
+        audit_events=[{"op": "move_entity", "handle": "1A"}],
+        snapshot_labels=["before-move"],
+    )
+
+
+class TestSaveAndGetWorkProgress:
+    def test_save_then_get_returns_progress(self, store: InMemoryDocumentStore) -> None:
+        """Saved progress is retrievable for the same doc."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        progress = _make_progress(user_id="u1", doc_id=doc.doc_id)
+
+        store.save_work_progress("u1", doc.doc_id, progress)
+
+        retrieved = store.get_work_progress("u1", doc.doc_id)
+        assert retrieved is not None
+        assert retrieved.doc_id == doc.doc_id
+        assert retrieved.user_id == "u1"
+        assert retrieved.edit_count == 3
+        assert retrieved.last_prompt == "move the door"
+        assert retrieved.conversation_history == [{"role": "user", "content": "move the door"}]
+        assert retrieved.audit_events == [{"op": "move_entity", "handle": "1A"}]
+        assert retrieved.snapshot_labels == ["before-move"]
+
+    def test_get_returns_none_when_nothing_saved(self, store: InMemoryDocumentStore) -> None:
+        """get_work_progress returns None for a doc with no saved progress."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+
+        result = store.get_work_progress("u1", doc.doc_id)
+
+        assert result is None
+
+    def test_get_returns_none_for_unknown_doc_id(self, store: InMemoryDocumentStore) -> None:
+        """get_work_progress returns None for a doc_id that was never seen."""
+        result = store.get_work_progress("u1", "nonexistent-doc-id")
+
+        assert result is None
+
+    def test_save_overwrites_previous_progress(self, store: InMemoryDocumentStore) -> None:
+        """A second save replaces the earlier progress for the same doc."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        first = WorkProgress(user_id="u1", doc_id=doc.doc_id, edit_count=1, last_prompt="first")
+        second = WorkProgress(user_id="u1", doc_id=doc.doc_id, edit_count=5, last_prompt="second")
+
+        store.save_work_progress("u1", doc.doc_id, first)
+        store.save_work_progress("u1", doc.doc_id, second)
+
+        retrieved = store.get_work_progress("u1", doc.doc_id)
+        assert retrieved is not None
+        assert retrieved.edit_count == 5
+        assert retrieved.last_prompt == "second"
+
+
+class TestWorkingDxf:
+    def test_save_with_working_dxf_path_stores_bytes(
+        self, store: InMemoryDocumentStore, tmp_path: Path
+    ) -> None:
+        """Providing a working_dxf_path persists its bytes and they are retrievable."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        progress = _make_progress(user_id="u1", doc_id=doc.doc_id)
+        working_file = tmp_path / "working.dxf"
+        working_file.write_bytes(WORKING_DXF)
+
+        store.save_work_progress("u1", doc.doc_id, progress, working_dxf_path=working_file)
+
+        data = store.get_working_dxf("u1", doc.doc_id)
+        assert data == WORKING_DXF
+
+    def test_get_working_dxf_returns_none_when_no_dxf_saved(
+        self, store: InMemoryDocumentStore
+    ) -> None:
+        """get_working_dxf returns None when progress was saved without a DXF path."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        progress = _make_progress(user_id="u1", doc_id=doc.doc_id)
+
+        store.save_work_progress("u1", doc.doc_id, progress)  # no working_dxf_path
+
+        assert store.get_working_dxf("u1", doc.doc_id) is None
+
+    def test_get_working_dxf_returns_none_for_unknown_doc(
+        self, store: InMemoryDocumentStore
+    ) -> None:
+        """get_working_dxf returns None when no progress exists at all."""
+        assert store.get_working_dxf("u1", "nonexistent-doc-id") is None
+
+    def test_save_with_nonexistent_path_does_not_store_dxf(
+        self, store: InMemoryDocumentStore, tmp_path: Path
+    ) -> None:
+        """If working_dxf_path points to a missing file, no DXF bytes are stored."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        progress = _make_progress(user_id="u1", doc_id=doc.doc_id)
+        missing_path = tmp_path / "does-not-exist.dxf"
+
+        store.save_work_progress("u1", doc.doc_id, progress, working_dxf_path=missing_path)
+
+        assert store.get_working_dxf("u1", doc.doc_id) is None
+
+
+class TestClearWorkProgress:
+    def test_clear_removes_progress_and_returns_true(self, store: InMemoryDocumentStore) -> None:
+        """clear_work_progress removes saved progress and returns True."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        store.save_work_progress("u1", doc.doc_id, _make_progress("u1", doc.doc_id))
+
+        result = store.clear_work_progress("u1", doc.doc_id)
+
+        assert result is True
+        assert store.get_work_progress("u1", doc.doc_id) is None
+
+    def test_clear_removes_working_dxf_bytes(
+        self, store: InMemoryDocumentStore, tmp_path: Path
+    ) -> None:
+        """clear_work_progress also purges stored working DXF bytes."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        working_file = tmp_path / "working.dxf"
+        working_file.write_bytes(WORKING_DXF)
+        store.save_work_progress(
+            "u1", doc.doc_id, _make_progress("u1", doc.doc_id), working_dxf_path=working_file
+        )
+
+        store.clear_work_progress("u1", doc.doc_id)
+
+        assert store.get_working_dxf("u1", doc.doc_id) is None
+
+    def test_clear_returns_false_when_nothing_to_clear(self, store: InMemoryDocumentStore) -> None:
+        """clear_work_progress returns False when no progress existed."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+
+        result = store.clear_work_progress("u1", doc.doc_id)
+
+        assert result is False
+
+    def test_clear_returns_false_for_unknown_doc_id(self, store: InMemoryDocumentStore) -> None:
+        """clear_work_progress returns False for a completely unknown doc."""
+        result = store.clear_work_progress("u1", "nonexistent-doc-id")
+
+        assert result is False
+
+    def test_clear_is_idempotent(self, store: InMemoryDocumentStore) -> None:
+        """A second clear on the same doc returns False (already gone)."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        store.save_work_progress("u1", doc.doc_id, _make_progress("u1", doc.doc_id))
+
+        assert store.clear_work_progress("u1", doc.doc_id) is True
+        assert store.clear_work_progress("u1", doc.doc_id) is False
+
+
+class TestHasWorkProgressFlag:
+    def test_save_sets_flag_on_document(self, store: InMemoryDocumentStore) -> None:
+        """save_work_progress marks has_work_progress=True on the UserDocument."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        assert doc.has_work_progress is False
+
+        store.save_work_progress("u1", doc.doc_id, _make_progress("u1", doc.doc_id))
+
+        refreshed = store.get_document("u1", doc.doc_id)
+        assert refreshed is not None
+        assert refreshed.has_work_progress is True
+
+    def test_clear_resets_flag_on_document(self, store: InMemoryDocumentStore) -> None:
+        """clear_work_progress resets has_work_progress=False on the UserDocument."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        store.save_work_progress("u1", doc.doc_id, _make_progress("u1", doc.doc_id))
+
+        store.clear_work_progress("u1", doc.doc_id)
+
+        refreshed = store.get_document("u1", doc.doc_id)
+        assert refreshed is not None
+        assert refreshed.has_work_progress is False
+
+    def test_flag_false_by_default_on_new_document(self, store: InMemoryDocumentStore) -> None:
+        """Freshly saved documents start with has_work_progress=False."""
+        doc = store.save_document("u1", "fresh.dxf", SAMPLE_DXF)
+
+        assert doc.has_work_progress is False
+
+    def test_clear_without_prior_save_leaves_flag_false(self, store: InMemoryDocumentStore) -> None:
+        """Clearing progress on a doc that never had any keeps the flag False."""
+        doc = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+
+        store.clear_work_progress("u1", doc.doc_id)
+
+        refreshed = store.get_document("u1", doc.doc_id)
+        assert refreshed is not None
+        assert refreshed.has_work_progress is False
+
+
+class TestMultipleDocumentIsolation:
+    def test_progress_is_isolated_per_doc(self, store: InMemoryDocumentStore) -> None:
+        """Progress saved for doc A does not affect doc B."""
+        doc_a = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        doc_b = store.save_document("u1", "b.dxf", SAMPLE_DXF)
+        progress_a = WorkProgress(user_id="u1", doc_id=doc_a.doc_id, edit_count=10)
+
+        store.save_work_progress("u1", doc_a.doc_id, progress_a)
+
+        assert store.get_work_progress("u1", doc_b.doc_id) is None
+        assert store.get_working_dxf("u1", doc_b.doc_id) is None
+
+    def test_clearing_one_doc_does_not_affect_another(self, store: InMemoryDocumentStore) -> None:
+        """Clearing progress for doc A leaves doc B's progress intact."""
+        doc_a = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        doc_b = store.save_document("u1", "b.dxf", SAMPLE_DXF)
+        store.save_work_progress("u1", doc_a.doc_id, _make_progress("u1", doc_a.doc_id))
+        store.save_work_progress("u1", doc_b.doc_id, _make_progress("u1", doc_b.doc_id))
+
+        store.clear_work_progress("u1", doc_a.doc_id)
+
+        assert store.get_work_progress("u1", doc_a.doc_id) is None
+        assert store.get_work_progress("u1", doc_b.doc_id) is not None
+
+    def test_progress_is_isolated_per_user(self, store: InMemoryDocumentStore) -> None:
+        """Two users can each have progress under the same doc_id without collision.
+
+        In practice doc_ids are globally unique (uuid hex), but the store keys
+        progress by doc_id alone — this test documents that the get/clear APIs
+        accept a user_id argument which is also used for the document ownership
+        check, even though the underlying progress dict is keyed by doc_id.
+        """
+        doc_u1 = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
+        doc_u2 = store.save_document("u2", "section.dxf", SAMPLE_DXF)
+        p_u1 = WorkProgress(user_id="u1", doc_id=doc_u1.doc_id, edit_count=2)
+        p_u2 = WorkProgress(user_id="u2", doc_id=doc_u2.doc_id, edit_count=7)
+
+        store.save_work_progress("u1", doc_u1.doc_id, p_u1)
+        store.save_work_progress("u2", doc_u2.doc_id, p_u2)
+
+        r_u1 = store.get_work_progress("u1", doc_u1.doc_id)
+        r_u2 = store.get_work_progress("u2", doc_u2.doc_id)
+        assert r_u1 is not None and r_u1.edit_count == 2
+        assert r_u2 is not None and r_u2.edit_count == 7
+
+    def test_has_work_progress_flag_isolated_per_doc(self, store: InMemoryDocumentStore) -> None:
+        """Setting the flag on doc A does not bleed onto doc B."""
+        doc_a = store.save_document("u1", "a.dxf", SAMPLE_DXF)
+        doc_b = store.save_document("u1", "b.dxf", SAMPLE_DXF)
+
+        store.save_work_progress("u1", doc_a.doc_id, _make_progress("u1", doc_a.doc_id))
+
+        doc_b_refreshed = store.get_document("u1", doc_b.doc_id)
+        assert doc_b_refreshed is not None
+        assert doc_b_refreshed.has_work_progress is False
+
+    def test_multiple_docs_can_all_have_progress(self, store: InMemoryDocumentStore) -> None:
+        """Three docs under the same user each hold independent progress state."""
+        docs = [store.save_document("u1", f"{c}.dxf", SAMPLE_DXF) for c in ("a", "b", "c")]
+        for i, doc in enumerate(docs):
+            store.save_work_progress(
+                "u1",
+                doc.doc_id,
+                WorkProgress(user_id="u1", doc_id=doc.doc_id, edit_count=i + 1),
+            )
+
+        for i, doc in enumerate(docs):
+            progress = store.get_work_progress("u1", doc.doc_id)
+            assert progress is not None
+            assert progress.edit_count == i + 1

--- a/tests/unit/test_document_store_progress.py
+++ b/tests/unit/test_document_store_progress.py
@@ -236,12 +236,11 @@ class TestMultipleDocumentIsolation:
         assert store.get_work_progress("u1", doc_b.doc_id) is not None
 
     def test_progress_is_isolated_per_user(self, store: InMemoryDocumentStore) -> None:
-        """Two users can each have progress under the same doc_id without collision.
+        """Two users can each have progress on different documents without collision.
 
-        In practice doc_ids are globally unique (uuid hex), but the store keys
-        progress by doc_id alone — this test documents that the get/clear APIs
-        accept a user_id argument which is also used for the document ownership
-        check, even though the underlying progress dict is keyed by doc_id.
+        The InMemoryDocumentStore keys work progress by (user_id, doc_id) tuples,
+        ensuring that progress is isolated between users even if doc_ids were
+        somehow not globally unique.
         """
         doc_u1 = store.save_document("u1", "floor.dxf", SAMPLE_DXF)
         doc_u2 = store.save_document("u2", "section.dxf", SAMPLE_DXF)

--- a/tests/unit/test_tenant_schema.py
+++ b/tests/unit/test_tenant_schema.py
@@ -1,0 +1,83 @@
+"""Tests for tenant_schema — Tenant model."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cad_dxf_agent.models.tenant_schema import Tenant
+
+
+class TestTenantDefaults:
+    def test_required_fields_only(self):
+        t = Tenant(name="Acme Corp", owner_uid="uid-abc")
+        assert t.name == "Acme Corp"
+        assert t.owner_uid == "uid-abc"
+        assert t.plan == "personal"
+        assert t.settings == {}
+        assert t.tenant_id  # auto-generated, non-empty
+        assert t.created_at  # non-empty ISO string
+
+    def test_tenant_id_length(self):
+        t = Tenant(name="Studio X", owner_uid="uid-xyz")
+        assert len(t.tenant_id) == 12
+
+    def test_unique_tenant_ids(self):
+        tenants = [Tenant(name="T", owner_uid="u") for _ in range(10)]
+        ids = {t.tenant_id for t in tenants}
+        assert len(ids) == 10
+
+    def test_explicit_tenant_id(self):
+        t = Tenant(tenant_id="custom000001", name="X", owner_uid="u")
+        assert t.tenant_id == "custom000001"
+
+
+class TestTenantAllFields:
+    def test_all_fields_accepted(self):
+        t = Tenant(
+            tenant_id="abc123def456",
+            name="Enterprise LLC",
+            owner_uid="uid-owner-1",
+            plan="enterprise",
+            created_at="2026-01-01T00:00:00+00:00",
+            settings={"max_users": 500, "feature_flags": ["batch_ops"]},
+        )
+        assert t.plan == "enterprise"
+        assert t.settings["max_users"] == 500
+        assert t.created_at == "2026-01-01T00:00:00+00:00"
+
+    def test_team_plan(self):
+        t = Tenant(name="Design Team", owner_uid="uid-t", plan="team")
+        assert t.plan == "team"
+
+
+class TestTenantPlanValidation:
+    def test_invalid_plan_raises(self):
+        with pytest.raises(ValidationError):
+            Tenant(name="X", owner_uid="u", plan="pro")
+
+    def test_invalid_plan_uppercase_raises(self):
+        with pytest.raises(ValidationError):
+            Tenant(name="X", owner_uid="u", plan="Personal")
+
+
+class TestTenantJsonRoundtrip:
+    def test_roundtrip_minimal(self):
+        t = Tenant(name="Round Trip Co", owner_uid="uid-rt")
+        restored = Tenant.model_validate_json(t.model_dump_json())
+        assert restored.tenant_id == t.tenant_id
+        assert restored.name == t.name
+        assert restored.owner_uid == t.owner_uid
+        assert restored.plan == t.plan
+        assert restored.settings == t.settings
+
+    def test_roundtrip_with_settings(self):
+        t = Tenant(
+            name="Full Corp",
+            owner_uid="uid-full",
+            plan="enterprise",
+            settings={"region": "us-west", "seats": 50},
+        )
+        restored = Tenant.model_validate_json(t.model_dump_json())
+        assert restored.settings == {"region": "us-west", "seats": 50}
+        assert restored.plan == "enterprise"

--- a/tests/unit/test_user_schema.py
+++ b/tests/unit/test_user_schema.py
@@ -1,0 +1,100 @@
+"""Tests for user_schema — UserProfile model."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cad_dxf_agent.models.user_schema import UserProfile
+
+
+class TestUserProfileDefaults:
+    def test_required_fields_only(self):
+        u = UserProfile(uid="uid-1", email="alice@example.com", tenant_id="tid-001")
+        assert u.uid == "uid-1"
+        assert u.email == "alice@example.com"
+        assert u.tenant_id == "tid-001"
+        assert u.display_name == ""
+        assert u.company == ""
+        assert u.role == "owner"
+        assert u.settings == {}
+        assert u.created_at  # non-empty ISO string
+        assert u.last_login_at  # non-empty ISO string
+
+
+class TestUserProfileAllFields:
+    def test_all_fields_accepted(self):
+        u = UserProfile(
+            uid="uid-2",
+            email="bob@firm.com",
+            display_name="Bob Builder",
+            company="Builder LLC",
+            tenant_id="tid-002",
+            role="editor",
+            created_at="2026-01-01T00:00:00+00:00",
+            last_login_at="2026-03-01T12:00:00+00:00",
+            settings={"theme": "dark", "notifications": True},
+        )
+        assert u.display_name == "Bob Builder"
+        assert u.company == "Builder LLC"
+        assert u.role == "editor"
+        assert u.settings["theme"] == "dark"
+
+    def test_viewer_role(self):
+        u = UserProfile(uid="u", email="v@x.com", tenant_id="t", role="viewer")
+        assert u.role == "viewer"
+
+
+class TestUserProfileRoleValidation:
+    def test_invalid_role_raises(self):
+        with pytest.raises(ValidationError):
+            UserProfile(uid="u", email="x@x.com", tenant_id="t", role="admin")
+
+    def test_invalid_role_uppercase_raises(self):
+        with pytest.raises(ValidationError):
+            UserProfile(uid="u", email="x@x.com", tenant_id="t", role="Owner")
+
+
+class TestUserProfileTouchLogin:
+    def test_touch_login_updates_timestamp(self):
+        u = UserProfile(
+            uid="uid-3",
+            email="charlie@x.com",
+            tenant_id="tid-003",
+            last_login_at="2020-01-01T00:00:00+00:00",
+        )
+        old = u.last_login_at
+        u.touch_login()
+        assert u.last_login_at != old
+        assert u.last_login_at > old
+
+    def test_touch_login_does_not_change_other_fields(self):
+        u = UserProfile(uid="uid-4", email="d@x.com", tenant_id="tid-004")
+        original_email = u.email
+        original_uid = u.uid
+        u.touch_login()
+        assert u.email == original_email
+        assert u.uid == original_uid
+
+
+class TestUserProfileJsonRoundtrip:
+    def test_roundtrip_minimal(self):
+        u = UserProfile(uid="uid-5", email="e@x.com", tenant_id="tid-005")
+        restored = UserProfile.model_validate_json(u.model_dump_json())
+        assert restored.uid == u.uid
+        assert restored.email == u.email
+        assert restored.tenant_id == u.tenant_id
+        assert restored.role == u.role
+        assert restored.settings == u.settings
+
+    def test_roundtrip_preserves_role_and_settings(self):
+        u = UserProfile(
+            uid="uid-6",
+            email="f@firm.com",
+            tenant_id="tid-006",
+            role="editor",
+            settings={"lang": "en"},
+        )
+        restored = UserProfile.model_validate_json(u.model_dump_json())
+        assert restored.role == "editor"
+        assert restored.settings == {"lang": "en"}

--- a/tests/unit/test_work_progress_schema.py
+++ b/tests/unit/test_work_progress_schema.py
@@ -1,0 +1,93 @@
+"""Tests for work_progress_schema — WorkProgress model."""
+
+from __future__ import annotations
+
+from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+
+class TestWorkProgressDefaults:
+    def test_required_fields_only(self):
+        wp = WorkProgress(user_id="uid-1", doc_id="doc-abc")
+        assert wp.user_id == "uid-1"
+        assert wp.doc_id == "doc-abc"
+        assert wp.tenant_id == ""
+        assert wp.conversation_history == []
+        assert wp.edit_count == 0
+        assert wp.last_prompt == ""
+        assert wp.has_working_dxf is False
+        assert wp.audit_events == []
+        assert wp.snapshot_labels == []
+        assert wp.saved_at  # non-empty ISO string
+
+
+class TestWorkProgressAllFields:
+    def test_all_fields_accepted(self):
+        wp = WorkProgress(
+            user_id="uid-2",
+            doc_id="doc-xyz",
+            tenant_id="tid-001",
+            saved_at="2026-03-01T10:00:00+00:00",
+            conversation_history=[{"role": "user", "content": "Move wall north"}],
+            edit_count=3,
+            last_prompt="Move wall north",
+            has_working_dxf=True,
+            audit_events=[{"event": "edit_applied", "op": "move_entity"}],
+            snapshot_labels=["before-demo", "after-demo"],
+        )
+        assert wp.tenant_id == "tid-001"
+        assert wp.edit_count == 3
+        assert wp.last_prompt == "Move wall north"
+        assert wp.has_working_dxf is True
+        assert len(wp.conversation_history) == 1
+        assert len(wp.audit_events) == 1
+        assert wp.snapshot_labels == ["before-demo", "after-demo"]
+
+
+class TestWorkProgressMutability:
+    def test_edit_count_can_be_incremented(self):
+        wp = WorkProgress(user_id="u", doc_id="d")
+        wp.edit_count += 1
+        assert wp.edit_count == 1
+
+    def test_conversation_history_can_be_appended(self):
+        wp = WorkProgress(user_id="u", doc_id="d")
+        wp.conversation_history.append({"role": "user", "content": "hello"})
+        assert len(wp.conversation_history) == 1
+
+    def test_snapshot_labels_can_be_appended(self):
+        wp = WorkProgress(user_id="u", doc_id="d")
+        wp.snapshot_labels.append("v1")
+        wp.snapshot_labels.append("v2")
+        assert wp.snapshot_labels == ["v1", "v2"]
+
+
+class TestWorkProgressJsonRoundtrip:
+    def test_roundtrip_minimal(self):
+        wp = WorkProgress(user_id="uid-3", doc_id="doc-3")
+        restored = WorkProgress.model_validate_json(wp.model_dump_json())
+        assert restored.user_id == wp.user_id
+        assert restored.doc_id == wp.doc_id
+        assert restored.edit_count == 0
+        assert restored.has_working_dxf is False
+        assert restored.conversation_history == []
+
+    def test_roundtrip_with_populated_lists(self):
+        wp = WorkProgress(
+            user_id="uid-4",
+            doc_id="doc-4",
+            tenant_id="tid-002",
+            edit_count=5,
+            last_prompt="Delete column",
+            has_working_dxf=True,
+            conversation_history=[{"role": "assistant", "content": "Done."}],
+            audit_events=[{"event": "snapshot_taken", "label": "pre-delete"}],
+            snapshot_labels=["pre-delete"],
+        )
+        restored = WorkProgress.model_validate_json(wp.model_dump_json())
+        assert restored.tenant_id == "tid-002"
+        assert restored.edit_count == 5
+        assert restored.last_prompt == "Delete column"
+        assert restored.has_working_dxf is True
+        assert restored.conversation_history == [{"role": "assistant", "content": "Done."}]
+        assert restored.snapshot_labels == ["pre-delete"]
+        assert len(restored.audit_events) == 1

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -134,9 +134,11 @@ class TestCheckLicense:
         import web.backend.auth as auth_mod
 
         auth_mod._license_cache.clear()
+        auth_mod._allowlist_cache.clear()
         old_dev = os.environ.pop("CAD_WEB_DEV_MODE", None)
         yield
         auth_mod._license_cache.clear()
+        auth_mod._allowlist_cache.clear()
         if old_dev is not None:
             os.environ["CAD_WEB_DEV_MODE"] = old_dev
         else:
@@ -177,7 +179,7 @@ class TestCheckLicense:
             await check_license(user)  # should not raise
 
     @pytest.mark.asyncio
-    async def test_new_user_auto_provisioned(self):
+    async def test_new_user_auto_provisioned_when_on_allowlist(self):
         from unittest.mock import MagicMock, patch
 
         from web.backend.auth import check_license
@@ -191,6 +193,7 @@ class TestCheckLicense:
         mock_provision = MagicMock()
         with (
             patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._check_email_allowed", return_value=True),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)  # should not raise
@@ -218,6 +221,157 @@ class TestCheckLicense:
 
     @pytest.mark.asyncio
     async def test_dev_mode_bypasses_license(self):
+        from web.backend.auth import check_license
+
+        os.environ["CAD_WEB_DEV_MODE"] = "1"
+        user = {"uid": "any-user"}
+        await check_license(user)  # should not raise
+
+
+@pytest.mark.web
+class TestAllowlist:
+    """Test email allowlist gating for auto-provisioning."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self):
+        """Reset caches and env vars between tests."""
+        import web.backend.auth as auth_mod
+
+        auth_mod._license_cache.clear()
+        auth_mod._allowlist_cache.clear()
+        old_dev = os.environ.pop("CAD_WEB_DEV_MODE", None)
+        old_allowed = os.environ.pop("CAD_ALLOWED_EMAILS", None)
+        yield
+        auth_mod._license_cache.clear()
+        auth_mod._allowlist_cache.clear()
+        if old_dev is not None:
+            os.environ["CAD_WEB_DEV_MODE"] = old_dev
+        else:
+            os.environ.pop("CAD_WEB_DEV_MODE", None)
+        if old_allowed is not None:
+            os.environ["CAD_ALLOWED_EMAILS"] = old_allowed
+        else:
+            os.environ.pop("CAD_ALLOWED_EMAILS", None)
+
+    @pytest.mark.asyncio
+    async def test_unlisted_email_rejected_with_403(self):
+        """A new user not on the allowlist gets 403, not auto-provisioned."""
+        from unittest.mock import patch
+
+        from web.backend.auth import check_license
+
+        user = {
+            "uid": "stranger",
+            "email": "stranger@gmail.com",
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+        with (
+            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._check_email_allowed", return_value=False),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await check_license(user)
+        assert exc_info.value.status_code == 403
+        assert "Access restricted" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_env_var_allows_email(self):
+        """Email listed in CAD_ALLOWED_EMAILS is auto-provisioned."""
+        from unittest.mock import MagicMock, patch
+
+        from web.backend.auth import check_license
+
+        os.environ["CAD_ALLOWED_EMAILS"] = "beta@test.com,vip@corp.com"
+        user = {
+            "uid": "beta-user",
+            "email": "beta@test.com",
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+        mock_provision = MagicMock()
+        with (
+            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._provision_license", mock_provision),
+        ):
+            await check_license(user)
+        mock_provision.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_env_var_case_insensitive(self):
+        """Allowlist matching is case-insensitive."""
+        from unittest.mock import MagicMock, patch
+
+        from web.backend.auth import check_license
+
+        os.environ["CAD_ALLOWED_EMAILS"] = "BETA@Test.COM"
+        user = {
+            "uid": "beta-user",
+            "email": "beta@test.com",
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+        mock_provision = MagicMock()
+        with (
+            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._provision_license", mock_provision),
+        ):
+            await check_license(user)
+        mock_provision.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_firestore_allowlist_allows_email(self):
+        """Email found in Firestore allowlist collection is auto-provisioned."""
+        from unittest.mock import MagicMock, patch
+
+        from web.backend.auth import check_license
+
+        user = {
+            "uid": "firestore-user",
+            "email": "approved@corp.com",
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+        mock_provision = MagicMock()
+        with (
+            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._check_email_allowed", return_value=True),
+            patch("web.backend.auth._provision_license", mock_provision),
+        ):
+            await check_license(user)
+        mock_provision.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_existing_license_skips_allowlist(self):
+        """A user with an active license is not checked against the allowlist."""
+        from unittest.mock import patch
+
+        from web.backend.auth import check_license
+
+        user = {
+            "uid": "existing-user",
+            "email": "old@example.com",
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+        # _check_email_allowed should NOT be called
+        with (
+            patch("web.backend.auth._fetch_license", return_value=True),
+            patch("web.backend.auth._check_email_allowed") as mock_check,
+        ):
+            await check_license(user)
+        mock_check.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowlist_cached(self):
+        """Second check for same email uses the cache, not Firestore."""
+        import time
+
+        from web.backend.auth import _allowlist_cache, _check_email_allowed
+
+        # Pre-populate cache
+        _allowlist_cache["cached@test.com"] = (True, time.monotonic())
+        # No Firestore or env var needed — cache hit
+        assert _check_email_allowed("cached@test.com") is True
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_bypasses_allowlist(self):
+        """Dev mode skips the entire license+allowlist chain."""
         from web.backend.auth import check_license
 
         os.environ["CAD_WEB_DEV_MODE"] = "1"

--- a/tests/web/test_auto_save.py
+++ b/tests/web/test_auto_save.py
@@ -1,0 +1,196 @@
+"""Tests for work-progress auto-save and restore behaviour (EPIC-CAD-30)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.document_store import InMemoryDocumentStore
+from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+SAMPLE_DXF_CONTENT = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+
+
+@pytest.fixture(autouse=True)
+def _use_inmemory_doc_store(monkeypatch):
+    """Force InMemoryDocumentStore for all tests in this module."""
+    import web.backend.main as main_mod
+
+    store = InMemoryDocumentStore()
+    monkeypatch.setattr(main_mod, "_document_store", store)
+    yield store
+    monkeypatch.setattr(main_mod, "_document_store", None)
+
+
+@pytest.mark.web
+class TestLoadDocumentRestoredField:
+    def test_load_returns_restored_false_when_no_progress(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Loading a doc with no saved progress returns restored=False."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert resp.status_code == 200
+        assert resp.json()["restored"] is False
+
+    def test_load_returns_restored_true_when_progress_exists(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Loading a doc that has saved progress returns restored=True."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        # Seed the store directly with a WorkProgress record
+        progress = WorkProgress(
+            user_id="test-user-123",
+            doc_id=doc.doc_id,
+            conversation_history=[{"role": "user", "content": "move wall to x=5"}],
+            edit_count=1,
+            last_prompt="move wall to x=5",
+        )
+        store.save_work_progress("test-user-123", doc.doc_id, progress)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert resp.status_code == 200
+        assert resp.json()["restored"] is True
+
+    def test_load_response_contains_session_id(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Load response always includes a session_id."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert "session_id" in resp.json()
+
+    def test_load_response_contains_document_id(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Load response always includes the correct document_id."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert resp.json()["document_id"] == doc.doc_id
+
+
+@pytest.mark.web
+class TestRestoreWorkProgressHelper:
+    """Unit tests for the _restore_work_progress helper function."""
+
+    def test_restore_returns_false_when_no_progress(self, _use_inmemory_doc_store):
+        """_restore_work_progress returns False when the store has no record."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        session.document_id = "no-progress-doc"
+
+        restored = _restore_work_progress(session, "test-user-123", store)
+        assert restored is False
+
+    def test_restore_returns_false_when_no_document_id(self, _use_inmemory_doc_store):
+        """_restore_work_progress returns False when the session has no document_id."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        # document_id is "" by default — no binding
+
+        restored = _restore_work_progress(session, "test-user-123", store)
+        assert restored is False
+
+    def test_restore_returns_true_when_progress_exists(self, _use_inmemory_doc_store):
+        """_restore_work_progress returns True when saved progress is found."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        # Seed progress
+        doc = store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+        progress = WorkProgress(
+            user_id="test-user-123",
+            doc_id=doc.doc_id,
+            conversation_history=[{"role": "user", "content": "rotate block 90 degrees"}],
+            edit_count=2,
+        )
+        store.save_work_progress("test-user-123", doc.doc_id, progress)
+
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        session.document_id = doc.doc_id
+
+        restored = _restore_work_progress(session, "test-user-123", store)
+        assert restored is True
+
+    def test_restore_populates_conversation_history(self, _use_inmemory_doc_store):
+        """After restore, session.conversation_history contains the saved messages."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+        history = [
+            {"role": "user", "content": "delete layer WALLS"},
+            {"role": "assistant", "content": "Understood, deleting WALLS layer."},
+        ]
+        progress = WorkProgress(
+            user_id="test-user-123",
+            doc_id=doc.doc_id,
+            conversation_history=history,
+        )
+        store.save_work_progress("test-user-123", doc.doc_id, progress)
+
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        session.document_id = doc.doc_id
+
+        _restore_work_progress(session, "test-user-123", store)
+
+        assert session.conversation_history == history
+
+    def test_restore_populates_audit_events(self, _use_inmemory_doc_store):
+        """After restore, session.audit_events contains the saved events."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+        events = [{"op": "move_entity", "handle": "0x1A"}]
+        progress = WorkProgress(
+            user_id="test-user-123",
+            doc_id=doc.doc_id,
+            audit_events=events,
+        )
+        store.save_work_progress("test-user-123", doc.doc_id, progress)
+
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        session.document_id = doc.doc_id
+
+        _restore_work_progress(session, "test-user-123", store)
+
+        assert session.audit_events == events
+
+    def test_restore_leaves_session_unchanged_on_miss(self, _use_inmemory_doc_store):
+        """When no progress exists, conversation_history and audit_events stay empty."""
+        from web.backend.main import _restore_work_progress
+        from web.backend.session import SessionManager
+
+        store = _use_inmemory_doc_store
+        mgr = SessionManager()
+        session = mgr.create("test-user-123")
+        session.document_id = "ghost-doc"
+
+        _restore_work_progress(session, "test-user-123", store)
+
+        assert session.conversation_history == []
+        assert session.audit_events == []

--- a/tests/web/test_profile.py
+++ b/tests/web/test_profile.py
@@ -1,0 +1,106 @@
+"""Tests for user profile endpoints (EPIC-CAD-30)."""
+
+from __future__ import annotations
+
+import pytest
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+
+@pytest.mark.web
+class TestGetProfile:
+    def test_get_profile_returns_200(self, client, monkeypatch):
+        """GET /api/profile returns 200 with the expected envelope."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        assert resp.status_code == 200
+
+    def test_get_profile_contains_uid(self, client, monkeypatch):
+        """Profile response includes the authenticated user's uid."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        data = resp.json()
+        assert "profile" in data
+        assert data["profile"]["uid"] == "test-user-123"
+
+    def test_get_profile_contains_email(self, client, monkeypatch):
+        """Profile response includes the authenticated user's email."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        profile = resp.json()["profile"]
+        assert profile["email"] == "test@example.com"
+
+    def test_get_profile_contains_display_name(self, client, monkeypatch):
+        """Profile response includes a display_name field."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        profile = resp.json()["profile"]
+        assert "display_name" in profile
+
+    def test_get_profile_contains_tenant_id(self, client, monkeypatch):
+        """Profile response includes a tenant_id field."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        profile = resp.json()["profile"]
+        assert "tenant_id" in profile
+
+    def test_get_profile_dev_mode_returns_synthetic(self, client, monkeypatch):
+        """Dev mode returns a synthetic profile without hitting Firestore."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.get("/api/profile")
+        assert resp.status_code == 200
+        profile = resp.json()["profile"]
+        # Tenant defaults to dev-tenant in dev mode
+        assert profile["tenant_id"] == "dev-tenant"
+
+
+@pytest.mark.web
+class TestUpdateProfile:
+    def test_put_profile_with_display_name_returns_200(self, client, monkeypatch):
+        """PUT /api/profile with a display_name returns 200."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.put("/api/profile", json={"display_name": "Alice Smith"})
+        assert resp.status_code == 200
+
+    def test_put_profile_response_contains_updated_display_name(self, client, monkeypatch):
+        """PUT /api/profile response echoes the updated display_name."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.put("/api/profile", json={"display_name": "Bob Jones"})
+        profile = resp.json()["profile"]
+        assert profile["display_name"] == "Bob Jones"
+
+    def test_put_profile_response_contains_uid(self, client, monkeypatch):
+        """PUT /api/profile response includes the authenticated user's uid."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.put("/api/profile", json={"display_name": "Carol"})
+        profile = resp.json()["profile"]
+        assert profile["uid"] == "test-user-123"
+
+    def test_put_profile_empty_body_returns_400_outside_dev_mode(self, client, monkeypatch):
+        """PUT /api/profile with no update fields returns 400 when not in dev mode.
+
+        In dev mode the endpoint short-circuits before the validation check, so this
+        test patches CAD_WEB_DEV_MODE out (not set) to exercise the real validation
+        path.  The auth dep is still overridden by the ``client`` fixture so the
+        request reaches the handler.
+        """
+        monkeypatch.delenv("CAD_WEB_DEV_MODE", raising=False)
+        resp = client.put("/api/profile", json={})
+        assert resp.status_code == 400
+
+    def test_put_profile_with_company_dev_mode_returns_200(self, client, monkeypatch):
+        """PUT /api/profile with a company field is accepted in dev mode."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.put("/api/profile", json={"company": "Acme Corp"})
+        assert resp.status_code == 200
+
+    def test_put_profile_with_both_fields_dev_mode(self, client, monkeypatch):
+        """PUT /api/profile with display_name and company succeeds in dev mode."""
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        resp = client.put(
+            "/api/profile",
+            json={"display_name": "Dana Lee", "company": "Blueprint Inc"},
+        )
+        assert resp.status_code == 200
+        profile = resp.json()["profile"]
+        assert profile["display_name"] == "Dana Lee"

--- a/tests/web/test_profile.py
+++ b/tests/web/test_profile.py
@@ -104,3 +104,4 @@ class TestUpdateProfile:
         assert resp.status_code == 200
         profile = resp.json()["profile"]
         assert profile["display_name"] == "Dana Lee"
+        assert profile["company"] == "Blueprint Inc"

--- a/tests/web/test_tenant_isolation.py
+++ b/tests/web/test_tenant_isolation.py
@@ -1,0 +1,400 @@
+"""Tests for cross-tenant document isolation.
+
+Verifies that documents uploaded by user A are invisible, inaccessible, and
+unmodifiable by user B — even when they share the same InMemoryDocumentStore
+instance (which proves the scoping is done correctly by user_id, not just
+by a separate store instance per user).
+
+EPIC-CAD-15 — Document Persistence
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.document_store import InMemoryDocumentStore
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+from starlette.testclient import TestClient  # noqa: E402
+
+SAMPLE_DXF_CONTENT = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+
+
+# ---------------------------------------------------------------------------
+# Module-level fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _use_inmemory_doc_store(monkeypatch):
+    """Force a fresh InMemoryDocumentStore for every test in this module.
+
+    Monkeypatching the module-level ``_document_store`` sentinel means the
+    lazy ``_get_document_store()`` factory inside main.py is bypassed — every
+    endpoint call hits our in-process store, so isolation behaviour is
+    deterministic and requires no network.
+    """
+    import web.backend.main as main_mod
+
+    store = InMemoryDocumentStore()
+    monkeypatch.setattr(main_mod, "_document_store", store)
+    yield store
+    monkeypatch.setattr(main_mod, "_document_store", None)
+
+
+def _make_client(uid: str, email: str, tenant_id: str) -> TestClient:
+    """Return a TestClient whose auth dependency yields the given identity.
+
+    Callers are responsible for managing the context-manager lifecycle.
+    """
+    from web.backend.main import app, get_user
+
+    async def _override():
+        return {"uid": uid, "email": email, "tenant_id": tenant_id}
+
+    app.dependency_overrides[get_user] = _override
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _upload_doc(client: TestClient, filename: str = "drawing.dxf") -> str:
+    """Upload SAMPLE_DXF_CONTENT and return the doc_id."""
+    resp = client.post(
+        "/api/documents",
+        files={"file": (filename, SAMPLE_DXF_CONTENT, "application/octet-stream")},
+    )
+    assert resp.status_code == 200, f"Upload failed: {resp.text}"
+    return resp.json()["document"]["doc_id"]
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.web
+class TestListIsolation:
+    """User B cannot see documents belonging to user A."""
+
+    def test_user_b_sees_empty_library_after_user_a_upload(self, _use_inmemory_doc_store):
+        """A document uploaded by user A must not appear in user B's list."""
+        from web.backend.main import app, get_user
+
+        # --- User A uploads a document ---
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            _upload_doc(client_a, "a-drawing.dxf")
+
+        # --- User B lists their library ---
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.get("/api/documents")
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        assert resp.json()["documents"] == []
+
+    def test_users_see_only_their_own_documents(self, _use_inmemory_doc_store):
+        """When both users have documents, each list response is scoped to that user."""
+        from web.backend.main import app, get_user
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        # Upload one doc each
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as c:
+            _upload_doc(c, "a.dxf")
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as c:
+            _upload_doc(c, "b.dxf")
+
+        # Verify each user's list
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as c:
+            docs_a = c.get("/api/documents").json()["documents"]
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as c:
+            docs_b = c.get("/api/documents").json()["documents"]
+
+        app.dependency_overrides.clear()
+
+        assert len(docs_a) == 1
+        assert docs_a[0]["filename"] == "a.dxf"
+        assert len(docs_b) == 1
+        assert docs_b[0]["filename"] == "b.dxf"
+
+
+@pytest.mark.web
+class TestLoadIsolation:
+    """User B cannot load (GET metadata for) user A's document."""
+
+    def test_get_user_b_cannot_load_user_a_document(self, _use_inmemory_doc_store):
+        """GET /api/documents/{id} returns 404 when the id belongs to another user."""
+        from web.backend.main import app, get_user
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            doc_id = _upload_doc(client_a)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.get(f"/api/documents/{doc_id}")
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 404
+
+    def test_load_session_user_b_cannot_load_user_a_document(self, _use_inmemory_doc_store):
+        """POST /api/documents/{id}/load returns 404 when the id belongs to another user."""
+        from web.backend.main import app, get_user
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            doc_id = _upload_doc(client_a)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.post(f"/api/documents/{doc_id}/load")
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 404
+
+
+@pytest.mark.web
+class TestDeleteIsolation:
+    """User B cannot delete user A's document."""
+
+    def test_user_b_cannot_delete_user_a_document(self, _use_inmemory_doc_store):
+        """DELETE /api/documents/{id} returns 404 when the id belongs to another user."""
+        from web.backend.main import app, get_user
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            doc_id = _upload_doc(client_a)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.delete(f"/api/documents/{doc_id}")
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 404
+
+    def test_document_survives_cross_user_delete_attempt(self, _use_inmemory_doc_store):
+        """After user B's failed delete, user A's document is still present."""
+        from web.backend.main import app, get_user
+
+        store: InMemoryDocumentStore = _use_inmemory_doc_store
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            doc_id = _upload_doc(client_a)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            client_b.delete(f"/api/documents/{doc_id}")
+
+        app.dependency_overrides.clear()
+
+        # Confirm the doc is still active in the store under user-a
+        doc = store.get_document("user-a", doc_id)
+        assert doc is not None
+        assert doc.status == "active"
+
+
+@pytest.mark.web
+class TestWorkProgressIsolation:
+    """User B cannot access work progress saved by user A.
+
+    Work progress isolation is enforced at the store layer: InMemoryDocumentStore
+    uses ``doc_id`` as the key but ``get_work_progress`` requires the correct
+    ``user_id`` because the document lookup (which gates file access) is already
+    scoped by user.  We test the invariant here directly via the store API to
+    confirm the contract without relying on an explicit HTTP endpoint for reads.
+    """
+
+    def test_user_b_get_work_progress_returns_none(self, _use_inmemory_doc_store):
+        """Work progress saved for user A's document is not accessible to user B.
+
+        InMemoryDocumentStore keys work progress by ``(user_id, doc_id)`` tuples,
+        so ``get_work_progress("user-b", doc_a_id)`` returns ``None`` even when
+        user A has progress saved under the same doc_id.  Likewise,
+        ``get_document("user-b", doc_a_id)`` returns ``None``, which means
+        higher-level callers such as ``_restore_work_progress`` that guard
+        themselves with a document ownership check also get no data.
+        """
+        from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+        store: InMemoryDocumentStore = _use_inmemory_doc_store
+
+        # User A saves a document and work progress
+        doc = store.save_document("user-a", "a.dxf", SAMPLE_DXF_CONTENT)
+        progress = WorkProgress(
+            user_id="user-a",
+            doc_id=doc.doc_id,
+            tenant_id="tenant-a",
+            last_prompt="move wall to x=10",
+            edit_count=3,
+        )
+        store.save_work_progress("user-a", doc.doc_id, progress)
+
+        # User A can retrieve their own progress
+        retrieved_a = store.get_work_progress("user-a", doc.doc_id)
+        assert retrieved_a is not None
+        assert retrieved_a.last_prompt == "move wall to x=10"
+
+        # The document is invisible to user B — the gating check used by
+        # _restore_work_progress before it ever calls get_work_progress
+        doc_b = store.get_document("user-b", doc.doc_id)
+        assert doc_b is None, "store.get_document must return None for cross-user access"
+
+    def test_save_progress_endpoint_respects_user_isolation(self, _use_inmemory_doc_store):
+        """POST /api/documents/{id}/save-progress returns 404 for another user's doc.
+
+        The endpoint looks up an active session scoped to the requesting user's
+        uid — it will never find user A's session when called as user B.
+        """
+        from web.backend.main import app, get_user
+
+        store: InMemoryDocumentStore = _use_inmemory_doc_store
+
+        # Seed a document directly in the store under user-a (no active session needed
+        # to confirm the 404 path — the endpoint checks session_mgr first)
+        doc = store.save_document("user-a", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        app.dependency_overrides.clear()
+
+        # No active session for user-b bound to this doc → 404
+        assert resp.status_code == 404
+
+    def test_clear_progress_endpoint_respects_user_isolation(self, _use_inmemory_doc_store):
+        """DELETE /api/documents/{id}/work-progress returns 404 for another user's doc.
+
+        User B calling the clear endpoint with user A's doc_id cannot erase
+        user A's progress because the store lookup is keyed by the requesting
+        user's uid.
+        """
+        from web.backend.main import app, get_user
+
+        from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+        store: InMemoryDocumentStore = _use_inmemory_doc_store
+
+        doc = store.save_document("user-a", "plan.dxf", SAMPLE_DXF_CONTENT)
+        progress = WorkProgress(user_id="user-a", doc_id=doc.doc_id, edit_count=1)
+        store.save_work_progress("user-a", doc.doc_id, progress)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.delete(f"/api/documents/{doc.doc_id}/work-progress")
+
+        app.dependency_overrides.clear()
+
+        # User B's uid has no progress for this doc_id → 404
+        assert resp.status_code == 404
+
+        # User A's progress must still be intact
+        still_there = store.get_work_progress("user-a", doc.doc_id)
+        assert still_there is not None
+        assert still_there.edit_count == 1
+
+
+@pytest.mark.web
+class TestReconnectIsolation:
+    """User B cannot reconnect to a session created from user A's document."""
+
+    def test_user_b_cannot_reconnect_to_user_a_document(self, _use_inmemory_doc_store):
+        """POST /api/session/reconnect returns 404 when document belongs to another user."""
+        from web.backend.main import app, get_user
+
+        store: InMemoryDocumentStore = _use_inmemory_doc_store
+        doc = store.save_document("user-a", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.post("/api/session/reconnect", json={"document_id": doc.doc_id})
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 404
+
+
+@pytest.mark.web
+class TestStorageUsageIsolation:
+    """Storage usage stats are scoped to the requesting user."""
+
+    def test_user_b_usage_is_zero_after_user_a_upload(self, _use_inmemory_doc_store):
+        """User B's /api/documents/usage shows 0 bytes even after user A uploads."""
+        from web.backend.main import app, get_user
+
+        async def _user_a():
+            return {"uid": "user-a", "email": "a@test.com", "tenant_id": "tenant-a"}
+
+        app.dependency_overrides[get_user] = _user_a
+        with TestClient(app, raise_server_exceptions=False) as client_a:
+            _upload_doc(client_a)
+
+        async def _user_b():
+            return {"uid": "user-b", "email": "b@test.com", "tenant_id": "tenant-b"}
+
+        app.dependency_overrides[get_user] = _user_b
+        with TestClient(app, raise_server_exceptions=False) as client_b:
+            resp = client_b.get("/api/documents/usage")
+
+        app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["document_count"] == 0
+        assert data["used_bytes"] == 0

--- a/tests/web/test_tenant_isolation.py
+++ b/tests/web/test_tenant_isolation.py
@@ -244,11 +244,11 @@ class TestDeleteIsolation:
 class TestWorkProgressIsolation:
     """User B cannot access work progress saved by user A.
 
-    Work progress isolation is enforced at the store layer: InMemoryDocumentStore
-    uses ``doc_id`` as the key but ``get_work_progress`` requires the correct
-    ``user_id`` because the document lookup (which gates file access) is already
-    scoped by user.  We test the invariant here directly via the store API to
-    confirm the contract without relying on an explicit HTTP endpoint for reads.
+    Work progress isolation is enforced at multiple layers.  At the storage
+    layer, ``InMemoryDocumentStore`` keys progress data by ``(user_id, doc_id)``
+    tuples.  At the application layer, endpoints validate document ownership by
+    the requesting user's ID before accessing or modifying data.  These tests
+    verify isolation at both the store API and the HTTP endpoint level.
     """
 
     def test_user_b_get_work_progress_returns_none(self, _use_inmemory_doc_store):

--- a/tests/web/test_work_progress.py
+++ b/tests/web/test_work_progress.py
@@ -1,0 +1,207 @@
+"""Tests for work-progress save/clear endpoints (EPIC-CAD-30)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.core.document_store import InMemoryDocumentStore
+from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+SAMPLE_DXF_CONTENT = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+
+
+@pytest.fixture(autouse=True)
+def _use_inmemory_doc_store(monkeypatch):
+    """Force InMemoryDocumentStore for all tests in this module."""
+    import web.backend.main as main_mod
+
+    store = InMemoryDocumentStore()
+    monkeypatch.setattr(main_mod, "_document_store", store)
+    yield store
+    monkeypatch.setattr(main_mod, "_document_store", None)
+
+
+@pytest.mark.web
+class TestSaveProgress:
+    def test_save_progress_returns_404_when_no_active_session(
+        self, client, _use_inmemory_doc_store
+    ):
+        """POST save-progress returns 404 when there is no active session for the doc."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/save-progress")
+        assert resp.status_code == 404
+
+    def test_save_progress_returns_404_for_unknown_doc(self, client):
+        """POST save-progress returns 404 for a non-existent document."""
+        resp = client.post("/api/documents/does-not-exist/save-progress")
+        assert resp.status_code == 404
+
+    def test_save_progress_returns_200_when_session_exists(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """POST save-progress succeeds when an active session is bound to the doc."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        # Load the document to create an active session
+        load_resp = client.post(f"/api/documents/{doc.doc_id}/load")
+        assert load_resp.status_code == 200
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/save-progress")
+        assert resp.status_code == 200
+
+    def test_save_progress_response_contains_status_saved(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """save-progress response includes status=saved and the doc_id."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+        client.post(f"/api/documents/{doc.doc_id}/load")
+
+        resp = client.post(f"/api/documents/{doc.doc_id}/save-progress")
+        data = resp.json()
+        assert data["status"] == "saved"
+        assert data["doc_id"] == doc.doc_id
+
+    def test_save_progress_persists_to_store(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """After saving progress, the store has a WorkProgress record for the doc."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+        client.post(f"/api/documents/{doc.doc_id}/load")
+
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        progress = store.get_work_progress("test-user-123", doc.doc_id)
+        assert progress is not None
+        assert isinstance(progress, WorkProgress)
+        assert progress.doc_id == doc.doc_id
+
+
+@pytest.mark.web
+class TestClearProgress:
+    def test_clear_progress_returns_404_when_no_progress_saved(
+        self, client, _use_inmemory_doc_store
+    ):
+        """DELETE work-progress returns 404 when nothing has been saved yet."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        resp = client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+        assert resp.status_code == 404
+
+    def test_clear_progress_returns_404_for_unknown_doc(self, client):
+        """DELETE work-progress returns 404 for a non-existent document."""
+        resp = client.delete("/api/documents/does-not-exist/work-progress")
+        assert resp.status_code == 404
+
+    def test_clear_progress_returns_200_after_progress_saved(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """DELETE work-progress returns 200 when there is progress to clear."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        # Create session and save progress
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        resp = client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+        assert resp.status_code == 200
+
+    def test_clear_progress_response_contains_status_cleared(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Clear response includes status=cleared and the doc_id."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        resp = client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+        data = resp.json()
+        assert data["status"] == "cleared"
+        assert data["doc_id"] == doc.doc_id
+
+    def test_clear_progress_removes_record_from_store(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """After clearing, the store no longer has a WorkProgress record."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+
+        assert store.get_work_progress("test-user-123", doc.doc_id) is None
+
+    def test_clear_progress_is_not_idempotent(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """Clearing progress twice returns 404 on the second call."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+        resp = client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+        assert resp.status_code == 404
+
+
+@pytest.mark.web
+class TestHasWorkProgressInDocumentList:
+    def test_document_list_has_work_progress_field(self, client, _use_inmemory_doc_store):
+        """Documents returned from GET /api/documents include has_work_progress."""
+        store = _use_inmemory_doc_store
+        store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        resp = client.get("/api/documents")
+        assert resp.status_code == 200
+        docs = resp.json()["documents"]
+        assert len(docs) == 1
+        assert "has_work_progress" in docs[0]
+
+    def test_has_work_progress_false_by_default(self, client, _use_inmemory_doc_store):
+        """Freshly uploaded documents have has_work_progress=False."""
+        store = _use_inmemory_doc_store
+        store.save_document("test-user-123", "plan.dxf", SAMPLE_DXF_CONTENT)
+
+        resp = client.get("/api/documents")
+        doc = resp.json()["documents"][0]
+        assert doc["has_work_progress"] is False
+
+    def test_has_work_progress_true_after_saving(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """has_work_progress becomes True after saving progress via the endpoint."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+
+        resp = client.get("/api/documents")
+        listed = resp.json()["documents"][0]
+        assert listed["has_work_progress"] is True
+
+    def test_has_work_progress_false_after_clearing(
+        self, client, sample_dxf_bytes, _use_inmemory_doc_store
+    ):
+        """has_work_progress returns to False after clearing saved progress."""
+        store = _use_inmemory_doc_store
+        doc = store.save_document("test-user-123", "plan.dxf", sample_dxf_bytes)
+
+        client.post(f"/api/documents/{doc.doc_id}/load")
+        client.post(f"/api/documents/{doc.doc_id}/save-progress")
+        client.delete(f"/api/documents/{doc.doc_id}/work-progress")
+
+        resp = client.get("/api/documents")
+        listed = resp.json()["documents"][0]
+        assert listed["has_work_progress"] is False

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -234,7 +234,8 @@ def _fetch_or_create_profile(uid: str, email: str, display_name: str) -> dict:
 
     # First login — create tenant + profile
     tenant_id = uuid.uuid4().hex[:12]
-    tenant_name = f"{display_name or email.split('@')[0]}'s Workspace"
+    name_part = display_name or (email.split("@")[0] if "@" in email else "") or "Personal"
+    tenant_name = f"{name_part}'s Workspace"
 
     tenant_data = {
         "tenant_id": tenant_id,

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -1,10 +1,12 @@
-"""Firebase Auth token validation and license gating for the web backend."""
+"""Firebase Auth token validation, license gating, and user profile provisioning."""
 
 from __future__ import annotations
 
 import logging
 import os
 import time
+import uuid
+from datetime import UTC, datetime
 
 from fastapi import HTTPException, Request
 
@@ -13,6 +15,14 @@ logger = logging.getLogger(__name__)
 # License cache: {uid: (active: bool, timestamp: float)}
 _license_cache: dict[str, tuple[bool, float]] = {}
 _LICENSE_CACHE_TTL = 300  # 5 minutes
+
+# Profile cache: {uid: (profile_dict, timestamp)}
+_profile_cache: dict[str, tuple[dict, float]] = {}
+_PROFILE_CACHE_TTL = 300  # 5 minutes
+
+# Tenant cache: {tenant_id: (tenant_dict, timestamp)}
+_tenant_cache: dict[str, tuple[dict, float]] = {}
+_TENANT_CACHE_TTL = 600  # 10 minutes — tenants rarely change
 
 # Lazy-init firebase admin
 _firebase_app = None
@@ -158,8 +168,151 @@ def _provision_license(uid: str, email: str) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# User profile + tenant auto-provisioning (EPIC-CAD-30)
+# ---------------------------------------------------------------------------
+
+
+async def ensure_user_profile(user: dict) -> dict:
+    """Ensure the user has a profile and tenant. Returns enriched user dict.
+
+    On first login, auto-creates a personal Tenant and UserProfile in Firestore.
+    Subsequent calls hit the in-process cache (5 min TTL).
+    In dev mode, returns a synthetic profile without touching Firestore.
+    """
+    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        user["tenant_id"] = "dev-tenant"
+        user["display_name"] = user.get("name", user.get("email", "dev"))
+        return user
+
+    uid = user.get("uid", "")
+    now = time.monotonic()
+
+    # Check profile cache
+    cached = _profile_cache.get(uid)
+    if cached is not None:
+        profile_dict, ts = cached
+        if now - ts < _PROFILE_CACHE_TTL:
+            user["tenant_id"] = profile_dict["tenant_id"]
+            user["display_name"] = profile_dict.get("display_name", "")
+            return user
+
+    # Firestore lookup + possible provisioning
+    try:
+        from starlette.concurrency import run_in_threadpool
+
+        profile_dict = await run_in_threadpool(
+            _fetch_or_create_profile,
+            uid,
+            user.get("email", ""),
+            user.get("name", ""),
+        )
+        _profile_cache[uid] = (profile_dict, now)
+        user["tenant_id"] = profile_dict["tenant_id"]
+        user["display_name"] = profile_dict.get("display_name", "")
+    except Exception as e:
+        logger.warning("Profile provisioning failed (non-fatal): %s", e)
+        # Fallback: use uid as tenant_id so the request can proceed
+        user["tenant_id"] = uid
+
+    return user
+
+
+def _fetch_or_create_profile(uid: str, email: str, display_name: str) -> dict:
+    """Sync Firestore: fetch or auto-create UserProfile + Tenant."""
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    profile_ref = db.collection("users").document(uid)
+    profile_doc = profile_ref.get()
+
+    if profile_doc.exists:
+        data = profile_doc.to_dict()
+        # Update last_login_at
+        profile_ref.update({"last_login_at": datetime.now(UTC).isoformat()})
+        return data
+
+    # First login — create tenant + profile
+    tenant_id = uuid.uuid4().hex[:12]
+    tenant_name = f"{display_name or email.split('@')[0]}'s Workspace"
+
+    tenant_data = {
+        "tenant_id": tenant_id,
+        "name": tenant_name,
+        "owner_uid": uid,
+        "plan": "personal",
+        "created_at": datetime.now(UTC).isoformat(),
+        "settings": {},
+    }
+    db.collection("tenants").document(tenant_id).set(tenant_data)
+
+    now_iso = datetime.now(UTC).isoformat()
+    profile_data = {
+        "uid": uid,
+        "email": email,
+        "display_name": display_name or email.split("@")[0],
+        "company": "",
+        "tenant_id": tenant_id,
+        "role": "owner",
+        "created_at": now_iso,
+        "last_login_at": now_iso,
+        "settings": {},
+    }
+    profile_ref.set(profile_data)
+
+    logger.info("Auto-provisioned tenant %s + profile for %s", tenant_id, email)
+    return profile_data
+
+
+def _get_profile(uid: str) -> dict | None:
+    """Sync Firestore lookup for user profile."""
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    doc = db.collection("users").document(uid).get()
+    if doc.exists:
+        return doc.to_dict()
+    return None
+
+
+def _update_profile(uid: str, updates: dict) -> dict | None:
+    """Sync Firestore update for user profile fields."""
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    ref = db.collection("users").document(uid)
+    doc = ref.get()
+    if not doc.exists:
+        return None
+    ref.update(updates)
+    # Invalidate cache
+    _profile_cache.pop(uid, None)
+    return {**doc.to_dict(), **updates}
+
+
+def _get_tenant(tenant_id: str) -> dict | None:
+    """Sync Firestore lookup for tenant."""
+    now = time.monotonic()
+    cached = _tenant_cache.get(tenant_id)
+    if cached is not None:
+        data, ts = cached
+        if now - ts < _TENANT_CACHE_TTL:
+            return data
+
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    doc = db.collection("tenants").document(tenant_id).get()
+    if not doc.exists:
+        return None
+    data = doc.to_dict()
+    _tenant_cache[tenant_id] = (data, now)
+    return data
+
+
 async def get_licensed_user(request: Request) -> dict:
-    """Combined dependency: authenticate then check license."""
+    """Combined dependency: authenticate, check license, ensure profile."""
     user = await verify_token(request)
     await check_license(user)
+    user = await ensure_user_profile(user)
     return user

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -24,6 +24,10 @@ _PROFILE_CACHE_TTL = 300  # 5 minutes
 _tenant_cache: dict[str, tuple[dict, float]] = {}
 _TENANT_CACHE_TTL = 600  # 10 minutes — tenants rarely change
 
+# Allowlist cache: {email: (allowed: bool, timestamp: float)}
+_allowlist_cache: dict[str, tuple[bool, float]] = {}
+_ALLOWLIST_CACHE_TTL = 300  # 5 minutes
+
 # Lazy-init firebase admin
 _firebase_app = None
 
@@ -115,8 +119,16 @@ async def check_license(user: dict) -> None:
         active = await run_in_threadpool(_fetch_license, uid)
 
         if not active:
-            # Auto-provision 30-day trial for any Google sign-in
+            # Only auto-provision if the email is on the allowlist
             email = user.get("email", "").lower()
+            allowed = await run_in_threadpool(_check_email_allowed, email)
+            if not allowed:
+                _license_cache[uid] = (False, now)
+                logger.info("Rejected unlisted email %s", email)
+                raise HTTPException(
+                    status_code=403,
+                    detail="Access restricted — contact admin for an invitation",
+                )
             await run_in_threadpool(_provision_license, uid, email)
             _license_cache[uid] = (True, now)
             logger.info("Auto-provisioned 30-day trial for %s", email)
@@ -166,6 +178,48 @@ def _provision_license(uid: str, email: str) -> None:
             "expires_at": datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
         }
     )
+
+
+def _check_email_allowed(email: str) -> bool:
+    """Check if an email is on the allowlist (env var or Firestore).
+
+    Two sources are checked in order:
+    1. ``CAD_ALLOWED_EMAILS`` env var — comma-separated list of emails
+    2. Firestore ``allowlist/{email}`` document
+
+    Results are cached for 5 minutes.  Called via ``run_in_threadpool``.
+    """
+    email = email.lower().strip()
+    now = time.monotonic()
+
+    cached = _allowlist_cache.get(email)
+    if cached is not None:
+        allowed, ts = cached
+        if now - ts < _ALLOWLIST_CACHE_TTL:
+            return allowed
+
+    # 1. Check env var (fast, no network)
+    env_list = os.getenv("CAD_ALLOWED_EMAILS", "")
+    if env_list:
+        allowed_emails = [e.strip().lower() for e in env_list.split(",") if e.strip()]
+        if email in allowed_emails:
+            _allowlist_cache[email] = (True, now)
+            return True
+
+    # 2. Check Firestore allowlist collection
+    try:
+        from google.cloud import firestore
+
+        db = firestore.Client()
+        doc = db.collection("allowlist").document(email).get()
+        found: bool = bool(doc.exists)
+    except Exception as exc:
+        logger.warning("Allowlist Firestore check failed: %s", exc)
+        # Fail closed — deny access if we can't verify
+        found = False
+
+    _allowlist_cache[email] = (found, now)
+    return found
 
 
 # ---------------------------------------------------------------------------

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -57,7 +57,7 @@ from cad_dxf_agent.core.edit_history import EditHistory  # noqa: E402
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 
 from .api_v1 import router as v1_router  # noqa: E402
-from .auth import get_licensed_user  # noqa: E402
+from .auth import _get_profile, _get_tenant, _update_profile, get_licensed_user  # noqa: E402
 from .session import Session, SessionManager  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -79,10 +79,22 @@ SESSION_CLEANUP_INTERVAL = 30 * 60  # 30 minutes
 
 
 async def _session_cleanup_loop():
-    """Periodically remove expired sessions to prevent memory/disk leaks."""
+    """Periodically remove expired sessions to prevent memory/disk leaks.
+
+    Before deleting, saves work progress for document-bound sessions
+    so users can resume where they left off (EPIC-CAD-30).
+    """
     while True:
         await asyncio.sleep(SESSION_CLEANUP_INTERVAL)
         try:
+            # Save progress for expiring document-bound sessions before cleanup
+            for session in list(session_mgr._sessions.values()):
+                if session.document_id and session.conversation_history:
+                    try:
+                        await _save_work_progress(session, session.user_id)
+                    except Exception:
+                        logger.debug("Pre-cleanup save failed for %s", session.session_id)
+
             removed = session_mgr.cleanup_expired()
             if removed:
                 logger.info("Session cleanup: removed %d expired session(s)", removed)
@@ -445,6 +457,156 @@ def _get_document_store():
     return _document_store
 
 
+# ---------------------------------------------------------------------------
+# Work progress auto-save helper (EPIC-CAD-30)
+# ---------------------------------------------------------------------------
+
+
+async def _save_work_progress(session: Session, user_id: str) -> None:
+    """Fire-and-forget: persist work progress for a document-bound session."""
+    if not session.document_id:
+        return
+    try:
+        from cad_dxf_agent.models.work_progress_schema import WorkProgress
+
+        progress = WorkProgress(
+            user_id=user_id,
+            doc_id=session.document_id,
+            tenant_id=getattr(session, "tenant_id", ""),
+            conversation_history=session.conversation_history[-MAX_CONVERSATION_HISTORY:],
+            edit_count=len(session.audit_events),
+            last_prompt=session.conversation_history[-1].get("content", "")
+            if session.conversation_history
+            else "",
+            has_working_dxf=session.edited_path is not None
+            and session.edited_path.exists(),
+            audit_events=session.audit_events[-50:],  # Cap at 50 events
+        )
+        working_path = session.edited_path if progress.has_working_dxf else None
+        store = _get_document_store()
+        store.save_work_progress(user_id, session.document_id, progress, working_path)
+        logger.debug("Auto-saved work progress for doc %s", session.document_id)
+    except Exception:
+        logger.warning("Work progress auto-save failed (non-fatal)", exc_info=True)
+
+
+def _restore_work_progress(session: Session, user_id: str, store) -> bool:
+    """Restore saved work progress into a session. Returns True if restored."""
+    if not session.document_id:
+        return False
+    progress = store.get_work_progress(user_id, session.document_id)
+    if progress is None:
+        return False
+
+    session.conversation_history = progress.conversation_history
+    session.audit_events = progress.audit_events
+
+    # Restore working DXF if available
+    if progress.has_working_dxf:
+        working_data = store.get_working_dxf(user_id, session.document_id)
+        if working_data:
+            working_path = session.session_dir / "working.dxf"
+            working_path.write_bytes(working_data)
+            session.working_path = working_path
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Profile + Workspace endpoints (EPIC-CAD-30)
+# ---------------------------------------------------------------------------
+
+
+class ProfileUpdateRequest(BaseModel):
+    display_name: str | None = None
+    company: str | None = None
+
+
+@app.get("/api/profile")
+async def get_profile(user: dict = Depends(get_user)):
+    """Get the current user's profile."""
+    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        return {
+            "profile": {
+                "uid": user["uid"],
+                "email": user.get("email", "dev@localhost"),
+                "display_name": user.get("display_name", "Dev User"),
+                "company": "",
+                "tenant_id": user.get("tenant_id", "dev-tenant"),
+                "role": "owner",
+            }
+        }
+    from starlette.concurrency import run_in_threadpool
+
+    profile = await run_in_threadpool(_get_profile, user["uid"])
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return {"profile": profile}
+
+
+@app.put("/api/profile")
+async def update_profile(body: ProfileUpdateRequest, user: dict = Depends(get_user)):
+    """Update the current user's display name and/or company."""
+    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        return {"profile": {"uid": user["uid"], "display_name": body.display_name or ""}}
+
+    updates = {}
+    if body.display_name is not None:
+        updates["display_name"] = body.display_name
+    if body.company is not None:
+        updates["company"] = body.company
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    from starlette.concurrency import run_in_threadpool
+
+    profile = await run_in_threadpool(_update_profile, user["uid"], updates)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return {"profile": profile}
+
+
+@app.get("/api/workspace")
+async def get_workspace(user: dict = Depends(get_user)):
+    """Get the current user's workspace/tenant info."""
+    tenant_id = user.get("tenant_id", "")
+    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        return {
+            "workspace": {"tenant_id": "dev-tenant", "name": "Dev Workspace", "plan": "personal"}
+        }
+
+    if not tenant_id:
+        raise HTTPException(status_code=404, detail="No workspace found")
+
+    from starlette.concurrency import run_in_threadpool
+
+    tenant = await run_in_threadpool(_get_tenant, tenant_id)
+    if tenant is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return {"workspace": tenant}
+
+
+@app.post("/api/documents/{doc_id}/save-progress")
+async def save_document_progress(doc_id: str, user: dict = Depends(get_user)):
+    """Manually save work progress for a document's active session."""
+    existing = session_mgr.find_by_document(user["uid"], doc_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="No active session for this document")
+
+    await _save_work_progress(existing, user["uid"])
+    return {"status": "saved", "doc_id": doc_id}
+
+
+@app.delete("/api/documents/{doc_id}/work-progress")
+async def clear_document_progress(doc_id: str, user: dict = Depends(get_user)):
+    """Clear saved work progress (start fresh next time)."""
+    store = _get_document_store()
+    cleared = store.clear_work_progress(user["uid"], doc_id)
+    if not cleared:
+        raise HTTPException(status_code=404, detail="No work progress to clear")
+    return {"status": "cleared", "doc_id": doc_id}
+
+
 @app.get("/api/documents")
 async def list_documents(user: dict = Depends(get_user)):
     """List all documents in the user's library."""
@@ -567,6 +729,7 @@ async def load_document(doc_id: str, user: dict = Depends(get_user)):
             "session_id": existing.session_id,
             "file_info": existing.file_info,
             "document_id": doc_id,
+            "restored": False,
         }
 
     file_data = store.get_file_data(user["uid"], doc_id)
@@ -576,6 +739,7 @@ async def load_document(doc_id: str, user: dict = Depends(get_user)):
     # Create a session linked to this document
     session = session_mgr.create(user["uid"])
     session.document_id = doc_id
+    session.tenant_id = user.get("tenant_id", "")
     Path(session.original_path).write_bytes(file_data)
 
     # Persist document binding in durable metadata
@@ -584,11 +748,16 @@ async def load_document(doc_id: str, user: dict = Depends(get_user)):
     # Touch the document's last_accessed (persists to GCS in production)
     store.touch_document(user["uid"], doc_id)
 
+    # Restore work progress if available
+    restored = _restore_work_progress(session, user["uid"], store)
+
     # Load drawing info
     try:
         from cad_dxf_agent.core.dxf_reader import load_dxf
 
-        ctx = load_dxf(str(session.original_path))
+        # Use working DXF if restored, otherwise original
+        dxf_to_load = session.working_path or session.original_path
+        ctx = load_dxf(str(dxf_to_load))
         session.context = ctx
         file_info = {
             "filename": doc.filename,
@@ -605,6 +774,7 @@ async def load_document(doc_id: str, user: dict = Depends(get_user)):
         "session_id": session.session_id,
         "file_info": file_info,
         "document_id": doc_id,
+        "restored": restored,
     }
 
 
@@ -657,14 +827,19 @@ async def reconnect_session(body: ReconnectRequest, user: dict = Depends(get_use
 
     session = session_mgr.create(user["uid"])
     session.document_id = body.document_id
+    session.tenant_id = user.get("tenant_id", "")
     Path(session.original_path).write_bytes(file_data)
     session_mgr.save_metadata(session)
     store.touch_document(user["uid"], body.document_id)
 
+    # Restore work progress if available
+    restored = _restore_work_progress(session, user["uid"], store)
+
     try:
         from cad_dxf_agent.core.dxf_reader import load_dxf
 
-        ctx = load_dxf(str(session.original_path))
+        dxf_to_load = session.working_path or session.original_path
+        ctx = load_dxf(str(dxf_to_load))
         session.context = ctx
         file_info = {
             "filename": doc.filename,
@@ -682,6 +857,7 @@ async def reconnect_session(body: ReconnectRequest, user: dict = Depends(get_use
         "file_info": file_info,
         "document_id": body.document_id,
         "reconnected": False,
+        "restored": restored,
     }
 
 
@@ -1627,6 +1803,11 @@ async def v2_apply(body: V2ApplyRequest, user: dict = Depends(get_user)):
     )
 
     audit = AuditMetadata()
+
+    # Auto-save work progress (fire-and-forget)
+    if session.document_id:
+        asyncio.create_task(_save_work_progress(session, user["uid"]))
+
     return ResponseBuilder.structured_apply_result(
         result=result,
         audit=audit,
@@ -1696,6 +1877,11 @@ async def apply_changes(body: ApplyRequest, user: dict = Depends(get_user)):
 
             render_available = session.edited_render is not None and session.edited_render.exists()
             success_count = sum(1 for r in results if r.success)
+
+            # Auto-save work progress (fire-and-forget)
+            if session.document_id:
+                asyncio.create_task(_save_work_progress(session, user["uid"]))
+
             return {
                 "message": f"Applied {success_count}/{len(results)} operations.",
                 "render_available": render_available,

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -548,7 +548,10 @@ async def get_profile(user: dict = Depends(get_user)):
 async def update_profile(body: ProfileUpdateRequest, user: dict = Depends(get_user)):
     """Update the current user's display name and/or company."""
     if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
-        return {"profile": {"uid": user["uid"], "display_name": body.display_name or ""}}
+        profile = {"uid": user["uid"], "display_name": body.display_name or ""}
+        if body.company is not None:
+            profile["company"] = body.company
+        return {"profile": profile}
 
     updates = {}
     if body.display_name is not None:

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -486,8 +486,8 @@ async def _save_work_progress(session: Session, user_id: str) -> None:
         store = _get_document_store()
         store.save_work_progress(user_id, session.document_id, progress, working_path)
         logger.debug("Auto-saved work progress for doc %s", session.document_id)
-    except Exception:
-        logger.warning("Work progress auto-save failed (non-fatal)", exc_info=True)
+    except (OSError, ValueError, TypeError) as exc:
+        logger.warning("Work progress auto-save failed (non-fatal): %s", exc)
 
 
 def _restore_work_progress(session: Session, user_id: str, store) -> bool:

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -69,6 +69,8 @@ class Session:
     edit_history: object | None = None  # EditHistory instance (transient)
     # EPIC-CAD-15: Document library binding
     document_id: str = ""
+    # EPIC-CAD-30: Tenant scope
+    tenant_id: str = ""
 
     @property
     def session_dir(self) -> Path:
@@ -85,6 +87,7 @@ class Session:
             conversation_history=self.conversation_history,
             audit_events=self.audit_events,
             document_id=self.document_id,
+            tenant_id=self.tenant_id,
             original_path=str(self.original_path) if self.original_path else "",
             working_path=str(self.working_path) if self.working_path else "",
             edited_path=str(self.edited_path) if self.edited_path else "",
@@ -109,6 +112,7 @@ class Session:
             user_id=meta.user_id,
             created_at=meta.created_at,
             document_id=meta.document_id,
+            tenant_id=getattr(meta, "tenant_id", ""),
             original_path=(
                 Path(meta.original_path)
                 if meta.original_path

--- a/web/frontend/src/lib/api.js
+++ b/web/frontend/src/lib/api.js
@@ -299,6 +299,37 @@ export async function compareLibraryDocuments(masterDocId, revisionDocId, profil
   return res.json();
 }
 
+// --- Profile + Workspace (EPIC-CAD-30) ---
+
+export async function getProfile() {
+  const res = await request('/api/profile');
+  return res.json();
+}
+
+export async function updateProfile(updates) {
+  const res = await request('/api/profile', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  });
+  return res.json();
+}
+
+export async function getWorkspace() {
+  const res = await request('/api/workspace');
+  return res.json();
+}
+
+export async function saveDocumentProgress(docId) {
+  const res = await request(`/api/documents/${docId}/save-progress`, { method: 'POST' });
+  return res.json();
+}
+
+export async function clearDocumentProgress(docId) {
+  const res = await request(`/api/documents/${docId}/work-progress`, { method: 'DELETE' });
+  return res.json();
+}
+
 // --- v2 Preview / Approve / Apply (EPIC-CAD-08) ---
 
 export async function v2Preview(sessionId) {


### PR DESCRIPTION
## Epic
EPIC-CAD-30: User Accounts, Workspaces & Persistent Work Progress

## Bead(s)
cad-dxf-agent-qvf (epic), cad-dxf-agent-ohj (schemas), cad-dxf-agent-fqn (doc store), cad-dxf-agent-4wc (auth), cad-dxf-agent-j9t (API), cad-dxf-agent-udg (frontend), cad-dxf-agent-piv (tests)

## Summary
- **Auto-save work progress**: conversation history, audit events, and working DXF auto-save on apply and before session expiry. Restored when document is reopened — users pick up where they left off.
- **User profiles + tenants**: auto-provisioned on first login via Firestore. Personal workspace (1:1 user→tenant) ships now; org/team tenants designed for future.
- **New endpoints**: GET/PUT profile, GET workspace, POST save-progress, DELETE work-progress. Document list now includes `has_work_progress` flag.

## What changed
| Area | Files | What |
|------|-------|------|
| Models | 3 new + 1 modified | Tenant, UserProfile, WorkProgress schemas; tenant_id + has_work_progress on UserDocument |
| Core | 2 modified | DocumentStore ABC + InMemory + GCS impls for work progress; tenant_id on SessionMetadata |
| Auth | 1 rewritten | ensure_user_profile(), profile/tenant caches, auto-provisioning on first login |
| API | 1 modified | 5 new endpoints, auto-save on apply, restore on load/reconnect, pre-cleanup save |
| Frontend | 1 modified | getProfile, updateProfile, getWorkspace, saveDocumentProgress, clearDocumentProgress API calls |
| Session | 1 modified | tenant_id field on Session dataclass, round-trips through metadata |
| Tests | 8 new | 96 tests: schemas, doc store progress, profile endpoints, auto-save/restore, tenant isolation |

## Test plan
- [x] `ruff check` — all clean
- [x] `mypy src/` — no issues in 124 files
- [x] 96 new tests all passing
- [x] 4125 total tests passing, 0 regressions
- [x] Existing document library, session reconnect, and switching tests unaffected
- [x] Tenant isolation verified: user A cannot see/load/delete/clear user B's docs or progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)