### PR TITLE
feat(converter): tighten PDF-to-DXF conversion fidelity

### DIFF
--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -10,6 +10,7 @@ PDF conversion extracts vector geometry from CAD-generated PDFs only.
 from __future__ import annotations
 
 import logging
+import re
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -363,6 +364,10 @@ PDF_PAGE_GAP = 50.0  # gap between pages in DXF units (~17.6mm)
 PDF_MIN_ENTITY_SIZE = 1.0
 PDF_MAX_HATCH_ENTITIES = 500
 
+# PDF bbox height includes ascenders/descenders and line spacing padding.
+# Empirical ratio to approximate the actual glyph cap-height from bbox height.
+PDF_TEXT_HEIGHT_RATIO = 0.7
+
 # DXF lineweight range (hundredths of mm): 13 (0.13mm) to 211 (2.11mm)
 _DXF_LW_MIN = 13
 _DXF_LW_MAX = 211
@@ -394,8 +399,6 @@ def _parse_pdf_dashes(dashes) -> list[float]:
             return []
     if isinstance(dashes, str):
         # Parse "[3 2] 0" format — extract numbers inside brackets
-        import re
-
         match = re.search(r"\[([^\]]*)\]", dashes)
         if not match:
             return []
@@ -429,27 +432,29 @@ def _classify_dash_pattern(dash_values: list[float]) -> str:
 
     ratio = dash_len / gap_len
 
-    # Dot pattern: very short dash relative to gap
+    # Dot: dash segment < 1pt is a rendered dot (typical PDF dot = 0.5pt or less)
     if dash_len < 1.0:
         return "DOT"
 
-    # Dash-dot: 4+ element pattern (dash, gap, dot, gap)
+    # Multi-element patterns: [dash, gap, dot, gap, ...] indicate dash-dot styles.
+    # The 3rd element being < 30% of the 1st indicates a "dot" between dashes.
     if len(dash_values) >= 4:
         dot_len = dash_values[2]
         if dot_len < dash_len * 0.3:
+            # 6+ elements = CENTER (dash-dot-dash), 4 = DASHDOT (dash-dot)
             if len(dash_values) >= 6:
-                return "CENTER"  # dash-dot-dash pattern
+                return "CENTER"
             return "DASHDOT"
 
-    # Short dashes (ratio near 1:1)
-    if 0.3 < ratio < 3.0:
+    # 2-element patterns: classify by dash/gap ratio.
+    # Ratio 0.3-3.0 covers standard dashed lines (e.g., [3,2]=1.5, [6,3]=2.0).
+    # Ratio ≥3.0 = long dashes with tight gaps — still reads as dashed.
+    if ratio >= 0.3:
         return "DASHED"
 
-    # Long dashes with short gaps
-    if ratio >= 3.0:
-        return "DASHED"
-
-    return "DASHED"
+    # Ratio < 0.3 = very short dash, long gap — unusual, treat as continuous
+    # rather than guessing wrong.
+    return "CONTINUOUS"
 
 
 def _create_fill_hatch(msp, path_item, x_offset, page_height, layer, hatch_count):
@@ -513,7 +518,6 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
     import math
 
     import fitz
-    from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
 
     min_size = settings.pdf_min_entity_size
     pdf_doc = fitz.open(str(source_path))
@@ -610,9 +614,6 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                             page_height,
                             x_offset,
                             attribs,
-                            Bezier4P,
-                            Vec2,
-                            bezier_to_bspline,
                         )
                     if entity is not None:
                         _set_entity_rgb(entity, stroke_rgb)
@@ -656,7 +657,7 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                     if font_size and float(font_size) > 0:
                         height = float(font_size)
                     else:
-                        height = max(float(bbox[3]) - float(bbox[1]), 1.0) * 0.7
+                        height = max(float(bbox[3]) - float(bbox[1]), 1.0) * PDF_TEXT_HEIGHT_RATIO
 
                     # Extract text color from PyMuPDF packed int
                     span_color_int = span.get("color", 0)
@@ -787,32 +788,22 @@ def _fit_arc_from_bezier(p1, p2, p3, p4, page_height: float):
     return (ux, uy, radius, start_angle, end_angle)
 
 
-def _bezier_to_spline(
-    msp,
-    p1,
-    p2,
-    p3,
-    p4,
-    page_height,
-    x_offset,
-    attribs,
-    bezier4p_cls,
-    vec2_cls,
-    bspline_fn,
-):
+def _bezier_to_spline(msp, p1, p2, p3, p4, page_height, x_offset, attribs):
     """Create a native DXF SPLINE from cubic Bezier control points.
 
     Uses ezdxf's bezier_to_bspline() for exact curve preservation. Falls back
     to an adaptive polyline if the BSpline conversion fails unexpectedly.
     """
+    from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
+
     try:
         ctrl = [
-            vec2_cls(x_offset + float(p1.x), page_height - float(p1.y)),
-            vec2_cls(x_offset + float(p2.x), page_height - float(p2.y)),
-            vec2_cls(x_offset + float(p3.x), page_height - float(p3.y)),
-            vec2_cls(x_offset + float(p4.x), page_height - float(p4.y)),
+            Vec2(x_offset + float(p1.x), page_height - float(p1.y)),
+            Vec2(x_offset + float(p2.x), page_height - float(p2.y)),
+            Vec2(x_offset + float(p3.x), page_height - float(p3.y)),
+            Vec2(x_offset + float(p4.x), page_height - float(p4.y)),
         ]
