### PR TITLE
feat(perf): cached EntityIndex + contextual tool narrowing

### DIFF
--- a/src/cad_dxf_agent/core/compliance_rules.py
+++ b/src/cad_dxf_agent/core/compliance_rules.py
@@ -76,7 +76,7 @@ def check_compliance(
     if zones is None:
         zones = detect_zones(context)
 
-    index = EntityIndex(context)
+    index = context.index
     findings: list[ComplianceFinding] = []
     checks_run: list[str] = []
 

--- a/src/cad_dxf_agent/core/context_builder.py
+++ b/src/cad_dxf_agent/core/context_builder.py
@@ -16,7 +16,6 @@ from typing import Any
 
 from ..models.cad_schema import DrawingContext, EntityRef, EntityType, Point2D
 from ..models.stats_schema import DrawingStats
-from .entity_index import EntityIndex
 
 
 def full_context(context: DrawingContext) -> dict[str, Any]:
@@ -55,7 +54,7 @@ def subset_context(
 
     When multiple filters are provided, they are intersected.
     """
-    index = EntityIndex(context)
+    index = context.index
     candidates = set(e.handle for e in context.entities)
 
     if entity_ids is not None:

--- a/src/cad_dxf_agent/core/health_checker.py
+++ b/src/cad_dxf_agent/core/health_checker.py
@@ -52,7 +52,7 @@ def check_drawing_health(
 
         issues: list[HealthIssue] = []
         checks_run: list[str] = []
-        index = EntityIndex(context)
+        index = context.index
 
         # Run each check
         for check_fn in _ALL_CHECKS:

--- a/src/cad_dxf_agent/core/plan_validator.py
+++ b/src/cad_dxf_agent/core/plan_validator.py
@@ -25,7 +25,6 @@ from ..models.plan_schema import (
     EditPlan,
     PlanValidationStatus,
 )
-from .entity_index import EntityIndex
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +54,7 @@ class PlanValidator:
     ) -> None:
         self._context = context
         self._rules = rules or RuleConfig()
-        self._index = EntityIndex(context)
+        self._index = context.index
         self._protected_upper = [layer.upper() for layer in self._rules.protected_layers]
 
     def validate(self, plan: EditPlan) -> EditPlan:

--- a/src/cad_dxf_agent/core/preview_builder.py
+++ b/src/cad_dxf_agent/core/preview_builder.py
@@ -12,7 +12,6 @@ from ..models.cad_schema import DrawingContext
 from ..models.plan_schema import EditAction, EditActionType, EditPlan
 from ..models.preview_schema import ActionPreview, EditPreview, PreviewStatus
 from ..models.response_schema import RiskLevel
-from .entity_index import EntityIndex
 
 
 class EditPreviewBuilder:
@@ -20,7 +19,7 @@ class EditPreviewBuilder:
 
     def __init__(self, context: DrawingContext) -> None:
         self._context = context
-        self._index = EntityIndex(context)
+        self._index = context.index
 
     def build(self, plan: EditPlan) -> EditPreview:
         """Build a preview of what the plan will do."""

--- a/src/cad_dxf_agent/core/preview_model.py
+++ b/src/cad_dxf_agent/core/preview_model.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from ..models.cad_schema import DrawingContext
 from ..models.changes_schema import ValidationResult
 from ..models.ops_schema import ChangeSet, OpType
-from .entity_index import EntityIndex
 
 
 class PreviewItem:
@@ -36,7 +35,7 @@ class PreviewModel:
         self._build()
 
     def _build(self) -> None:
-        entity_index = EntityIndex(self.context)
+        entity_index = self.context.index
 
         for i, op in enumerate(self.changeset.operations):
             entity = entity_index.get_by_handle(op.target_handle) if op.target_handle else None

--- a/src/cad_dxf_agent/core/region_associator.py
+++ b/src/cad_dxf_agent/core/region_associator.py
@@ -92,7 +92,7 @@ class RegionAssociator:
         Returns ranked candidates with association types and confidence.
         """
         if index is None:
-            index = EntityIndex(context)
+            index = context.index
 
         candidates: list[AssociatedEntity] = []
         flags: list[str] = []

--- a/src/cad_dxf_agent/core/region_context.py
+++ b/src/cad_dxf_agent/core/region_context.py
@@ -37,7 +37,7 @@ class RegionContextBuilder:
         in/near the region. Otherwise builds whole-drawing context.
         """
         if index is None:
-            index = EntityIndex(context)
+            index = context.index
 
         if region is not None:
             return self._build_from_region(context, region, index)

--- a/src/cad_dxf_agent/core/repeated_condition.py
+++ b/src/cad_dxf_agent/core/repeated_condition.py
@@ -26,7 +26,6 @@ from ..models.repeated_condition_schema import (
     SimilaritySignalType,
 )
 from ..models.response_schema import EvidenceRef
-from .entity_index import EntityIndex
 from .text_utils import levenshtein_similarity as _levenshtein_similarity
 
 logger = logging.getLogger(__name__)
@@ -96,7 +95,7 @@ class ConditionDetector:
         config: SimilarityConfig | None = None,
     ) -> None:
         self._context = context
-        self._index = EntityIndex(context)
+        self._index = context.index
         self._config = config or SimilarityConfig()
 
     def find_repeated(

--- a/src/cad_dxf_agent/core/validators.py
+++ b/src/cad_dxf_agent/core/validators.py
@@ -40,7 +40,7 @@ def validate_changeset(
         span.set_attribute("cad.ops.count", changeset.op_count)
 
         result = ValidationResult()
-        index = EntityIndex(context)
+        index = context.index
         protected_upper = [layer.upper() for layer in rules.protected_layers]
 
         for i, op in enumerate(changeset.operations):

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -58,6 +58,7 @@ class AgentProvider(PlannerProvider):
         self._request_class = request_class
         self._model: Any = None  # lazy init
         self._model_tool_set: str = ""  # tracks which tool set is cached
+        self._vertexai_initialized = False
 
     @property
     def name(self) -> str:
@@ -226,10 +227,12 @@ class AgentProvider(PlannerProvider):
                 Tool,
             )
 
-            vertexai.init(
-                project=self._project,
-                location=self._location,
-            )
+            if not self._vertexai_initialized:
+                vertexai.init(
+                    project=self._project,
+                    location=self._location,
+                )
+                self._vertexai_initialized = True
 
             # Convert tool dicts to FunctionDeclaration objects
             declarations = []

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -24,7 +24,7 @@ from ..otel import get_tracer
 from ..settings import settings
 from .prompt_templates import AGENT_SYSTEM_PROMPT
 from .providers import PlannerProvider
-from .tool_definitions import ALL_TOOLS
+from .tool_definitions import get_tools_for_request_class
 from .tool_executor import ToolExecutor
 from .vision_describer import describe_drawing
 
@@ -49,12 +49,15 @@ class AgentProvider(PlannerProvider):
         location: str | None = None,
         model_name: str | None = None,
         image_path: str | Path | None = None,
+        request_class: str = "modify",
     ) -> None:
         self._project = project or settings.gcp_project
         self._location = location or settings.gcp_location
         self._model_name = model_name or settings.gemini_model
         self._image_path = image_path
+        self._request_class = request_class
         self._model: Any = None  # lazy init
+        self._model_tool_set: str = ""  # tracks which tool set is cached
 
     @property
     def name(self) -> str:
@@ -201,52 +204,70 @@ class AgentProvider(PlannerProvider):
             return changeset
 
     def _get_model(self):
-        """Lazy-initialize the Gemini model with tool declarations and GenerationConfig."""
-        if self._model is None:
-            try:
-                import vertexai
-                from vertexai.generative_models import (
-                    FunctionDeclaration,
-                    GenerationConfig,
-                    GenerativeModel,
-                    Tool,
-                )
+        """Lazy-initialize the Gemini model with tool declarations and GenerationConfig.
 
-                vertexai.init(
-                    project=self._project,
-                    location=self._location,
-                )
+        Tool set is narrowed by request_class: non-MODIFY requests get
+        query-only tools to avoid wasting tokens and prevent the LLM
+        from attempting edits on read-only requests.
+        """
+        tool_defs = get_tools_for_request_class(self._request_class)
+        tool_set_key = self._request_class
 
-                # Convert tool dicts to FunctionDeclaration objects
-                declarations = []
-                for tool_def in ALL_TOOLS:
-                    declarations.append(
-                        FunctionDeclaration(
-                            name=str(tool_def["name"]),
-                            description=str(tool_def["description"]),
-                            parameters=dict(tool_def["parameters"]),  # type: ignore[arg-type]
-                        )
+        # Rebuild model if tool set changed (e.g., reuse across request classes)
+        if self._model is not None and self._model_tool_set == tool_set_key:
+            return self._model
+
+        try:
+            import vertexai
+            from vertexai.generative_models import (
+                FunctionDeclaration,
+                GenerationConfig,
+                GenerativeModel,
+                Tool,
+            )
+
+            vertexai.init(
+                project=self._project,
+                location=self._location,
+            )
+
+            # Convert tool dicts to FunctionDeclaration objects
+            declarations = []
+            for td in tool_defs:
+                declarations.append(
+                    FunctionDeclaration(
+                        name=str(td["name"]),
+                        description=str(td["description"]),
+                        parameters=dict(td["parameters"]),  # type: ignore[arg-type]
                     )
-                tools = [Tool(function_declarations=declarations)]
-
-                gen_config = GenerationConfig(
-                    temperature=settings.llm_temperature,
-                    top_p=settings.llm_top_p,
-                    top_k=settings.llm_top_k,
-                    max_output_tokens=settings.llm_max_output_tokens,
                 )
+            tools = [Tool(function_declarations=declarations)]
 
-                self._model = GenerativeModel(
-                    self._model_name,
-                    system_instruction=AGENT_SYSTEM_PROMPT,
-                    tools=tools,
-                    generation_config=gen_config,
-                )
-            except ImportError as err:
-                raise ImportError(
-                    "google-cloud-aiplatform not installed. "
-                    "Install with: pip install google-cloud-aiplatform"
-                ) from err
+            gen_config = GenerationConfig(
+                temperature=settings.llm_temperature,
+                top_p=settings.llm_top_p,
+                top_k=settings.llm_top_k,
+                max_output_tokens=settings.llm_max_output_tokens,
+            )
+
+            self._model = GenerativeModel(
+                self._model_name,
+                system_instruction=AGENT_SYSTEM_PROMPT,
+                tools=tools,
+                generation_config=gen_config,
+            )
+            self._model_tool_set = tool_set_key
+
+            logger.info(
+                "Agent model initialized with %d tools (request_class=%s)",
+                len(tool_defs),
+                self._request_class,
+            )
+        except ImportError as err:
+            raise ImportError(
+                "google-cloud-aiplatform not installed. "
+                "Install with: pip install google-cloud-aiplatform"
+            ) from err
 
         return self._model
 

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -26,6 +26,7 @@ tracer = get_tracer(__name__)
 def get_provider(
     provider_name: str | None = None,
     image_path: Path | None = None,
+    request_class: str = "modify",
 ) -> PlannerProvider:
     """Get the configured planner provider.
 
@@ -34,6 +35,7 @@ def get_provider(
     Args:
         provider_name: Override for the provider name.
         image_path: Optional path to a rendered PNG for vision-augmented planning.
+        request_class: RequestClass value for tool narrowing (default "modify").
     """
     name = (provider_name or settings.llm_provider).lower()
 
@@ -56,7 +58,7 @@ def get_provider(
         try:
             from .agent_provider import AgentProvider
 
-            return AgentProvider(image_path=image_path)
+            return AgentProvider(image_path=image_path, request_class=request_class)
         except ImportError:
             logger.warning(
                 "google-cloud-aiplatform not installed, falling back to mock-agent. "
@@ -140,6 +142,7 @@ def run_planner(
     context: DrawingContext | None = None,
     rule_config: RuleConfig | None = None,
     conversation_history: list[dict] | None = None,
+    request_class: str = "modify",
 ) -> ChangeSet:
     """Run the planner to generate a changeset from a user prompt.
 
@@ -168,7 +171,7 @@ def run_planner(
     """
     with tracer.start_as_current_span("cad.run_planner") as span:
         if provider is None:
-            provider = get_provider(image_path=image_path)
+            provider = get_provider(image_path=image_path, request_class=request_class)
 
         # Try deterministic planner first (no LLM call needed)
         from .deterministic_planner import deterministic_plan

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -742,3 +742,16 @@ def get_tool_by_name(name: str) -> dict[str, Any] | None:
 def is_edit_tool(name: str) -> bool:
     """Return True if the tool name is an edit (mutating) tool."""
     return any(t["name"] == name for t in EDIT_TOOLS)
+
+
+def get_tools_for_request_class(request_class: str) -> list[dict[str, Any]]:
+    """Return the tool subset appropriate for a given RequestClass.
+
+    Only MODIFY requests get the full tool set (query + edit).
+    All other request classes (understand, estimate, recommend, optimize,
+    summarize, compare, validate) get query-only tools — sending edit
+    tools for read-only requests wastes tokens and risks LLM confusion.
+    """
+    if request_class == "modify":
+        return ALL_TOOLS
+    return QUERY_TOOLS

--- a/src/cad_dxf_agent/llm/tool_executor.py
+++ b/src/cad_dxf_agent/llm/tool_executor.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ..core.entity_index import EntityIndex
 from ..models.cad_schema import DrawingContext, EntityRef
 from ..models.ops_schema import EditOperation, OpType
 
@@ -32,7 +31,7 @@ class ToolExecutor:
         protected_layers: list[str] | None = None,
     ) -> None:
         self._context = context
-        self._index = EntityIndex(context)
+        self._index = context.index
         self._protected = [p.upper() for p in (protected_layers or [])]
         self._operations: list[EditOperation] = []
 

--- a/src/cad_dxf_agent/models/cad_schema.py
+++ b/src/cad_dxf_agent/models/cad_schema.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from ..core.entity_index import EntityIndex
 
 
 class EntityType(StrEnum):
@@ -214,6 +218,18 @@ class DrawingContext(BaseModel):
     unsupported_entity_types: list[str] = Field(default_factory=list)
     load_warnings: list[LoadWarning] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @cached_property
+    def index(self) -> EntityIndex:
+        """Lazily build and cache an EntityIndex for this context.
+
+        Avoids redundant O(n) R-tree rebuilds when multiple consumers
+        (validators, compliance, health checker, etc.) need spatial queries
+        on the same DrawingContext within a single request.
+        """
+        from ..core.entity_index import EntityIndex as _EntityIndex
+
+        return _EntityIndex(self)
 
     @property
     def entity_count(self) -> int:

--- a/tests/unit/test_agent_provider.py
+++ b/tests/unit/test_agent_provider.py
@@ -427,6 +427,7 @@ class TestAgentProviderGetModel:
         provider = AgentProvider(project="p", location="l")
         mock_model = MagicMock()
         provider._model = mock_model
+        provider._model_tool_set = "modify"  # match default request_class
 
         result = provider._get_model()
         assert result is mock_model

--- a/tests/unit/test_entity_index.py
+++ b/tests/unit/test_entity_index.py
@@ -234,3 +234,42 @@ def test_get_by_layer_unknown(entity_index):
     result = entity_index.get_by_layer("NONEXISTENT")
     assert result == []
     assert isinstance(result, list)
+
+
+# --- DrawingContext.index cached property ---
+
+
+class TestDrawingContextIndex:
+    """Verify that DrawingContext.index returns a cached EntityIndex."""
+
+    def test_index_returns_entity_index(self, sample_context):
+        """context.index returns an EntityIndex instance."""
+        idx = sample_context.index
+        assert isinstance(idx, EntityIndex)
+        assert idx.count == sample_context.entity_count
+
+    def test_index_is_cached(self, sample_context):
+        """Repeated access returns the same object (no rebuild)."""
+        idx1 = sample_context.index
+        idx2 = sample_context.index
+        assert idx1 is idx2
+
+    def test_index_matches_direct_construction(self, sample_context):
+        """Cached index produces same results as manually constructed one."""
+        cached = sample_context.index
+        direct = EntityIndex(sample_context)
+        assert cached.count == direct.count
+        assert set(cached.handles()) == set(direct.handles())
+
+    def test_index_on_empty_context(self):
+        """Empty context produces an index with count 0."""
+        ctx = DrawingContext(file_path="empty.dxf", entities=[], layers=[])
+        assert ctx.index.count == 0
+
+    def test_index_spatial_queries_work(self, sample_context):
+        """Spatial queries via cached index work correctly."""
+        idx = sample_context.index
+        # Should be able to call nearest without error
+        result = idx.nearest(0.0, 0.0)
+        # Result depends on fixture data, just verify no crash
+        assert result is None or result.handle

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -7,6 +7,7 @@ from cad_dxf_agent.llm.tool_definitions import (
     EDIT_TOOLS,
     QUERY_TOOLS,
     get_tool_by_name,
+    get_tools_for_request_class,
     is_edit_tool,
 )
 
@@ -98,3 +99,35 @@ class TestToolDefinitions:
         tool = get_tool_by_name("find_entities")
         assert tool is not None
         assert tool["parameters"]["required"] == []
+
+
+class TestToolNarrowing:
+    """Verify request_class → tool subset mapping."""
+
+    def test_modify_gets_all_tools(self):
+        tools = get_tools_for_request_class("modify")
+        assert tools == ALL_TOOLS
+
+    def test_non_modify_gets_query_only(self):
+        for rc in ("understand", "estimate", "recommend", "optimize",
+                    "summarize", "compare", "validate"):
+            tools = get_tools_for_request_class(rc)
+            assert tools == QUERY_TOOLS, f"{rc} should get QUERY_TOOLS only"
+            # Verify no edit tools leak through
+            tool_names = {t["name"] for t in tools}
+            edit_names = {t["name"] for t in EDIT_TOOLS}
+            assert tool_names & edit_names == set(), f"Edit tools in {rc}"
+
+    def test_query_tools_always_present(self):
+        """Every request class gets at least the query tools."""
+        for rc in ("modify", "understand", "estimate", "recommend",
+                    "optimize", "summarize", "compare", "validate"):
+            tools = get_tools_for_request_class(rc)
+            tool_names = {t["name"] for t in tools}
+            query_names = {t["name"] for t in QUERY_TOOLS}
+            assert query_names.issubset(tool_names), f"Missing query tools in {rc}"
+
+    def test_unknown_request_class_gets_query_only(self):
+        """Unknown/future request classes default to query-only (safe)."""
+        tools = get_tools_for_request_class("unknown_future_class")
+        assert tools == QUERY_TOOLS

--- a/web/backend/api_v1.py
+++ b/web/backend/api_v1.py
@@ -27,7 +27,6 @@ from cad_dxf_agent.core.compliance_rules import check_compliance
 from cad_dxf_agent.core.design_ops import TakeoffGenerator
 from cad_dxf_agent.core.drawing_summarizer import summarize_drawing
 from cad_dxf_agent.core.dxf_reader import load_dxf
-from cad_dxf_agent.core.entity_index import EntityIndex
 from cad_dxf_agent.core.rfi_generator import generate_rfi
 from cad_dxf_agent.core.zone_detector import detect_zones as run_zones
 from cad_dxf_agent.models.compliance_schema import BUILTIN_PROFILES
@@ -79,7 +78,7 @@ async def analyze(file: UploadFile = File(...)):
     """
     with otel_span("api.v1.analyze"):
         context = _load_context(file)
-        index = EntityIndex(context)
+        index = context.index
 
         # Layer breakdown
         layers = []
@@ -200,7 +199,7 @@ async def search_entities(
     """
     with otel_span("api.v1.entities"):
         context = _load_context(file)
-        index = EntityIndex(context)
+        index = context.index
 
         candidates = index.filter(layer=layer, entity_type=entity_type)
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -54,7 +54,6 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from cad_dxf_agent.core.edit_history import EditHistory  # noqa: E402
-from cad_dxf_agent.core.entity_index import EntityIndex  # noqa: E402
 from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 from cad_dxf_agent.settings import settings as cad_settings  # noqa: E402
 
@@ -359,7 +358,7 @@ async def entities_near(
     if not session.context:
         raise HTTPException(400, "No drawing loaded")
 
-    idx = EntityIndex(session.context)
+    idx = session.context.index
     nearby = idx.find_in_radius(req.x, req.y, req.radius)
 
     # Apply limit


### PR DESCRIPTION
## Summary
- **Cached EntityIndex**: `DrawingContext.index` cached property eliminates redundant R-tree rebuilds across 14 pipeline consumers (validators, compliance, health checker, preview, tool executor, web endpoints)
- **Tool narrowing**: `get_tools_for_request_class()` sends only 5 query tools (instead of 23) to Gemini for non-edit requests, saving tokens and preventing LLM confusion
- Adopted from architectural comparison with Pascal Editor (pascalorg/editor)

## Test plan
- [x] 4,195 tests pass (3,640 unit + 546 integration/web + 9 new)
- [x] Smoke test passes
- [x] Scorecard: no classification regression (205 pass, 41 xfail)
- [x] mypy clean, ruff clean
- [x] Cached index verified: `context.index is context.index` (same object)
- [x] Tool narrowing verified: MODIFY → 23 tools, all other classes → 5 query-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)