### PR TITLE
fix(docs): rename gist link to One-Pager convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Drawing Intelligence Platform for AEC professionals — edit, analyze, and valid
 
 [![CI](https://github.com/jeremylongshore/cad-dxf-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremylongshore/cad-dxf-agent/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/jeremylongshore/cad-dxf-agent/blob/main/LICENSE)
 
-**Links:** [Full Audit (Gist)](https://gist.github.com/jeremylongshore/0303189683f9547c79e1fc1fc68be711) · [Docs](000-docs/000-INDEX.md)
+**Links:** [Gist One-Pager](https://gist.github.com/jeremylongshore/0303189683f9547c79e1fc1fc68be711) · [Docs](000-docs/000-INDEX.md)
 
 ## What Is This?
 


### PR DESCRIPTION
## Summary
- Renames README link from `[Full Audit (Gist)]` to `[Gist One-Pager]` per template convention
- The gist now has a proper Pattern A one-pager file (`0-cad-dxf-agent-one-pager-and-operator-audit.md`) with Problem/Solution/W5/Stack/Key Differentiators + condensed operator audit
- Also added issue #13 (Missing Project Landing gist) to gist-auditor skill to prevent this gap in the future

## Test plan
- [ ] README renders correctly with new link text
- [ ] Gist URL still resolves and shows one-pager as primary file

🤖 Generated with [Claude Code](https://claude.com/claude-code)