-        bsp = bspline_fn([bezier4p_cls(ctrl)])
+        bsp = bezier_to_bspline([Bezier4P(ctrl)])
         entity = msp.add_spline(dxfattribs=attribs)
         entity.apply_construction_tool(bsp)
         return entity
@@ -904,7 +895,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         height = max(float(word["bottom"]) - float(word["top"]), 1.0)
         msp.add_text(
             text,
-            height=height * 0.7,  # approximate PDF text height to DXF
+            height=height * PDF_TEXT_HEIGHT_RATIO,
             dxfattribs={"layer": layer, "color": PDF_ENTITY_COLOR, "insert": (x, y)},
         )
         count += 1

--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -372,13 +372,6 @@ PDF_TEXT_HEIGHT_RATIO = 0.7
 _DXF_LW_MIN = 13
 _DXF_LW_MAX = 211
 
-# Standard DXF linetypes mapped from common PDF dash patterns
-_STANDARD_LINETYPES = {
-    "DASHED": "DASHED",
-    "DOTTED": "DOT",
-    "DASHDOT": "DASHDOT",
-    "CENTER": "CENTER",
-}
 
 
 def _parse_pdf_dashes(dashes) -> list[float]:

--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -358,14 +358,98 @@ def _rgb_to_aci(rgb_tuple) -> int:
 
 PDF_PAGE_GAP = 50.0  # gap between pages in DXF units (~17.6mm)
 
-# Minimum entity length in PDF points.  PDF path decomposition produces
-# thousands of sub-pixel strokes (fill patterns, hatch artifacts, stroke caps)
-# that add density without readable information.  Filtering these reduces the
-# "black blob" effect when viewing dense structural PDFs at auto-fit zoom.
+# Legacy module-level constants — kept for backward compatibility with tests
+# that import them directly. At runtime, _extract_pdf_fitz reads from settings.
 PDF_MIN_ENTITY_SIZE = 1.0
-
-# Maximum HATCH entities per page to avoid bloating files with fill patterns.
 PDF_MAX_HATCH_ENTITIES = 500
+
+# DXF lineweight range (hundredths of mm): 13 (0.13mm) to 211 (2.11mm)
+_DXF_LW_MIN = 13
+_DXF_LW_MAX = 211
+
+# Standard DXF linetypes mapped from common PDF dash patterns
+_STANDARD_LINETYPES = {
+    "DASHED": "DASHED",
+    "DOTTED": "DOT",
+    "DASHDOT": "DASHDOT",
+    "CENTER": "CENTER",
+}
+
+
+def _parse_pdf_dashes(dashes) -> list[float]:
+    """Parse PDF dash pattern into a list of numeric dash/gap lengths.
+
+    PyMuPDF returns dashes as a string like ``"[3 2] 0"`` (PDF array + phase)
+    or sometimes as an actual list/tuple. Handles both.
+
+    Returns:
+        List of dash/gap lengths, or empty list if no pattern.
+    """
+    if dashes is None:
+        return []
+    if isinstance(dashes, (list, tuple)):
+        try:
+            return [float(v) for v in dashes if float(v) != 0]
+        except (TypeError, ValueError):
+            return []
+    if isinstance(dashes, str):
+        # Parse "[3 2] 0" format — extract numbers inside brackets
+        import re
+
+        match = re.search(r"\[([^\]]*)\]", dashes)
+        if not match:
+            return []
+        inner = match.group(1).strip()
+        if not inner:
+            return []
+        try:
+            return [float(v) for v in inner.split()]
+        except ValueError:
+            return []
+    return []
+
+
+def _classify_dash_pattern(dash_values: list[float]) -> str:
+    """Map parsed PDF dash lengths to a standard DXF linetype name.
+
+    Args:
+        dash_values: List of dash/gap lengths (already parsed).
+
+    Returns:
+        DXF linetype name: DASHED, DOT, DASHDOT, CENTER, or CONTINUOUS.
+    """
+    if len(dash_values) < 2:
+        return "CONTINUOUS"
+
+    dash_len = dash_values[0]
+    gap_len = dash_values[1]
+
+    if dash_len <= 0 or gap_len <= 0:
+        return "CONTINUOUS"
+
+    ratio = dash_len / gap_len
+
+    # Dot pattern: very short dash relative to gap
+    if dash_len < 1.0:
+        return "DOT"
+
+    # Dash-dot: 4+ element pattern (dash, gap, dot, gap)
+    if len(dash_values) >= 4:
+        dot_len = dash_values[2]
+        if dot_len < dash_len * 0.3:
+            if len(dash_values) >= 6:
+                return "CENTER"  # dash-dot-dash pattern
+            return "DASHDOT"
+
+    # Short dashes (ratio near 1:1)
+    if 0.3 < ratio < 3.0:
+        return "DASHED"
+
+    # Long dashes with short gaps
+    if ratio >= 3.0:
+        return "DASHED"
+
+    return "DASHED"
 
 
 def _create_fill_hatch(msp, path_item, x_offset, page_height, layer, hatch_count):
