### PR TITLE
feat: entity selection, intent fix & viewer interaction improvements

### DIFF
--- a/src/cad_dxf_agent/core/converter.py
+++ b/src/cad_dxf_agent/core/converter.py
@@ -373,7 +373,6 @@ _DXF_LW_MIN = 13
 _DXF_LW_MAX = 211
 
 
-
 def _parse_pdf_dashes(dashes) -> list[float]:
     """Parse PDF dash pattern into a list of numeric dash/gap lengths.
 

--- a/src/cad_dxf_agent/llm/intent_router.py
+++ b/src/cad_dxf_agent/llm/intent_router.py
@@ -167,7 +167,7 @@ _RULES: list[HeuristicRule] = [
             r"\bwhere\s+is\b",
             r"\bshow\s+me\b",
             r"\bhow\s+many\b",
-            r"\blist\s+all\b",
+            r"\blist\b",
             r"\btell\s+me\b",
             r"\bwhat\s+are\b",
             r"\bwhat\s+text\b",

--- a/tests/web/test_entities_near.py
+++ b/tests/web/test_entities_near.py
@@ -1,0 +1,92 @@
+"""Tests for POST /api/entities/near — entity picking for viewer selection."""
+
+from __future__ import annotations
+
+import pytest
+
+starlette = pytest.importorskip("starlette", reason="web backend tests require fastapi/starlette")
+
+
+@pytest.mark.web
+class TestEntitiesNear:
+    """Tests for the /api/entities/near endpoint."""
+
+    def test_returns_entities_near_known_position(self, client, upload_dxf):
+        session_id, file_info = upload_dxf
+        # Use a large radius to ensure we find at least one entity
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session_id, "x": 0.0, "y": 0.0, "radius": 100_000.0, "limit": 3},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "entities" in data
+        # The sample DXF has entities, so we should find at least one near origin with big radius
+        # (if sample has entities with insert_point, this will find them)
+
+    def test_returns_empty_when_far_from_entities(self, client, upload_dxf):
+        session_id, _ = upload_dxf
+        # Use a position very far away with a tiny radius
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session_id, "x": 999_999.0, "y": 999_999.0, "radius": 1.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entities"] == []
+
+    def test_respects_limit_parameter(self, client, upload_dxf):
+        session_id, _ = upload_dxf
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session_id, "x": 0.0, "y": 0.0, "radius": 100_000.0, "limit": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entities"]) <= 1
+
+    def test_entity_fields(self, client, upload_dxf):
+        session_id, _ = upload_dxf
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session_id, "x": 0.0, "y": 0.0, "radius": 100_000.0, "limit": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        if data["entities"]:
+            entity = data["entities"][0]
+            assert "handle" in entity
+            assert "entity_type" in entity
+            assert "layer" in entity
+            assert "label" in entity
+
+    def test_404_for_invalid_session(self, client):
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": "nonexistent", "x": 0.0, "y": 0.0},
+        )
+        assert resp.status_code == 404
+
+    def test_400_when_no_drawing_loaded(self, client):
+        """Session exists but no context loaded — should return 400."""
+        from web.backend.main import session_mgr
+
+        session = session_mgr.create("test-user-123")
+        session.context = None  # Ensure no context
+
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session.session_id, "x": 0.0, "y": 0.0},
+        )
+        assert resp.status_code == 400
+
+    def test_default_radius_and_limit(self, client, upload_dxf):
+        """Omitting radius and limit uses defaults (50, 5)."""
+        session_id, _ = upload_dxf
+        resp = client.post(
+            "/api/entities/near",
+            json={"session_id": session_id, "x": 0.0, "y": 0.0},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["entities"]) <= 5

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -54,6 +54,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from cad_dxf_agent.core.edit_history import EditHistory  # noqa: E402
+from cad_dxf_agent.core.entity_index import EntityIndex  # noqa: E402
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 from cad_dxf_agent.settings import settings as cad_settings  # noqa: E402
 
@@ -357,8 +358,6 @@ async def entities_near(
 
     if not session.context:
         raise HTTPException(400, "No drawing loaded")
-
-    from cad_dxf_agent.core.entity_index import EntityIndex
 
     idx = EntityIndex(session.context)
     nearby = idx.find_in_radius(req.x, req.y, req.radius)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -327,6 +327,63 @@ async def health():
     return {"status": "ok", "service": "cad-dxf-web"}
 
 
+class EntitiesNearRequest(BaseModel):
+    session_id: str
+    x: float
+    y: float
+    radius: float = 50.0
+    limit: int = 5
+
+
+def _entity_label(entity) -> str:
+    """Human-readable label for an entity."""
+    if entity.text_content:
+        return f'{entity.entity_type.value}: "{entity.text_content[:40]}"'
+    if entity.block_name:
+        return f"INSERT: {entity.block_name}"
+    return f"{entity.entity_type.value} on {entity.layer}"
+
+
+@app.post("/api/entities/near")
+async def entities_near(
+    req: EntitiesNearRequest,
+    user=Depends(get_user),
+):
+    """Find entities near a click point for viewer selection."""
+    try:
+        session = session_mgr.get(req.session_id, user["uid"])
+    except (KeyError, PermissionError) as e:
+        raise HTTPException(404, str(e)) from None
+
+    if not session.context:
+        raise HTTPException(400, "No drawing loaded")
+
+    from cad_dxf_agent.core.entity_index import EntityIndex
+
+    idx = EntityIndex(session.context)
+    nearby = idx.find_in_radius(req.x, req.y, req.radius)
+
+    # Apply limit
+    entities = nearby[: req.limit]
+
+    return {
+        "entities": [
+            {
+                "handle": e.handle,
+                "entity_type": e.entity_type.value,
+                "layer": e.layer,
+                "insert_point": (
+                    {"x": e.insert_point.x, "y": e.insert_point.y}
+                    if e.insert_point
+                    else None
+                ),
+                "label": _entity_label(e),
+            }
+            for e in entities
+        ]
+    }
+
+
 class DrawingHealthRequest(BaseModel):
     session_id: str
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -373,9 +373,7 @@ async def entities_near(
                 "entity_type": e.entity_type.value,
                 "layer": e.layer,
                 "insert_point": (
-                    {"x": e.insert_point.x, "y": e.insert_point.y}
-                    if e.insert_point
-                    else None
+                    {"x": e.insert_point.x, "y": e.insert_point.y} if e.insert_point else None
                 ),
                 "label": _entity_label(e),
             }
@@ -562,8 +560,7 @@ async def _save_work_progress(session: Session, user_id: str) -> None:
             last_prompt=session.conversation_history[-1].get("content", "")
             if session.conversation_history
             else "",
-            has_working_dxf=session.edited_path is not None
-            and session.edited_path.exists(),
+            has_working_dxf=session.edited_path is not None and session.edited_path.exists(),
             audit_events=session.audit_events[-50:],  # Cap at 50 events
         )
         working_path = session.edited_path if progress.has_working_dxf else None

--- a/web/frontend/src/components/ChatPanel.jsx
+++ b/web/frontend/src/components/ChatPanel.jsx
@@ -111,6 +111,9 @@ export default function ChatPanel({
   disabled,
   hasOperations,
   hasEdited,
+  selectedEntities,
+  onRemoveEntity,
+  onClearSelection,
 }) {
   const [input, setInput] = useState('');
   const messagesEndRef = useRef(null);
@@ -139,7 +142,14 @@ export default function ChatPanel({
     e.preventDefault();
     const trimmed = input.trim();
     if (!trimmed || loading || disabled) return;
-    onSend(trimmed);
+
+    if (selectedEntities?.length > 0) {
+      const regions = [{ handles: selectedEntities.map(ent => ent.handle) }];
+      onSend(trimmed, regions);
+      onClearSelection?.();
+    } else {
+      onSend(trimmed);
+    }
     setInput('');
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
   };
@@ -298,6 +308,18 @@ export default function ChatPanel({
               {text}
             </button>
           ))}
+        </div>
+      )}
+
+      {selectedEntities?.length > 0 && (
+        <div className="chat-selection-tags">
+          {selectedEntities.map(ent => (
+            <span key={ent.handle} className="entity-tag">
+              {ent.label}
+              <button type="button" onClick={() => onRemoveEntity?.(ent.handle)} aria-label={`Remove ${ent.label}`}>&times;</button>
+            </span>
+          ))}
+          <button type="button" className="btn btn--ghost btn--xs" onClick={onClearSelection}>Clear</button>
         </div>
       )}
 

--- a/web/frontend/src/components/DxfViewerComponent.jsx
+++ b/web/frontend/src/components/DxfViewerComponent.jsx
@@ -15,7 +15,7 @@ import { Color, Vector3 } from 'three';
  *   focusOnBounds({ minX, minY, maxX, maxY }) — pan/zoom to bounds with highlight ring
  */
 const DxfViewerComponent = forwardRef(function DxfViewerComponent(
-  { dxfUrl, onPointClick, className, pickingMode },
+  { dxfUrl, onPointClick, onEntityClick, className, pickingMode, selectedEntities },
   ref,
 ) {
   const containerRef = useRef(null);
@@ -183,10 +183,17 @@ const DxfViewerComponent = forwardRef(function DxfViewerComponent(
 
     viewerRef.current = viewer;
 
-    // Pointer down for control point picking
+    // Pointer down for control point picking + entity selection
     const handlePointerDown = (e) => {
       if (onPointClick && e.detail?.position) {
         onPointClick({ x: e.detail.position.x, y: e.detail.position.y });
+      }
+      if (onEntityClick && e.detail?.position) {
+        const domEvent = e.detail.domEvent;
+        onEntityClick(
+          { x: e.detail.position.x, y: e.detail.position.y },
+          domEvent?.ctrlKey || domEvent?.metaKey || false,
+        );
       }
     };
     viewer.Subscribe('pointerdown', handlePointerDown);
@@ -259,6 +266,29 @@ const DxfViewerComponent = forwardRef(function DxfViewerComponent(
           }}
         />
       )}
+
+      {selectedEntities?.map(entity => {
+        if (!entity.insert_point) return null;
+        const rect = computeScreenRect({
+          minX: entity.insert_point.x - 10,
+          minY: entity.insert_point.y - 10,
+          maxX: entity.insert_point.x + 10,
+          maxY: entity.insert_point.y + 10,
+        });
+        if (!rect) return null;
+        return (
+          <div
+            key={entity.handle}
+            className="viewer-entity-highlight"
+            style={{
+              left: rect.left,
+              top: rect.top,
+              width: rect.width,
+              height: rect.height,
+            }}
+          />
+        );
+      })}
 
       <div className="viewer-toolbar">
         <button

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -60,6 +60,8 @@ export default function PreviewPanel({
   onApprovePlan,
   onApproveAndApplyPlan,
   onApplyPlan,
+  onEntityClick,
+  selectedEntities,
 }) {
   const [activeTab, setActiveTab] = useState('original');
   const hasEdited = !!previewUrls.edited;
@@ -420,7 +422,7 @@ export default function PreviewPanel({
           </div>
         ) : dxfUrls?.[activeTab] ? (
           <div style={{ transform: `rotate(${rotation}deg)`, transition: 'transform 0.3s', width: '100%', height: '100%' }}>
-            <DxfViewerComponent ref={activeViewerRef} dxfUrl={dxfUrls[activeTab]} />
+            <DxfViewerComponent ref={activeViewerRef} dxfUrl={dxfUrls[activeTab]} onEntityClick={onEntityClick} selectedEntities={selectedEntities} />
           </div>
         ) : previewUrls[activeTab] ? (
           <img

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -81,8 +81,8 @@ export default function Workspace({ user, onSignOut }) {
       } else {
         setSelectedEntities([entity]);
       }
-    } catch {
-      // Silently ignore entity pick failures
+    } catch (err) {
+      console.error('Entity pick failed:', err);
     }
   }, [sessionId]);
 

--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
 import { useSession } from '../hooks/useSession';
 import { useDocumentLibrary } from '../hooks/useDocumentLibrary';
+import { entitiesNear } from '../lib/api';
 import FileUpload from './FileUpload';
 import ChatPanel from './ChatPanel';
 import PreviewPanel from './PreviewPanel';
@@ -14,6 +15,7 @@ export default function Workspace({ user, onSignOut }) {
   const replaceInputRef = useRef(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [compareLibraryOpen, setCompareLibraryOpen] = useState(false);
+  const [selectedEntities, setSelectedEntities] = useState([]);
 
   const isAuthenticated = !!user;
   const library = useDocumentLibrary(isAuthenticated);
@@ -61,6 +63,36 @@ export default function Workspace({ user, onSignOut }) {
     session.compareRevision && console.info('[cad] Library compare result:', data);
     return data;
   }, [library, session]);
+
+  // Entity selection via viewer click
+  const handleEntityClick = useCallback(async (position, ctrlKey) => {
+    if (!sessionId) return;
+    try {
+      const res = await entitiesNear(sessionId, position.x, position.y);
+      if (!res.entities?.length) return;
+      const entity = res.entities[0];
+
+      if (ctrlKey) {
+        setSelectedEntities(prev => {
+          const exists = prev.find(e => e.handle === entity.handle);
+          if (exists) return prev.filter(e => e.handle !== entity.handle);
+          return [...prev, entity];
+        });
+      } else {
+        setSelectedEntities([entity]);
+      }
+    } catch {
+      // Silently ignore entity pick failures
+    }
+  }, [sessionId]);
+
+  const handleRemoveEntity = useCallback((handle) => {
+    setSelectedEntities(prev => prev.filter(e => e.handle !== handle));
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedEntities([]);
+  }, []);
 
   return (
     <div className="page" style={{ height: '100vh', overflow: 'hidden' }}>
@@ -299,6 +331,8 @@ export default function Workspace({ user, onSignOut }) {
               onApprovePlan={session.approvePlan}
               onApproveAndApplyPlan={session.approveAndApplyPlan}
               onApplyPlan={session.applyPlan}
+              onEntityClick={handleEntityClick}
+              selectedEntities={selectedEntities}
             />
           </section>
 
@@ -313,6 +347,9 @@ export default function Workspace({ user, onSignOut }) {
               disabled={!sessionId}
               hasOperations={operations.length > 0}
               hasEdited={!!previewUrls.edited}
+              selectedEntities={selectedEntities}
+              onRemoveEntity={handleRemoveEntity}
+              onClearSelection={handleClearSelection}
             />
           </aside>
         </div>

--- a/web/frontend/src/lib/api.js
+++ b/web/frontend/src/lib/api.js
@@ -332,6 +332,17 @@ export async function clearDocumentProgress(docId) {
   return res.json();
 }
 
+// --- Entity picking (viewer click → nearest entities) ---
+
+export async function entitiesNear(sessionId, x, y, radius = 50, limit = 5) {
+  const res = await request('/api/entities/near', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, x, y, radius, limit }),
+  });
+  return res.json();
+}
+
 // --- v2 Preview / Approve / Apply (EPIC-CAD-08) ---
 
 export async function v2Preview(sessionId) {

--- a/web/frontend/src/styles/components.css
+++ b/web/frontend/src/styles/components.css
@@ -1668,3 +1668,51 @@
     background: var(--bg-tertiary);
   }
 }
+
+/* --- Entity selection tags (above chat input) --- */
+
+.chat-selection-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: var(--space-1) var(--space-4);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.entity-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: rgba(37, 99, 235, 0.15);
+  border: 1px solid rgba(37, 99, 235, 0.3);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  color: var(--accent-primary);
+}
+
+.entity-tag button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0 2px;
+  font-size: 13px;
+  font-family: var(--font-body);
+  line-height: 1;
+}
+
+.btn--xs {
+  padding: 1px 6px;
+  font-size: var(--text-xs);
+}
+
+/* Entity highlight overlay — appears on click-selected entities */
+.viewer-entity-highlight {
+  position: absolute;
+  border: 2px solid #3b82f6;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 11;
+  background: rgba(59, 130, 246, 0.08);
+}


### PR DESCRIPTION
## Epic
N/A — UX improvement from user feedback

## Bead(s)
N/A

## Summary
- **Intent router fix**: Broadened `\blist\s+all\b` → `\blist\b` so "list available entities", "list entities", "list layers" route to QNA instead of NEEDS_CLARIFICATION
- **Entity selection via viewer click**: New `/api/entities/near` endpoint uses R-tree spatial index. Click entities in viewer → cyan highlight + entity tags above chat input → handles passed as `selectedRegions` on prompt submit. Ctrl+click for multi-select.
- **Edit op focus already wired**: Confirmed `handleFocusEditOp` from PR #121 works for planned edit operations too

## Test plan
- [x] 80 intent router tests pass (including "list" variations)
- [x] 7 new tests for `/api/entities/near` endpoint (near, far, limit, fields, 404, 400, defaults)
- [x] 419 web tests pass
- [x] 197 eval tests pass (41 xfailed)
- [x] 4263 total tests pass, 0 failures
- [ ] Manual: upload DXF → "list available entities" → QNA response
- [ ] Manual: click entity in viewer → highlight + tag → type prompt → handles sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)