@@ -374,7 +458,7 @@ def _create_fill_hatch(msp, path_item, x_offset, page_height, layer, hatch_count
     Returns (hatch_or_none, updated_hatch_count).
     """
     fill_rgb = path_item.get("fill")
-    if fill_rgb is None or hatch_count >= PDF_MAX_HATCH_ENTITIES:
+    if fill_rgb is None or hatch_count >= settings.pdf_max_hatch_entities:
         return None, hatch_count
 
     items = path_item.get("items", [])
@@ -429,7 +513,9 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
     import math
 
     import fitz
+    from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
 
+    min_size = settings.pdf_min_entity_size
     pdf_doc = fitz.open(str(source_path))
     total = 0
     x_offset = 0.0
@@ -448,6 +534,20 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
             stroke_color = _rgb_to_aci(path_item.get("color"))
             stroke_rgb = path_item.get("color")
 
+            # Extract stroke width and dash pattern from PDF path
+            stroke_width = path_item.get("width", 0)
+
+            # Build base attribs with optional lineweight and linetype
+            base_attribs: dict = {}
+            if stroke_width and float(stroke_width) > 0:
+                lw = max(_DXF_LW_MIN, min(_DXF_LW_MAX, int(float(stroke_width) * 25)))
+                base_attribs["lineweight"] = lw
+            dash_values = _parse_pdf_dashes(path_item.get("dashes", None))
+            if dash_values:
+                lt = _classify_dash_pattern(dash_values)
+                if lt != "CONTINUOUS":
+                    base_attribs["linetype"] = lt
+
             # Create fill HATCH if path has a fill color
             if path_item.get("fill") is not None:
                 hatch, hatch_count = _create_fill_hatch(
@@ -458,13 +558,13 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
 
             for item in path_item.get("items", []):
                 kind = item[0]
-                attribs = {"layer": layer, "color": stroke_color}
+                attribs = {"layer": layer, "color": stroke_color, **base_attribs}
 
                 if kind == "l":  # Line
                     p1, p2 = item[1], item[2]
                     x0, y0 = x_offset + float(p1.x), page_height - float(p1.y)
                     x1, y1 = x_offset + float(p2.x), page_height - float(p2.y)
-                    if math.hypot(x1 - x0, y1 - y0) < PDF_MIN_ENTITY_SIZE:
+                    if math.hypot(x1 - x0, y1 - y0) < min_size:
                         continue
                     entity = msp.add_line((x0, y0), (x1, y1), dxfattribs=attribs)
                     _set_entity_rgb(entity, stroke_rgb)
@@ -476,7 +576,7 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                     y0 = page_height - float(rect.y0)
                     x1 = x_offset + float(rect.x1)
                     y1 = page_height - float(rect.y1)
-                    if abs(x1 - x0) < PDF_MIN_ENTITY_SIZE and abs(y1 - y0) < PDF_MIN_ENTITY_SIZE:
+                    if abs(x1 - x0) < min_size and abs(y1 - y0) < min_size:
                         continue
                     points = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
                     entity = msp.add_lwpolyline(points, close=True, dxfattribs=attribs)
@@ -487,7 +587,7 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                     p1, p2, p3, p4 = item[1], item[2], item[3], item[4]
                     # Skip tiny curves (fill artifacts)
                     chord = math.hypot(float(p4.x) - float(p1.x), float(p4.y) - float(p1.y))
-                    if chord < PDF_MIN_ENTITY_SIZE:
+                    if chord < min_size:
                         continue
                     arc = _fit_arc_from_bezier(p1, p2, p3, p4, page_height)
                     if arc:
@@ -500,13 +600,20 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                             dxfattribs=attribs,
                         )
                     else:
-                        # Approximate as polyline segments
-                        pts = _bezier_to_points(p1, p2, p3, p4, page_height, segments=8)
-                        if len(pts) >= 2:
-                            shifted = [(x_offset + px, py) for px, py in pts]
-                            entity = msp.add_lwpolyline(shifted, dxfattribs=attribs)
-                        else:
-                            entity = None
+                        # Create native DXF SPLINE from Bezier control points
+                        entity = _bezier_to_spline(
+                            msp,
+                            p1,
+                            p2,
+                            p3,
+                            p4,
+                            page_height,
+                            x_offset,
+                            attribs,
+                            Bezier4P,
+                            Vec2,
+                            bezier_to_bspline,
+                        )
                     if entity is not None:
                         _set_entity_rgb(entity, stroke_rgb)
                     total += 1
@@ -543,7 +650,13 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
                     bbox = span.get("bbox", (0, 0, 0, 0))
                     x = x_offset + float(bbox[0])
                     y = page_height - float(bbox[1])
-                    height = max(float(bbox[3]) - float(bbox[1]), 1.0)
+
+                    # Prefer span font size over bbox-derived height
+                    font_size = span.get("size", None)
+                    if font_size and float(font_size) > 0:
+                        height = float(font_size)
+                    else:
+                        height = max(float(bbox[3]) - float(bbox[1]), 1.0) * 0.7
 
                     # Extract text color from PyMuPDF packed int
                     span_color_int = span.get("color", 0)
@@ -553,7 +666,7 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
 
                     text_entity = msp.add_text(
                         text,
-                        height=height * 0.7,
+                        height=height,
                         dxfattribs={
                             "layer": layer,
                             "color": PDF_ENTITY_COLOR,
@@ -573,51 +686,150 @@ def _extract_pdf_fitz(msp, source_path: Path, doc=None) -> int:
 def _fit_arc_from_bezier(p1, p2, p3, p4, page_height: float):
     """Try to fit a circular arc to a cubic Bezier curve.
 
+    Samples 5 points along the Bezier (t=0, 0.25, 0.5, 0.75, 1.0) and uses
+    the Kåsa algebraic least-squares method to fit a circle. Checks that the
+    maximum deviation from the fitted circle is within tolerance.
+
     Returns (cx, cy, radius, start_angle, end_angle) if the Bezier is
     near-circular, or None if it's a general curve.
     """
     import math
 
-    # Convert to DXF coords (flip Y)
-    x0, y0 = float(p1.x), page_height - float(p1.y)
-    x1, y1 = float(p2.x), page_height - float(p2.y)
-    x2, y2 = float(p3.x), page_height - float(p3.y)
-    x3, y3 = float(p4.x), page_height - float(p4.y)
+    tolerance = settings.pdf_arc_tolerance
 
-    # Mid-point of the Bezier (t=0.5)
-    mx = 0.125 * (x0 + 3 * x1 + 3 * x2 + x3)
-    my = 0.125 * (y0 + 3 * y1 + 3 * y2 + y3)
+    # Convert control points to DXF coords (flip Y)
+    cp = [
+        (float(p1.x), page_height - float(p1.y)),
+        (float(p2.x), page_height - float(p2.y)),
+        (float(p3.x), page_height - float(p3.y)),
+        (float(p4.x), page_height - float(p4.y)),
+    ]
 
-    # Try to find circumscribed circle of start, mid, end points
-    ax, ay = x0, y0
-    bx, by = mx, my
-    cx, cy = x3, y3
+    # Sample 5 points along the Bezier at t = 0, 0.25, 0.5, 0.75, 1.0
+    sample_pts = []
+    for t in (0.0, 0.25, 0.5, 0.75, 1.0):
+        mt = 1 - t
+        mt2 = mt * mt
+        mt3 = mt2 * mt
+        t2 = t * t
+        t3 = t2 * t
+        sx = mt3 * cp[0][0] + 3 * mt2 * t * cp[1][0] + 3 * mt * t2 * cp[2][0] + t3 * cp[3][0]
+        sy = mt3 * cp[0][1] + 3 * mt2 * t * cp[1][1] + 3 * mt * t2 * cp[2][1] + t3 * cp[3][1]
+        sample_pts.append((sx, sy))
 
-    d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
-    if abs(d) < 1e-10:
-        return None  # Collinear — not an arc
+    n = len(sample_pts)
 
-    a_sq = ax * ax + ay * ay
-    b_sq = bx * bx + by * by
-    c_sq = cx * cx + cy * cy
-    ux = (a_sq * (by - cy) + b_sq * (cy - ay) + c_sq * (ay - by)) / d
-    uy = (a_sq * (cx - bx) + b_sq * (ax - cx) + c_sq * (bx - ax)) / d
+    # Kåsa algebraic least-squares circle fit
+    # Solve: [sum(xi²) sum(xi*yi) sum(xi)] [A]   [sum(xi³ + xi*yi²)]
+    #        [sum(xi*yi) sum(yi²) sum(yi)] [B] = [sum(xi²*yi + yi³)]
+    #        [sum(xi)    sum(yi)  n      ] [C]   [sum(xi² + yi²)    ]
+    sx = sum(p[0] for p in sample_pts)
+    sy = sum(p[1] for p in sample_pts)
+    sx2 = sum(p[0] ** 2 for p in sample_pts)
+    sy2 = sum(p[1] ** 2 for p in sample_pts)
+    sxy = sum(p[0] * p[1] for p in sample_pts)
+    sx3 = sum(p[0] ** 3 for p in sample_pts)
+    sy3 = sum(p[1] ** 3 for p in sample_pts)
+    sx2y = sum(p[0] ** 2 * p[1] for p in sample_pts)
+    sxy2 = sum(p[0] * p[1] ** 2 for p in sample_pts)
 
-    r1 = math.hypot(ax - ux, ay - uy)
-    r2 = math.hypot(bx - ux, by - uy)
-    r3 = math.hypot(cx - ux, cy - uy)
+    # 3x3 linear system: M * [A, B, C]^T = rhs
+    m00, m01, m02 = sx2, sxy, sx
+    m10, m11, m12 = sxy, sy2, sy
+    m20, m21, m22 = sx, sy, float(n)
+    rhs0 = sx3 + sxy2
+    rhs1 = sx2y + sy3
+    rhs2 = sx2 + sy2
 
-    # Check if all three radii match (within 5% tolerance)
-    avg_r = (r1 + r2 + r3) / 3
-    if avg_r < 0.1:
+    # Solve via Cramer's rule
+    det = (
+        m00 * (m11 * m22 - m12 * m21)
+        - m01 * (m10 * m22 - m12 * m20)
+        + m02 * (m10 * m21 - m11 * m20)
+    )
+    if abs(det) < 1e-10:
+        return None  # Degenerate — points are collinear
+
+    a_val = (
+        rhs0 * (m11 * m22 - m12 * m21)
+        - m01 * (rhs1 * m22 - m12 * rhs2)
+        + m02 * (rhs1 * m21 - m11 * rhs2)
+    ) / det
+    b_val = (
+        m00 * (rhs1 * m22 - m12 * rhs2)
+        - rhs0 * (m10 * m22 - m12 * m20)
+        + m02 * (m10 * rhs2 - rhs1 * m20)
+    ) / det
+    c_val = (
+        m00 * (m11 * rhs2 - rhs1 * m21)
+        - m01 * (m10 * rhs2 - rhs1 * m20)
+        + rhs0 * (m10 * m21 - m11 * m20)
+    ) / det
+
+    ux = a_val / 2
+    uy = b_val / 2
+    r_sq = c_val + ux * ux + uy * uy
+    if r_sq <= 0:
         return None
-    if max(abs(r1 - avg_r), abs(r2 - avg_r), abs(r3 - avg_r)) / avg_r > 0.05:
+    radius = math.sqrt(r_sq)
+
+    if radius < 0.1:
+        return None
+
+    # Check max deviation from fitted circle
+    max_dev = max(abs(math.hypot(px - ux, py - uy) - radius) for px, py in sample_pts)
+    if max_dev / radius > tolerance:
         return None  # Not circular enough
 
-    start_angle = math.atan2(ay - uy, ax - ux)
-    end_angle = math.atan2(cy - uy, cx - ux)
+    start_angle = math.atan2(sample_pts[0][1] - uy, sample_pts[0][0] - ux)
+    end_angle = math.atan2(sample_pts[-1][1] - uy, sample_pts[-1][0] - ux)
 
-    return (ux, uy, avg_r, start_angle, end_angle)
+    return (ux, uy, radius, start_angle, end_angle)
+
+
+def _bezier_to_spline(
+    msp,
+    p1,
+    p2,
+    p3,
+    p4,
+    page_height,
+    x_offset,
+    attribs,
+    bezier4p_cls,
+    vec2_cls,
+    bspline_fn,
+):
+    """Create a native DXF SPLINE from cubic Bezier control points.
+
+    Uses ezdxf's bezier_to_bspline() for exact curve preservation. Falls back
+    to an adaptive polyline if the BSpline conversion fails unexpectedly.
+    """
+    try:
+        ctrl = [
+            vec2_cls(x_offset + float(p1.x), page_height - float(p1.y)),
+            vec2_cls(x_offset + float(p2.x), page_height - float(p2.y)),
+            vec2_cls(x_offset + float(p3.x), page_height - float(p3.y)),
+            vec2_cls(x_offset + float(p4.x), page_height - float(p4.y)),
+        ]
+        bsp = bspline_fn([bezier4p_cls(ctrl)])
+        entity = msp.add_spline(dxfattribs=attribs)
+        entity.apply_construction_tool(bsp)
+        return entity
+    except Exception:
+        # Fallback: adaptive polyline
+        pts = _bezier_to_points(
+            p1,
+            p2,
+            p3,
+            p4,
+            page_height,
+            segments=settings.pdf_bezier_segments,
+        )
+        if len(pts) >= 2:
+            shifted = [(x_offset + px, py) for px, py in pts]
+            return msp.add_lwpolyline(shifted, dxfattribs=attribs)
+        return None
 
 
 def _bezier_to_points(p1, p2, p3, p4, page_height: float, segments: int = 8):
@@ -663,7 +875,7 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         page_height = float(page.height)
         y0 = page_height - y0
         y1 = page_height - y1
-        if math.hypot(x1 - x0, y1 - y0) < PDF_MIN_ENTITY_SIZE:
+        if math.hypot(x1 - x0, y1 - y0) < settings.pdf_min_entity_size:
             continue
         msp.add_line((x0, y0), (x1, y1), dxfattribs=attribs)
         count += 1
@@ -676,7 +888,8 @@ def _extract_pdf_page_plumber(msp, page, page_num: int, x_offset: float = 0.0) -
         page_height = float(page.height)
         y0 = page_height - y0
         y1 = page_height - y1
-        if abs(x1 - x0) < PDF_MIN_ENTITY_SIZE and abs(y1 - y0) < PDF_MIN_ENTITY_SIZE:
+        min_sz = settings.pdf_min_entity_size
+        if abs(x1 - x0) < min_sz and abs(y1 - y0) < min_sz:
             continue
         points = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
         msp.add_lwpolyline(points, close=True, dxfattribs=attribs)

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -84,6 +84,12 @@ class Settings:
             os.getenv("CAD_ROUTER_CONFIDENCE_THRESHOLD", "0.9")
         )
 
+        # PDF conversion tuning
+        self.pdf_arc_tolerance: float = float(os.getenv("CAD_PDF_ARC_TOLERANCE", "0.05"))
+        self.pdf_bezier_segments: int = int(os.getenv("CAD_PDF_BEZIER_SEGMENTS", "8"))
+        self.pdf_max_hatch_entities: int = int(os.getenv("CAD_PDF_MAX_HATCH_ENTITIES", "500"))
+        self.pdf_min_entity_size: float = float(os.getenv("CAD_PDF_MIN_ENTITY_SIZE", "1.0"))
+
         # Edit history
         self.max_undo_snapshots: int = int(os.getenv("CAD_MAX_UNDO_SNAPSHOTS", "50"))
 

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -311,16 +311,16 @@ class TestFitzExtraction:
         assert len(entities) == 1
         assert entities[0].dxftype() == "ARC"
 
-    def test_bezier_arc_fit_failure_polyline_fallback(self, tmp_path, monkeypatch):
-        """'c' item where arc fitting fails produces a LWPOLYLINE fallback."""
+    def test_bezier_arc_fit_failure_creates_spline(self, tmp_path, monkeypatch):
+        """'c' item where arc fitting fails produces a native DXF SPLINE."""
         import sys
 
         import ezdxf
 
-        # Collinear points — arc fit will return None
+        # Non-circular curve — arc fit will return None, SPLINE created instead
         p1 = self._make_point(0, 0)
-        p2 = self._make_point(1, 0)
-        p3 = self._make_point(2, 0)
+        p2 = self._make_point(1, 3)
+        p3 = self._make_point(2, 3)
         p4 = self._make_point(3, 0)
 
         page = self._make_page(drawings=[{"items": [("c", p1, p2, p3, p4)]}])
@@ -335,7 +335,7 @@ class TestFitzExtraction:
         assert count == 1
         entities = list(msp)
         assert len(entities) == 1
-        assert entities[0].dxftype() == "LWPOLYLINE"
+        assert entities[0].dxftype() == "SPLINE"
 
     def test_quad_new_style_extracted(self, tmp_path, monkeypatch):
         """'qu' with len==2 (pymupdf >=1.27 Quad object) produces LWPOLYLINE."""
@@ -1347,6 +1347,473 @@ class TestFillHatch:
         # Should have HATCH (fill) + LWPOLYLINE (rect stroke) + LINE (line stroke)
         assert "HATCH" in types_found
         assert count >= 3  # 1 hatch + 1 rect + 1 line
+
+
+class TestPdfDashPatternParsing:
+    """Test PDF dash pattern parsing and DXF linetype classification."""
+
+    def test_parse_empty_bracket_string(self):
+        from cad_dxf_agent.core.converter import _parse_pdf_dashes
+
+        assert _parse_pdf_dashes("[] 0") == []
+
+    def test_parse_dash_bracket_string(self):
+        from cad_dxf_agent.core.converter import _parse_pdf_dashes
+
+        assert _parse_pdf_dashes("[3 2] 0") == [3.0, 2.0]
+
+    def test_parse_complex_bracket_string(self):
+        from cad_dxf_agent.core.converter import _parse_pdf_dashes
+
+        assert _parse_pdf_dashes("[6 3 1 3] 0") == [6.0, 3.0, 1.0, 3.0]
+
+    def test_parse_list_input(self):
+        from cad_dxf_agent.core.converter import _parse_pdf_dashes
+
+        assert _parse_pdf_dashes([3, 2]) == [3.0, 2.0]
+
+    def test_parse_none_input(self):
+        from cad_dxf_agent.core.converter import _parse_pdf_dashes
+
+        assert _parse_pdf_dashes(None) == []
+
+    def test_classify_dashed(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        assert _classify_dash_pattern([3.0, 2.0]) == "DASHED"
+
+    def test_classify_dotted(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        assert _classify_dash_pattern([0.5, 2.0]) == "DOT"
+
+    def test_classify_dashdot(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        assert _classify_dash_pattern([6.0, 3.0, 1.0, 3.0]) == "DASHDOT"
+
+    def test_classify_center(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        # 6+ element pattern: dash-gap-dot-gap-dash-gap
+        assert _classify_dash_pattern([12.0, 3.0, 2.0, 3.0, 2.0, 3.0]) == "CENTER"
+
+    def test_classify_empty(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        assert _classify_dash_pattern([]) == "CONTINUOUS"
+
+    def test_classify_single_element(self):
+        from cad_dxf_agent.core.converter import _classify_dash_pattern
+
+        assert _classify_dash_pattern([3.0]) == "CONTINUOUS"
+
+
+class TestPdfConfigurableSettings:
+    """Test that PDF conversion respects settings."""
+
+    def test_settings_have_pdf_defaults(self):
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.pdf_arc_tolerance == 0.05
+        assert s.pdf_bezier_segments == 8
+        assert s.pdf_max_hatch_entities == 500
+        assert s.pdf_min_entity_size == 1.0
+
+    def test_settings_read_from_env(self, monkeypatch):
+        monkeypatch.setenv("CAD_PDF_ARC_TOLERANCE", "0.1")
+        monkeypatch.setenv("CAD_PDF_BEZIER_SEGMENTS", "16")
+        monkeypatch.setenv("CAD_PDF_MAX_HATCH_ENTITIES", "1000")
+        monkeypatch.setenv("CAD_PDF_MIN_ENTITY_SIZE", "0.5")
+
+        from cad_dxf_agent.settings import Settings
+
+        s = Settings()
+        assert s.pdf_arc_tolerance == 0.1
+        assert s.pdf_bezier_segments == 16
+        assert s.pdf_max_hatch_entities == 1000
+        assert s.pdf_min_entity_size == 0.5
+
+
+class TestImprovedArcFitting:
+    """Test the 5-point least-squares arc fitting."""
+
+    def _make_point(self, x, y):
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        return Pt(x, y)
+
+    def test_circular_bezier_detected_as_arc(self):
+        """Control points forming a near-circular curve should be detected as ARC."""
+        from cad_dxf_agent.core.converter import _fit_arc_from_bezier
+
+        # Approximate a 90-degree arc of radius 100 centered at origin
+        # Standard cubic Bezier approximation of a quarter circle
+        k = 0.5522847498  # magic number for cubic Bezier circle approx
+        p1 = self._make_point(100, 0)
+        p2 = self._make_point(100, 100 * k)
+        p3 = self._make_point(100 * k, 100)
+        p4 = self._make_point(0, 100)
+
+        # page_height=200 so Y-flip doesn't cause issues
+        result = _fit_arc_from_bezier(p1, p2, p3, p4, page_height=200)
+        assert result is not None
+        cx, cy, radius, start_angle, end_angle = result
+        assert abs(radius - 100) < 5  # within 5% of expected
+
+    def test_non_circular_bezier_rejected(self):
+        """A clearly non-circular S-curve should return None."""
+        from cad_dxf_agent.core.converter import _fit_arc_from_bezier
+
+        # S-curve — definitely not circular
+        p1 = self._make_point(0, 0)
+        p2 = self._make_point(100, 200)
+        p3 = self._make_point(200, -100)
+        p4 = self._make_point(300, 100)
+
+        result = _fit_arc_from_bezier(p1, p2, p3, p4, page_height=400)
+        assert result is None
+
+    def test_collinear_points_rejected(self):
+        """Collinear Bezier (straight line) should return None."""
+        from cad_dxf_agent.core.converter import _fit_arc_from_bezier
+
+        p1 = self._make_point(0, 100)
+        p2 = self._make_point(100, 100)
+        p3 = self._make_point(200, 100)
+        p4 = self._make_point(300, 100)
+
+        result = _fit_arc_from_bezier(p1, p2, p3, p4, page_height=200)
+        assert result is None
+
+
+class TestSplineCreation:
+    """Test native DXF SPLINE creation from Bezier curves."""
+
+    def _make_point(self, x, y):
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        return Pt(x, y)
+
+    def test_bezier_to_spline_creates_spline_entity(self):
+        """_bezier_to_spline should create a SPLINE entity with correct control points."""
+        import ezdxf
+        from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
+
+        from cad_dxf_agent.core.converter import _bezier_to_spline
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        p1 = self._make_point(0, 0)
+        p2 = self._make_point(50, 100)
+        p3 = self._make_point(150, 100)
+        p4 = self._make_point(200, 0)
+
+        entity = _bezier_to_spline(
+            msp,
+            p1,
+            p2,
+            p3,
+            p4,
+            page_height=200,
+            x_offset=0,
+            attribs={"layer": "0", "color": 7},
+            bezier4p_cls=Bezier4P,
+            vec2_cls=Vec2,
+            bspline_fn=bezier_to_bspline,
+        )
+        assert entity is not None
+        assert entity.dxftype() == "SPLINE"
+        assert entity.control_point_count() > 0
+
+    def test_bezier_to_spline_with_offset(self):
+        """SPLINE control points should be offset by x_offset."""
+        import ezdxf
+        from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
+
+        from cad_dxf_agent.core.converter import _bezier_to_spline
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        p1 = self._make_point(10, 10)
+        p2 = self._make_point(20, 50)
+        p3 = self._make_point(40, 50)
+        p4 = self._make_point(50, 10)
+
+        entity = _bezier_to_spline(
+            msp,
+            p1,
+            p2,
+            p3,
+            p4,
+            page_height=100,
+            x_offset=500,
+            attribs={"layer": "0"},
+            bezier4p_cls=Bezier4P,
+            vec2_cls=Vec2,
+            bspline_fn=bezier_to_bspline,
+        )
+        assert entity is not None
+        # First control point X should be >= 500 (offset)
+        ctrl_pts = list(entity.control_points)
+        assert ctrl_pts[0][0] >= 500
+
+
+class TestTextFontSize:
+    """Test that text height prefers span font size over bbox-derived height."""
+
+    def _make_point(self, x, y):
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        return Pt(x, y)
+
+    def _make_fitz_module(self, pages):
+        import types
+
+        fitz_mod = types.ModuleType("fitz")
+        fitz_mod.TEXT_PRESERVE_WHITESPACE = 1
+
+        class MockDoc:
+            def __init__(self):
+                self._pages = pages
+
+            def __len__(self):
+                return len(self._pages)
+
+            def __iter__(self):
+                return iter(self._pages)
+
+            def close(self):
+                pass
+
+        fitz_mod.open = lambda path: MockDoc()
+        return fitz_mod
+
+    def _make_page(self, height=792, width=612, drawings=None, text_dict=None):
+        class MockPage:
+            def __init__(self, h, w, d, t):
+                class Rect:
+                    def __init__(self, h, w):
+                        self.height = h
+                        self.width = w
+
+                self.rect = Rect(h, w)
+                self._drawings = d or []
+                self._text = t or {"blocks": []}
+
+            def get_drawings(self):
+                return self._drawings
+
+            def get_text(self, mode, flags=0):
+                return self._text
+
+        return MockPage(height, width, drawings, text_dict)
+
+    def test_span_font_size_used_when_available(self, tmp_path, monkeypatch):
+        """When span has 'size', use it directly instead of bbox * 0.7."""
+        import sys
+
+        import ezdxf
+
+        text_dict = {
+            "blocks": [
+                {
+                    "type": 0,
+                    "lines": [
+                        {
+                            "spans": [
+                                {
+                                    "text": "Hello",
+                                    "bbox": (10, 10, 50, 30),  # bbox height = 20
+                                    "size": 14.0,  # actual font size
+                                    "color": 0,
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+        page = self._make_page(text_dict=text_dict)
+        fitz_mod = self._make_fitz_module([page])
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
+
+        entities = list(msp)
+        assert len(entities) == 1
+        text_ent = entities[0]
+        assert text_ent.dxftype() == "TEXT"
+        # Should use font size 14.0, not bbox height 20 * 0.7 = 14.0
+        assert abs(text_ent.dxf.height - 14.0) < 0.01
+
+    def test_bbox_fallback_when_no_font_size(self, tmp_path, monkeypatch):
+        """When span has no 'size', fall back to bbox-derived height * 0.7."""
+        import sys
+
+        import ezdxf
+
+        text_dict = {
+            "blocks": [
+                {
+                    "type": 0,
+                    "lines": [
+                        {
+                            "spans": [
+                                {
+                                    "text": "World",
+                                    "bbox": (10, 10, 50, 30),  # bbox height = 20
+                                    "color": 0,
+                                    # no "size" key
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+        page = self._make_page(text_dict=text_dict)
+        fitz_mod = self._make_fitz_module([page])
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
+
+        entities = list(msp)
+        assert len(entities) == 1
+        text_ent = entities[0]
+        # Fallback: bbox height (20) * 0.7 = 14.0
+        assert abs(text_ent.dxf.height - 14.0) < 0.01
+
+
+class TestStrokeExtraction:
+    """Test PDF stroke width and dash pattern extraction."""
+
+    def _make_point(self, x, y):
+        class Pt:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        return Pt(x, y)
+
+    def _make_fitz_module(self, pages):
+        import types
+
+        fitz_mod = types.ModuleType("fitz")
+        fitz_mod.TEXT_PRESERVE_WHITESPACE = 1
+
+        class MockDoc:
+            def __init__(self):
+                self._pages = pages
+
+            def __len__(self):
+                return len(self._pages)
+
+            def __iter__(self):
+                return iter(self._pages)
+
+            def close(self):
+                pass
+
+        fitz_mod.open = lambda path: MockDoc()
+        return fitz_mod
+
+    def _make_page(self, height=792, width=612, drawings=None, text_dict=None):
+        class MockPage:
+            def __init__(self, h, w, d, t):
+                class Rect:
+                    def __init__(self, h, w):
+                        self.height = h
+                        self.width = w
+
+                self.rect = Rect(h, w)
+                self._drawings = d or []
+                self._text = t or {"blocks": []}
+
+            def get_drawings(self):
+                return self._drawings
+
+            def get_text(self, mode, flags=0):
+                return self._text
+
+        return MockPage(height, width, drawings, text_dict)
+
+    def test_stroke_width_applied_as_lineweight(self, tmp_path, monkeypatch):
+        """Lines from paths with stroke width get DXF lineweight."""
+        import sys
+
+        import ezdxf
+
+        p1 = self._make_point(0, 0)
+        p2 = self._make_point(100, 0)
+        drawing = {
+            "items": [("l", p1, p2)],
+            "color": (0.0, 0.0, 0.0),
+            "width": 2.0,  # 2pt stroke
+            "dashes": "[] 0",
+        }
+        page = self._make_page(drawings=[drawing])
+        fitz_mod = self._make_fitz_module([page])
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
+
+        entities = list(msp)
+        assert len(entities) == 1
+        line = entities[0]
+        # 2.0 * 25 = 50, clamped to [13, 211]
+        assert line.dxf.lineweight == 50
+
+    def test_dashed_line_gets_linetype(self, tmp_path, monkeypatch):
+        """Lines from paths with dash patterns get DXF linetype."""
+        import sys
+
+        import ezdxf
+
+        p1 = self._make_point(0, 0)
+        p2 = self._make_point(100, 0)
+        drawing = {
+            "items": [("l", p1, p2)],
+            "color": (0.0, 0.0, 0.0),
+            "width": 1.0,
+            "dashes": "[3 2] 0",  # standard dashed
+        }
+        page = self._make_page(drawings=[drawing])
+        fitz_mod = self._make_fitz_module([page])
+        monkeypatch.setitem(sys.modules, "fitz", fitz_mod)
+
+        from cad_dxf_agent.core.converter import _extract_pdf_fitz
+
+        doc = ezdxf.new()
+        msp = doc.modelspace()
+        _extract_pdf_fitz(msp, tmp_path / "dummy.pdf")
+
+        entities = list(msp)
+        assert len(entities) == 1
+        line = entities[0]
+        assert line.dxf.linetype == "DASHED"
 
 
 def _create_minimal_pdf(path: Path, *, empty: bool = False) -> None:

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1505,7 +1505,6 @@ class TestSplineCreation:
     def test_bezier_to_spline_creates_spline_entity(self):
         """_bezier_to_spline should create a SPLINE entity with correct control points."""
         import ezdxf
-        from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
 
         from cad_dxf_agent.core.converter import _bezier_to_spline
 
@@ -1525,9 +1524,6 @@ class TestSplineCreation:
             page_height=200,
             x_offset=0,
             attribs={"layer": "0", "color": 7},
-            bezier4p_cls=Bezier4P,
-            vec2_cls=Vec2,
-            bspline_fn=bezier_to_bspline,
         )
         assert entity is not None
         assert entity.dxftype() == "SPLINE"
@@ -1536,7 +1532,6 @@ class TestSplineCreation:
     def test_bezier_to_spline_with_offset(self):
         """SPLINE control points should be offset by x_offset."""
         import ezdxf
-        from ezdxf.math import Bezier4P, Vec2, bezier_to_bspline
 
         from cad_dxf_agent.core.converter import _bezier_to_spline
 
@@ -1556,9 +1551,6 @@ class TestSplineCreation:
             page_height=100,
             x_offset=500,
             attribs={"layer": "0"},
-            bezier4p_cls=Bezier4P,
-            vec2_cls=Vec2,
-            bspline_fn=bezier_to_bspline,
         )
         assert entity is not None
         # First control point X should be >= 500 (offset)


### PR DESCRIPTION
## Summary
- Replace lossy 8-segment polyline fallback for non-circular Bezier curves with **native DXF SPLINE** entities via ezdxf's `bezier_to_bspline()` — exact curve preservation, zero faceting
- Upgrade arc detection from 3-point circumscribed circle to **5-point Kåsa least-squares** circle fit, catching more near-circular arcs the old method rejected
- Extract PDF **stroke width → DXF lineweight** and **dash patterns → standard linetypes** (DASHED/DOT/DASHDOT/CENTER)
- Use PyMuPDF span `font_size` for text height instead of `bbox_height * 0.7` magic multiplier
- Make all hardcoded PDF limits **configurable via env vars**: `CAD_PDF_ARC_TOLERANCE`, `CAD_PDF_BEZIER_SEGMENTS`, `CAD_PDF_MAX_HATCH_ENTITIES`, `CAD_PDF_MIN_ENTITY_SIZE`

## Test plan
- [x] 22 new tests covering SPLINE creation, dash pattern parsing, arc fitting, text height, stroke extraction, configurable settings
- [x] 90 converter tests pass (`pytest tests/unit/test_converter.py`)
- [x] 4155 total tests pass (unit + integration + web), 0 failures
- [x] `ruff check` clean, `ruff format` clean, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)