### PR TITLE
feat: EPIC-CAD-31 Phase 0+1 — system design pattern adoption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,16 @@ permissions:
   contents: read
 
 jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Architectural drift detection
+        run: bash scripts/ci/check_nodrift.sh
+
   lint:
     runs-on: ubuntu-latest
+    needs: [drift-check]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -26,6 +34,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    needs: [drift-check]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -38,6 +47,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    needs: [drift-check]
     strategy:
       fail-fast: true
       matrix:
@@ -61,7 +71,7 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [drift-check, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -80,7 +90,7 @@ jobs:
 
   live-test:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [drift-check, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/000-docs/074-AT-ARCH-adk-agent-engine-architecture.md
+++ b/000-docs/074-AT-ARCH-adk-agent-engine-architecture.md
@@ -1,0 +1,128 @@
+# 074-AT-ARCH — ADK Agent Engine Architecture Decision Record
+
+**Status:** Accepted
+**Epic:** EPIC-CAD-31 (System Design Pattern Adoption)
+**Date:** 2026-03-22
+**Author:** Jeremy Longshore + Claude
+
+---
+
+## Context
+
+After completing Phase 9 (User Accounts & Workspaces) and the Pascal Editor PR #127 (cached EntityIndex + tool narrowing), a cross-project research sweep identified system design patterns worth adopting from three sources:
+
+1. **Google ADK** (v1.27.2) — official Agent Development Kit with managed runtime, auto-schema tools, session management, and Agent Engine deployment
+2. **bobs-brain** — Jeremy's production ADK reference implementation, featured in Google's agent-starter-pack community showcase (PR #580, merged) and vertex-ai-samples inline deployment tutorial (PR #4393, merged)
+3. **External projects** — Shapely (geometry), OPA/Cedar (rules), Aider (architect/editor), Great Expectations (composable validation)
+
+The cad-dxf-agent currently runs a custom tool-use loop (`AgentProvider`) with 758 lines of hand-written JSON Schema for 20+ tool definitions. Sessions are managed by a custom `SessionStore` ABC. Geometry computations are hand-rolled. Compliance rules are hardcoded Python.
+
+## Decision
+
+Adopt a phased migration toward ADK Agent Engine as the LLM runtime, while keeping Cloud Run as the REST gateway for file I/O, auth, and document CRUD.
+
+### Architecture: Gateway + Agent Engine (R2/R3 Pattern)
+
+```
+Client → Cloud Run (FastAPI gateway)  → Agent Engine (ADK runtime)
+              ↓                              ↓
+     REST endpoints (~29)            Agent loop (plan/preview/apply)
+     File I/O, auth, CRUD          LLM tool-use, sessions, memory
+     Documents, renders             Managed scaling + observability
+```
+
+### What Stays on Cloud Run
+- File upload/download, DXF processing, rendering
+- Firebase auth validation, tenant/user provisioning
+- Document library (GCS-backed), session CRUD
+- Health checks, static serving, CORS
+
+### What Moves to Agent Engine
+- The agent tool-use loop (currently `AgentProvider._get_model()` + while loop)
+- Tool definitions (as typed Python functions, not JSON Schema dicts)
+- Session state for agent conversations (via `VertexAiSessionService`)
+- Cross-session memory (via `VertexAiMemoryBankService`)
+
+### Why Agent Engine Over Cloud Run for the Agent Loop
+
+| Concern | Cloud Run (current) | Agent Engine (target) |
+|---------|--------------------|-----------------------|
+| Session management | Custom `SessionStore` ABC | Built-in, managed |
+| Observability | Custom OTel bootstrap | Cloud Trace + Logging built-in |
+| Scaling | Configured per-container | Auto-managed |
+| Memory/learning | None | `VertexAiMemoryBankService` |
+| Tool definition | 758 LOC hand-written JSON | Type-hint auto-generation |
+| Agent loop | Custom while loop (10 turns) | Managed `Runner` |
+| Cold start | vertexai.init() in hot path | Pre-warmed by platform |
+
+### What We're NOT Doing
+- **Not replacing Cloud Run** — it stays as the REST gateway. This follows bobs-brain R3: "Gateway = pure HTTP proxy, no Runner."
+- **Not adopting A2A protocol** — single-agent architecture is sufficient for CAD workflows. Multi-agent orchestration adds complexity without clear benefit here.
+- **Not breaking the existing pipeline** — all changes are additive. Existing dict-based tools remain canonical until ADK migration is complete and validated.
+
+## Migration Phases
+
+### Phase 1: ADK Foundation (Week 1-2)
+1. **Typed tool functions** — Add Python functions with type hints alongside existing JSON Schema dicts. Validate auto-generated schemas match hand-written ones. (5 query tools first, then edit tools.)
+2. **Drift detection in CI** — `scripts/ci/check_nodrift.sh` runs FIRST in CI, blocks on violation. Catches framework imports, raw DXF mutation outside allowed files, protected layer enforcement gaps.
+3. **Lazy-loading refinement** — Extract `_ensure_vertexai()` method, clean up `_get_model()`. Extends PR #127 direction.
+
+### Phase 2: Agent Engine Deployment (Week 2-3)
+1. **Session alignment** — Align `SessionStore` method signatures toward ADK `SessionService` interface (`app_name`, `append_event`). Production: swap to `VertexAiSessionService`.
+2. **ADK agent module** — `src/cad_dxf_agent/adk/` with `Agent()` definition using typed tool functions. Reuses all existing pipeline code.
+3. **Agent Engine deployment** — GitHub Actions workflow, CI-only (R4 pattern). Cloud Run proxies agent requests.
+
+### Phase 3: Geometry + Rules (Week 3-4, parallel)
+1. **Shapely 2.0** — Replace `_shoelace_area`, `_polygon_perimeter`, `_polygon_centroid`, `_aspect_ratio` with Shapely `Polygon`. Enables arc handling and polygon intersection.
+2. **Externalized compliance rules** — YAML rule specs alongside Python functions. Firms can customize without code changes. Python stays canonical.
+
+### Phase 4: Design Patterns
+1. **Composable validation suites** (Great Expectations pattern) — Extend `ComplianceProfile` to compose from atomic rules.
+2. **Architect/editor separation** (Aider pattern) — Design principle for future planner improvements.
+
+## Dependency Chain
+
+```
+1A (typed tools) → 2B (ADK agent module) → 2C (deploy to Agent Engine)
+                 → 2A (session alignment) ↗
+1B (drift detection) — independent
+1C (lazy loading) — independent
+3A (Shapely) — independent, parallel with Phase 2
+3B (YAML rules) — independent, after 3A
+```
+
+## Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Agent Engine cold start latency | Medium | Benchmark before/after; keep Cloud Run fallback |
+| ADK version churn | Low | Pin version like bobs-brain (`>=1.18.0,<1.19.0`) |
+| Dual tool definition maintenance burden | Low | Schema-match tests enforce sync; sunset dicts after validation |
+| Session migration data loss | Medium | Migration script + parallel run period |
+| Shapely dependency size | Low | Optional install group `[geometry]` |
+
+## Verification
+
+Per-change gates:
+- `make check` (lint + format + typecheck + tests + smoke)
+- `make scorecard` — no classification regression
+- Coverage stays above 65%
+
+Pattern-specific:
+- Drift detection: CI fails when forbidden import is added (test with intentional violation)
+- Tool functions: auto-generated schemas match hand-written dicts (test)
+- ADK agent: `adk run` starts locally, tool calls execute against test DXF
+- Agent Engine deploy: health check returns 200
+- Shapely: zone detection tests produce identical results
+- YAML rules: produce identical `ComplianceReport` as Python functions
+
+## References
+
+- [Google ADK docs](https://google.github.io/adk-docs/)
+- [google/adk-python](https://github.com/google/adk-python) (Apache 2.0)
+- [bobs-brain](https://github.com/GoogleCloudPlatform/agent-starter-pack/pull/580) — community showcase
+- [Agent Engine deployment tutorial](https://github.com/GoogleCloudPlatform/vertex-ai-samples/pull/4393)
+- [Shapely 2.0](https://github.com/shapely/shapely) (BSD)
+- [OPA](https://openpolicyagent.org/) / [Cedar](https://docs.cedarpolicy.com/)
+- [Aider](https://aider.chat/) (Apache 2.0)
+- [Great Expectations](https://greatexpectations.io/) (Apache 2.0)

--- a/000-docs/074-AT-ARCH-adk-agent-engine-architecture.md
+++ b/000-docs/074-AT-ARCH-adk-agent-engine-architecture.md
@@ -99,7 +99,7 @@ Client → Cloud Run (FastAPI gateway)  → Agent Engine (ADK runtime)
 | ADK version churn | Low | Pin version like bobs-brain (`>=1.18.0,<1.19.0`) |
 | Dual tool definition maintenance burden | Low | Schema-match tests enforce sync; sunset dicts after validation |
 | Session migration data loss | Medium | Migration script + parallel run period |
-| Shapely dependency size | Low | Optional install group `[geometry]` |
+| Shapely dependency size | Low | Core dep (~3MB wheel); zone detection is a core feature, conditional imports not worth the complexity |
 
 ## Verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ cd web/frontend && npm run build && firebase deploy --only hosting --project cad
 gcloud run deploy cad-dxf-web \
   --source . --dockerfile web/backend/Dockerfile \
   --region us-central1 --project cad-dxf-agent \
-  --allow-unauthenticated --memory 1Gi --cpu 1 --timeout 300 \
+  --allow-unauthenticated --memory 8Gi --cpu 4 --timeout 600 \
   --service-account cad-dxf-web-run@cad-dxf-agent.iam.gserviceaccount.com \
   --set-env-vars CAD_LLM_PROVIDER=gemini,CAD_GCP_PROJECT=cad-dxf-agent,OTEL_ENABLED=1,OTEL_EXPORTER=gcp-trace
 ```
@@ -93,7 +93,7 @@ CAD_GCP_PROJECT=cad-dxf-agent pytest tests/live/ -v -m live_api -s
 
 ## Architecture
 
-### Request Flow (v0.8.0)
+### Request Flow (v0.10.1)
 
 ```
 User Prompt
@@ -169,7 +169,7 @@ src/cad_dxf_agent/
     config_schema      #   RuleConfig, ValidationResult
     ...                #   + comparison, region, qna, precision, rfi, stats, etc.
 
-  core/                # 41 modules — DXF I/O, validation, editing, platform services
+  core/                # 43 modules — DXF I/O, validation, editing, platform services
     dxf_reader         #   Load DXF → DrawingContext
     dxf_writer         #   Save working copy to new path
     edit_engine        #   Apply validated ops to DXF
@@ -191,7 +191,7 @@ src/cad_dxf_agent/
     edit_history       #   Undo/redo + named snapshots
     comparison/        #   Revision diff engine (alignment, matching, changelog, bundle, overlay)
 
-  llm/                 # 22 modules — intent classification, planning, agent loop
+  llm/                 # 24 modules — intent classification, planning, agent loop
     planner            #   Orchestrator: prompt → ChangeSet
     providers          #   PlannerProvider ABC
     gemini_provider    #   Vertex AI tool-use with vision
@@ -259,10 +259,10 @@ Optional tracing via `otel.py` bootstrap module. Off by default, CI-safe (no net
 
 | Tier | Location | Count | What |
 |------|----------|-------|------|
-| Unit | `tests/unit/` | ~3570 | Schemas, validators, reader, writer, engine, preview, semantic model, snapshots, comparison, compliance, takeoff, zones, families |
-| Integration | `tests/integration/` | ~102 | Full pipeline, undo/redo, agent loop with ScriptedAgentProvider |
-| Web | `tests/web/` | ~362 | FastAPI backend endpoints (TestClient), document library, session management |
-| Eval | `tests/eval/` | ~42 | Intent classification accuracy scorecard |
+| Unit | `tests/unit/` | ~3600 | Schemas, validators, reader, writer, engine, preview, semantic model, snapshots, comparison, compliance, takeoff, zones, families |
+| Integration | `tests/integration/` | ~100 | Full pipeline, undo/redo, agent loop with ScriptedAgentProvider |
+| Web | `tests/web/` | ~420 | FastAPI backend endpoints (TestClient), document library, session management |
+| Eval | `tests/eval/` | ~40 | Intent classification accuracy scorecard |
 | Live | `tests/live/` | ~42 | Real Gemini API tests (require ADC + `cad-dxf-agent` GCP project) |
 | E2E | `tests/e2e/` | ~33 | End-to-end tests with real DXF files |
 | Benchmark | `tests/benchmark/` | ~19 | Performance micro-benchmarks (pytest-benchmark) |
@@ -270,7 +270,7 @@ Optional tracing via `otel.py` bootstrap module. Off by default, CI-safe (no net
 | Property | `tests/property/` | ~7 | Fuzz/property tests (randomized, bounded runtime) |
 | Smoke | `tests/smoke/` + `scripts/smoke_test.py` | ~7 | End-to-end pipeline via mock planner |
 
-Total: ~4494 tests collected.
+Total: ~4556 tests collected.
 
 ### LLM Testing Patterns
 
@@ -303,7 +303,7 @@ make scorecard-live    # Eval scorecard (real Gemini)
 
 ## CI
 
-GitHub Actions on push/PR to main: lint, format check, mypy, tests (matrix: ubuntu+windows, Python 3.11+3.12). Pre-commit hooks enforce ruff, trailing whitespace, no `.env` commits, no direct commits to main.
+GitHub Actions on push/PR to main: lint, format check, mypy, tests (matrix: ubuntu, Python 3.11+3.12), benchmarks + live API tests on main only. Security: bandit + pip-audit. Pre-commit hooks enforce ruff, trailing whitespace, no `.env` commits, no direct commits to main.
 
 ## Commit & PR Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,16 @@ web/
   frontend/            # React + Vite SPA on Firebase Hosting
 ```
 
+### Tool Function Architecture (EPIC-CAD-31)
+
+Tool schemas exist in two coexisting representations in `llm/tool_definitions.py`:
+1. **Dict-based schemas** — hand-written Gemini FunctionDeclaration dicts (canonical, used at runtime)
+2. **Typed Python functions** — `_fn` stub functions with type hints and docstrings for ADK-pattern schema generation
+
+Both are kept in sync via CI tests (`test_all_tools_typed`, schema-matching assertions). The typed functions `raise NotImplementedError` — dispatch stays in `ToolExecutor`. When ADK migration happens (Phase 2+), the typed functions become the canonical source and the dicts are deleted.
+
+`_hint_to_json_schema()` handles: primitives, `Optional`, `Literal` (→ `enum`), dataclasses (→ nested `object`), `list[X]` (→ `array`).
+
 ### Provider Pattern
 
 `PlannerProvider` ABC in `llm/providers.py` → implement `plan(prompt, drawing_context) → ChangeSet`. Three providers:
@@ -248,10 +258,12 @@ All settings via environment variables (`.env` file, `.gitignore`d):
 | `OTEL_ENABLED` | _(unset)_ | Enable OpenTelemetry tracing (`1`, `true`, `yes`) |
 | `OTEL_EXPORTER` | `console` | Span exporter: `console`, `otlp`, or `gcp-trace` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP collector endpoint (e.g., `http://localhost:4317`) |
+| `CAD_AGENT_BACKEND` | `cloud_run` | Agent backend: `cloud_run` (local pipeline) or `agent_engine` (future Vertex AI Agent Engine) |
+| `CAD_AGENT_ENGINE_URL` | _(unset)_ | Vertex AI Agent Engine endpoint (future use, requires `CAD_AGENT_BACKEND=agent_engine`) |
 
 ### Observability (OpenTelemetry)
 
-Optional tracing via `otel.py` bootstrap module. Off by default, CI-safe (no network). Each pipeline stage emits a span (e.g., `cad.load_dxf`, `cad.run_planner`, `cad.validate`). No full file paths or drawing text in span attributes. Install extras: `pip install -e ".[otel]"`.
+Optional tracing + metrics via `otel.py` bootstrap module. Off by default, CI-safe (no network). Each pipeline stage emits a span (e.g., `cad.load_dxf`, `cad.run_planner`, `cad.validate`). Core metrics: `cad.request.count`, `cad.request.latency_ms`, `cad.agent.turns`, `cad.tool.success`, `cad.tool.failure`. No full file paths or drawing text in span attributes. Install extras: `pip install -e ".[otel]"`.
 
 ## Testing
 
@@ -396,3 +408,16 @@ This project uses `bd` (beads) for issue tracking. Run `bd ready` to find availa
 | EPIC-CAD-27 | cad-dxf-agent-xvs | Session Undo/Redo + Snapshots | 8 | Done |
 | EPIC-CAD-29 | cad-dxf-agent-9cd | Agent-Mode API v1 | 8 | Done |
 | EPIC-CAD-30 | cad-dxf-agent-qvf | User Accounts, Workspaces & Persistent Work Progress | 9 | Done |
+| EPIC-CAD-31 | cad-dxf-agent-ees | System Design Pattern Adoption | — | Phase 0+1 Done, Phase 2+ Deferred |
+
+### EPIC-CAD-31 Review Outcome
+
+A 12-specialist engineer review (ADK, security, database, performance, backend architecture, Python, cloud, DevOps, testing, architecture review, DX, observability) evaluated the EPIC-CAD-31 rollout plan. Key findings:
+
+- **Decision:** Phase 0+1 shipped, Phase 2+ deferred until user growth demands it.
+- **Critical finding:** Tools cannot run inside Agent Engine (ezdxf C library, R-tree, local file I/O). When ready, adopt the HTTP-Client FunctionTool pattern (tools as Cloud Run endpoints).
+- **Pre-existing bugs fixed:** V1 API had zero rate limiting (now 60 req/min per IP), `CAD_WEB_DEV_MODE` parsing was inconsistent across auth/lifespan (now `is_dev_mode()` helper), `SessionManager.get_by_id()` bypassed ownership (now private `_get_by_id_internal()`).
+- **Dead code removed:** `from __future__ import annotations` in tool_definitions (latent `get_type_hints()` bug), dead `Point2D` dataclass (name collision), dead `pname == "return"` guard, loop-body imports in agent_provider.
+- **Foundation completed:** All 23 tools have typed function stubs with schema sync tests, `_hint_to_json_schema()` handles Literal/dataclass/list types, drift detection extended (6 checks), OTel metrics baseline added.
+- **`CAD_AGENT_BACKEND` feature flag** exists (`cloud_run` default) but Agent Engine routing is not wired — just the config plumbing for future use.
+- **Reference materials** for Phase 2 resumption preserved in `memory/reference_*.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "httpx>=0.27",
     "python-dotenv>=1.0",
     "rtree>=1.0",
+    "shapely>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -125,7 +126,7 @@ disallow_untyped_defs = false
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "fitz.*", "matplotlib.*", "fpdf.*", "google.*", "vertexai.*", "rtree.*"]
+module = ["ezdxf.*", "PySide6.*", "opentelemetry.*", "pdfplumber.*", "fitz.*", "matplotlib.*", "fpdf.*", "google.*", "vertexai.*", "rtree.*", "shapely.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "numpy>=1.26",
     "httpx>=0.27",
     "python-dotenv>=1.0",
+    "pyyaml>=6.0",
     "rtree>=1.0",
     "shapely>=2.0",
 ]
@@ -65,6 +66,9 @@ gemini = [
 ]
 gemini-key = [
     "google-generativeai>=0.8",
+]
+adk = [
+    "google-adk>=1.18.0,<1.19.0",
 ]
 build = [
     "pyinstaller>=6.0",
@@ -113,7 +117,7 @@ select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "SIM"]
 ignore = ["S101"]  # Allow assert in tests
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "S106", "S108", "N806"]
+"tests/**/*.py" = ["S101", "S106", "S108", "S603", "S607", "N806"]
 "scripts/**/*.py" = ["S603", "S607", "E402"]  # subprocess + sys.path before imports
 "src/**/alignment.py" = ["N803", "N806"]  # R, U, Vt, H are standard linear algebra names
 "web/backend/**/*.py" = ["B008", "S108", "E402"]  # FastAPI Depends/File, /tmp sessions, sys.path

--- a/scripts/ci/check_nodrift.sh
+++ b/scripts/ci/check_nodrift.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Architectural Drift Detection Gate
+# ============================================================================
+# Scans the codebase for violations of key architectural invariants.
+# Runs as the first CI job — all other jobs depend on this passing.
+#
+# Checks:
+#   1. No forbidden framework imports (langchain, crewai, autogen, llamaindex)
+#   2. No raw DXF mutation outside the approved modules
+#   3. Protected layer dual-enforcement (validators.py + tool_executor.py)
+#   4. No .env files tracked by git
+#
+# Exit 0 on success, exit 1 on any violation.
+# ============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+VIOLATIONS=0
+
+red()    { printf '\033[0;31m%s\033[0m\n' "$1"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$1"; }
+header() { printf '\n=== %s ===\n' "$1"; }
+
+# Helper: filter grep output, keeping only lines from unapproved files.
+# Reads from stdin, prints unapproved hits to stdout.
+filter_approved() {
+    while IFS= read -r line; do
+        local file_path
+        file_path=$(echo "$line" | cut -d: -f1)
+        local relative="${file_path#"$REPO_ROOT"/}"
+        local is_approved=0
+        for approved in "${APPROVED_MUTATION_FILES[@]}"; do
+            if [[ "$relative" == "$approved" ]]; then
+                is_approved=1
+                break
+            fi
+        done
+        if [[ $is_approved -eq 0 ]]; then
+            echo "$line"
+        fi
+    done
+}
+
+# --------------------------------------------------------------------------
+# 1. No forbidden framework imports in src/
+# --------------------------------------------------------------------------
+header "Check 1: No forbidden framework imports"
+
+FORBIDDEN_FRAMEWORKS="langchain|crewai|autogen|llamaindex|llama_index"
+if grep -rn --include='*.py' -E "^(import |from )(${FORBIDDEN_FRAMEWORKS})" "$REPO_ROOT/src/"; then
+    red "FAIL: Forbidden framework imports found in src/."
+    red "      This project uses Vertex AI / ADK only — no langchain, crewai, autogen, or llamaindex."
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: No forbidden framework imports."
+fi
+
+# --------------------------------------------------------------------------
+# 2. No raw DXF mutation outside approved modules
+# --------------------------------------------------------------------------
+header "Check 2: No raw DXF mutation outside approved modules"
+
+# Approved files for DXF write operations (msp.add_*, doc.saveas, entity.dxf.X = ...)
+APPROVED_MUTATION_FILES=(
+    "src/cad_dxf_agent/core/edit_engine.py"
+    "src/cad_dxf_agent/core/dxf_reader.py"
+    "src/cad_dxf_agent/core/dxf_writer.py"
+    "src/cad_dxf_agent/core/revision_notes.py"
+    "src/cad_dxf_agent/core/converter.py"
+    "src/cad_dxf_agent/core/comparison/applier.py"
+    "src/cad_dxf_agent/core/comparison/diff_overlay.py"
+    "src/cad_dxf_agent/core/comparison/bundle.py"
+    "src/cad_dxf_agent/cli/commands.py"
+)
+
+DXF_MUTATION_FOUND=0
+
+# 2a. Check for msp.add_* calls (entity creation)
+HITS=$(grep -rn --include='*.py' -E 'msp\.add_' "$REPO_ROOT/src/" | filter_approved || true)
+if [[ -n "$HITS" ]]; then
+    red "FAIL: DXF entity creation (msp.add_*) found outside approved modules:"
+    echo "$HITS"
+    DXF_MUTATION_FOUND=1
+fi
+
+# 2b. Check for .saveas() calls (file saving)
+HITS=$(grep -rn --include='*.py' -E '\.saveas\(' "$REPO_ROOT/src/" | filter_approved || true)
+if [[ -n "$HITS" ]]; then
+    red "FAIL: DXF save operations found outside approved modules:"
+    echo "$HITS"
+    DXF_MUTATION_FOUND=1
+fi
+
+# 2c. Check for entity.dxf.X = ... (attribute mutation via assignment)
+#     Filter out comparison operators (==, !=) which are reads, not writes.
+HITS=$(grep -rn --include='*.py' -E 'entity\.dxf\.\w+\s*=[^=]' "$REPO_ROOT/src/" | filter_approved || true)
+if [[ -n "$HITS" ]]; then
+    red "FAIL: DXF entity attribute mutation found outside approved modules:"
+    echo "$HITS"
+    DXF_MUTATION_FOUND=1
+fi
+
+if [[ $DXF_MUTATION_FOUND -eq 1 ]]; then
+    red "      DXF mutations must be contained in: edit_engine, dxf_reader, dxf_writer, revision_notes,"
+    red "      converter, comparison/applier, comparison/diff_overlay, comparison/bundle, cli/commands."
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: No DXF mutations outside approved modules."
+fi
+
+# --------------------------------------------------------------------------
+# 3. Protected layer dual-enforcement
+# --------------------------------------------------------------------------
+header "Check 3: Protected layer dual-enforcement"
+
+PROTECTED_LAYERS_RE='TITLE.*TITLEBLOCK.*SEAL.*REVISION'
+DUAL_ENFORCEMENT_OK=1
+
+# Check validators.py has protected layer reference
+if ! grep -q 'protected_layers' "$REPO_ROOT/src/cad_dxf_agent/core/validators.py"; then
+    red "FAIL: src/cad_dxf_agent/core/validators.py does not enforce protected layers."
+    DUAL_ENFORCEMENT_OK=0
+fi
+
+# Check tool_executor.py has protected layer reference
+if ! grep -q 'protected' "$REPO_ROOT/src/cad_dxf_agent/llm/tool_executor.py"; then
+    red "FAIL: src/cad_dxf_agent/llm/tool_executor.py does not enforce protected layers."
+    DUAL_ENFORCEMENT_OK=0
+fi
+
+# Verify the canonical list exists in config_schema.py (source of truth)
+if ! grep -qE "$PROTECTED_LAYERS_RE" "$REPO_ROOT/src/cad_dxf_agent/models/config_schema.py"; then
+    red "FAIL: Canonical protected layer list (TITLE, TITLEBLOCK, SEAL, REVISION) missing from config_schema.py."
+    DUAL_ENFORCEMENT_OK=0
+fi
+
+if [[ $DUAL_ENFORCEMENT_OK -eq 0 ]]; then
+    red "      Protected layers must be enforced in BOTH validators.py AND tool_executor.py."
+    red "      Canonical list defined in models/config_schema.py."
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: Protected layer dual-enforcement verified."
+fi
+
+# --------------------------------------------------------------------------
+# 4. No .env files committed
+# --------------------------------------------------------------------------
+header "Check 4: No .env files committed"
+
+# Check for tracked .env files (excluding .env.example which is expected)
+TRACKED_ENV=$(cd "$REPO_ROOT" && git ls-files '*.env' '.env*' 'web/.env*' | grep -v '\.env\.example$' || true)
+if [[ -n "$TRACKED_ENV" ]]; then
+    red "FAIL: .env files are tracked by git:"
+    echo "$TRACKED_ENV"
+    red "      Remove them with: git rm --cached <file>"
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: No .env files committed (only .env.example, which is expected)."
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+if [[ $VIOLATIONS -gt 0 ]]; then
+    red "DRIFT DETECTED: $VIOLATIONS violation(s) found. Fix them before merging."
+    exit 1
+else
+    green "ALL CLEAR: No architectural drift detected."
+    exit 0
+fi

--- a/scripts/ci/check_nodrift.sh
+++ b/scripts/ci/check_nodrift.sh
@@ -161,6 +161,34 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# 5. No google.adk imports outside approved ADK module
+# --------------------------------------------------------------------------
+header "Check 5: No google.adk imports outside approved module"
+
+ADK_IMPORT_HITS=$(grep -rn --include='*.py' -E '^(import |from )google\.adk' "$REPO_ROOT/src/" | grep -v 'src/cad_dxf_agent/adk/' || true)
+if [[ -n "$ADK_IMPORT_HITS" ]]; then
+    red "FAIL: google.adk imports found outside src/cad_dxf_agent/adk/:"
+    echo "$ADK_IMPORT_HITS"
+    red "      ADK imports must only appear in the adk/ module (when it exists)."
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: No google.adk imports outside approved module."
+fi
+
+# --------------------------------------------------------------------------
+# 6. Gateway must not import google.adk (bobs-brain R3: gateway = pure proxy)
+# --------------------------------------------------------------------------
+header "Check 6: Gateway (web/backend/main.py) does not import google.adk"
+
+if grep -qn -E '^(import |from )google\.adk' "$REPO_ROOT/web/backend/main.py" 2>/dev/null; then
+    red "FAIL: web/backend/main.py imports google.adk."
+    red "      The gateway must be a pure proxy — no ADK dependency."
+    VIOLATIONS=$((VIOLATIONS + 1))
+else
+    green "PASS: Gateway does not import google.adk."
+fi
+
+# --------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------
 echo ""

--- a/src/cad_dxf_agent/core/zone_detector.py
+++ b/src/cad_dxf_agent/core/zone_detector.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 
+from shapely.geometry import Polygon as ShapelyPolygon
+
 from cad_dxf_agent.core.primitive_extractors import LayerClassification, classify_layers
 from cad_dxf_agent.models.cad_schema import DrawingContext, EntityType, Point2D
 from cad_dxf_agent.models.zone_schema import DetectedZone, ZoneDetectionResult
@@ -417,70 +419,59 @@ def _snap_point(x: float, y: float, tolerance: float) -> tuple[float, float]:
 
 
 def _shoelace_area(vertices: list[Point2D]) -> float:
-    """Compute polygon area using the shoelace formula. Returns absolute area."""
-    n = len(vertices)
-    if n < 3:
+    """Compute polygon area using Shapely. Returns absolute area."""
+    if len(vertices) < 3:
         return 0.0
-    area = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        area += vertices[i].x * vertices[j].y
-        area -= vertices[j].x * vertices[i].y
-    return abs(area) / 2.0
+    coords = [(v.x, v.y) for v in vertices]
+    return float(ShapelyPolygon(coords).area)
 
 
 def _polygon_perimeter(vertices: list[Point2D]) -> float:
-    """Compute polygon perimeter."""
-    n = len(vertices)
-    perimeter = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        perimeter += _point_distance(vertices[i], vertices[j])
-    return perimeter
+    """Compute polygon perimeter using Shapely."""
+    if len(vertices) < 3:
+        return 0.0
+    coords = [(v.x, v.y) for v in vertices]
+    return float(ShapelyPolygon(coords).length)
 
 
 def _polygon_centroid(vertices: list[Point2D]) -> Point2D:
-    """Compute polygon centroid using the signed-area formula.
+    """Compute polygon centroid using Shapely.
 
-    This gives the true geometric centroid (center of mass) of the polygon,
-    not just the average of vertices. Falls back to vertex average for
-    degenerate cases where signed area is zero.
+    Falls back to vertex average for degenerate cases (zero-area or < 3 vertices).
     """
     n = len(vertices)
     if n == 0:
         return Point2D(x=0, y=0)
-
-    # Signed area (2x) for centroid weighting
-    signed_area_2x = 0.0
-    cx = 0.0
-    cy = 0.0
-    for i in range(n):
-        j = (i + 1) % n
-        cross = vertices[i].x * vertices[j].y - vertices[j].x * vertices[i].y
-        signed_area_2x += cross
-        cx += (vertices[i].x + vertices[j].x) * cross
-        cy += (vertices[i].y + vertices[j].y) * cross
-
-    if abs(signed_area_2x) < 1e-12:
+    coords = [(v.x, v.y) for v in vertices]
+    if n < 3:
+        return Point2D(
+            x=sum(v.x for v in vertices) / n,
+            y=sum(v.y for v in vertices) / n,
+        )
+    poly = ShapelyPolygon(coords)
+    if poly.area < 1e-12:
         # Degenerate polygon — fall back to vertex average
         return Point2D(
             x=sum(v.x for v in vertices) / n,
             y=sum(v.y for v in vertices) / n,
         )
-
-    factor = 1.0 / (3.0 * signed_area_2x)
-    return Point2D(x=cx * factor, y=cy * factor)
+    c = poly.centroid
+    return Point2D(x=c.x, y=c.y)
 
 
 def _aspect_ratio(vertices: list[Point2D]) -> float:
-    """Compute bounding-box aspect ratio (max/min dimension)."""
+    """Compute bounding-box aspect ratio using Shapely bounds."""
     if len(vertices) < 2:
         return 1.0
-    xs = [v.x for v in vertices]
-    ys = [v.y for v in vertices]
-    width = max(xs) - min(xs)
-    height = max(ys) - min(ys)
+    coords = [(v.x, v.y) for v in vertices]
+    if len(coords) >= 3:
+        minx, miny, maxx, maxy = ShapelyPolygon(coords).bounds
+    else:
+        xs = [v.x for v in vertices]
+        ys = [v.y for v in vertices]
+        minx, miny, maxx, maxy = min(xs), min(ys), max(xs), max(ys)
+    width = maxx - minx
+    height = maxy - miny
     if width == 0 or height == 0:
         return 1.0
-    ratio = max(width, height) / min(width, height)
-    return ratio
+    return float(max(width, height) / min(width, height))

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -204,6 +204,48 @@ class AgentProvider(PlannerProvider):
             changeset.planner_trace = trace
             return changeset
 
+    def _ensure_vertexai(self) -> None:
+        """Initialize Vertex AI SDK on first use (lazy, idempotent).
+
+        Separates SDK initialization from model construction so that
+        the two concerns can evolve independently and be tested in
+        isolation.
+        """
+        if self._vertexai_initialized:
+            return
+        try:
+            import vertexai
+
+            vertexai.init(project=self._project, location=self._location)
+            self._vertexai_initialized = True
+            logger.info(
+                "Vertex AI initialized (project=%s, location=%s)",
+                self._project,
+                self._location,
+            )
+        except ImportError as err:
+            raise ImportError(
+                "google-cloud-aiplatform not installed. "
+                "Install with: pip install google-cloud-aiplatform"
+            ) from err
+
+    @property
+    def _generation_config(self):
+        """Lazily create GenerationConfig from current settings.
+
+        Called from _get_model() after _ensure_vertexai() has already
+        confirmed the SDK is available, so the import is guaranteed to
+        succeed at this point.
+        """
+        from vertexai.generative_models import GenerationConfig
+
+        return GenerationConfig(
+            temperature=settings.llm_temperature,
+            top_p=settings.llm_top_p,
+            top_k=settings.llm_top_k,
+            max_output_tokens=settings.llm_max_output_tokens,
+        )
+
     def _get_model(self):
         """Lazy-initialize the Gemini model with tool declarations and GenerationConfig.
 
@@ -219,45 +261,30 @@ class AgentProvider(PlannerProvider):
             return self._model
 
         try:
-            import vertexai
+            self._ensure_vertexai()
+
             from vertexai.generative_models import (
                 FunctionDeclaration,
-                GenerationConfig,
                 GenerativeModel,
                 Tool,
             )
 
-            if not self._vertexai_initialized:
-                vertexai.init(
-                    project=self._project,
-                    location=self._location,
-                )
-                self._vertexai_initialized = True
-
             # Convert tool dicts to FunctionDeclaration objects
-            declarations = []
-            for td in tool_defs:
-                declarations.append(
-                    FunctionDeclaration(
-                        name=str(td["name"]),
-                        description=str(td["description"]),
-                        parameters=dict(td["parameters"]),  # type: ignore[arg-type]
-                    )
+            declarations = [
+                FunctionDeclaration(
+                    name=str(td["name"]),
+                    description=str(td["description"]),
+                    parameters=dict(td["parameters"]),  # type: ignore[arg-type]
                 )
+                for td in tool_defs
+            ]
             tools = [Tool(function_declarations=declarations)]
-
-            gen_config = GenerationConfig(
-                temperature=settings.llm_temperature,
-                top_p=settings.llm_top_p,
-                top_k=settings.llm_top_k,
-                max_output_tokens=settings.llm_max_output_tokens,
-            )
 
             self._model = GenerativeModel(
                 self._model_name,
                 system_instruction=AGENT_SYSTEM_PROMPT,
                 tools=tools,
-                generation_config=gen_config,
+                generation_config=self._generation_config,
             )
             self._model_tool_set = tool_set_key
 
@@ -266,11 +293,8 @@ class AgentProvider(PlannerProvider):
                 len(tool_defs),
                 self._request_class,
             )
-        except ImportError as err:
-            raise ImportError(
-                "google-cloud-aiplatform not installed. "
-                "Install with: pip install google-cloud-aiplatform"
-            ) from err
+        except ImportError:
+            raise
 
         return self._model
 

--- a/src/cad_dxf_agent/llm/agent_provider.py
+++ b/src/cad_dxf_agent/llm/agent_provider.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +24,7 @@ from ..models.ops_schema import ChangeSet
 from ..models.trace_schema import AgentTurn, PlannerTrace, ToolCall
 from ..otel import get_tracer
 from ..settings import settings
+from .errors import PlannerTimeoutError
 from .prompt_templates import AGENT_SYSTEM_PROMPT
 from .providers import PlannerProvider
 from .tool_definitions import get_tools_for_request_class
@@ -154,11 +157,6 @@ class AgentProvider(PlannerProvider):
                     )
 
                 # Send results back to Gemini with per-turn timeout
-                from concurrent.futures import ThreadPoolExecutor
-                from concurrent.futures import TimeoutError as FuturesTimeoutError
-
-                from .errors import PlannerTimeoutError
-
                 with ThreadPoolExecutor(max_workers=1) as pool:
                     future = pool.submit(self._send_tool_results, chat, tool_results)
                     try:

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -917,14 +917,24 @@ def _fn_to_tool_schema(fn: Callable) -> dict[str, Any]:
     description = desc_parts[0].strip()
 
     # Parse the "Args:" section for per-parameter descriptions.
-    # Format expected: "    param_name: description text"
+    # Handles multi-line descriptions: continuation lines (indented without
+    # a leading "name:") are appended to the current parameter.
     param_descs: dict[str, str] = {}
     if len(desc_parts) > 1:
+        current_pname: str | None = None
         for line in desc_parts[1].strip().splitlines():
-            line = line.strip()
-            if ":" in line:
-                pname, pdesc = line.split(":", 1)
-                param_descs[pname.strip()] = pdesc.strip()
+            stripped = line.strip()
+            if not stripped:
+                continue
+            # Continuation line: indented and no new param name
+            if line.startswith("    ") and current_pname and ":" not in stripped.split()[0]:
+                param_descs[current_pname] += " " + stripped
+            elif ":" in stripped:
+                pname, pdesc = stripped.split(":", 1)
+                current_pname = pname.strip()
+                param_descs[current_pname] = pdesc.strip()
+            else:
+                current_pname = None
 
     # Build JSON Schema properties and required list.
     properties: dict[str, Any] = {}

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -6,8 +6,7 @@ methods. The LLM never touches DXF directly — it calls these tools,
 and the host code executes them against the validated pipeline.
 """
 
-from __future__ import annotations
-
+import dataclasses
 import inspect
 import types
 import typing
@@ -772,8 +771,8 @@ def get_tools_for_request_class(request_class: str) -> list[dict[str, Any]]:
 
 
 @dataclass
-class Point2D:
-    """A 2D point in drawing units."""
+class ToolPoint2D:
+    """A 2D point in drawing units (used for schema generation only)."""
 
     x: float
     y: float
@@ -856,6 +855,397 @@ QUERY_TOOL_FUNCTIONS: list[Callable] = [
     is_protected_fn,
 ]
 
+# ---------------------------------------------------------------------------
+# Typed stubs for edit tools
+# ---------------------------------------------------------------------------
+
+
+def move_entity_fn(handle: str, dx: float, dy: float) -> dict:
+    """Move an entity by a displacement vector (dx, dy) in drawing units.
+
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to move
+        dx: Displacement in X direction (drawing units)
+        dy: Displacement in Y direction (drawing units)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def edit_text_fn(handle: str, new_text: str) -> dict:
+    """Change the text content of a TEXT or MTEXT entity.
+
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the TEXT/MTEXT entity to edit
+        new_text: The new text content
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def delete_entity_fn(handle: str) -> dict:
+    """Delete an entity from the drawing.
+
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to delete
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_block_fn(
+    block_name: str,
+    x: float,
+    y: float,
+    layer: str | None = None,
+    scale: float | None = None,
+    rotation: float | None = None,
+) -> dict:
+    """Insert a block reference at a specified point.
+
+    The block must exist in the drawing's block definitions.
+
+    Args:
+        block_name: Name of the block definition to insert
+        x: X coordinate for insertion point
+        y: Y coordinate for insertion point
+        layer: Optional target layer for the block reference
+        scale: Uniform scale factor (default 1.0)
+        rotation: Rotation angle in degrees (default 0)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def rotate_entity_fn(
+    handle: str,
+    angle: float,
+    cx: float | None = None,
+    cy: float | None = None,
+) -> dict:
+    """Rotate an entity by a given angle in degrees.
+
+    Rotation center defaults to origin (0,0) unless cx, cy are specified.
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to rotate
+        angle: Rotation angle in degrees (positive = counter-clockwise)
+        cx: X coordinate of rotation center (default 0)
+        cy: Y coordinate of rotation center (default 0)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def copy_entity_fn(handle: str, dx: float, dy: float) -> dict:
+    """Create a copy of an entity at an offset position.
+
+    The original entity is preserved. The copy gets a new handle.
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to copy
+        dx: X offset for the copy from original position
+        dy: Y offset for the copy from original position
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def scale_entity_fn(
+    handle: str,
+    factor: float,
+    cx: float | None = None,
+    cy: float | None = None,
+) -> dict:
+    """Scale an entity by a uniform factor relative to a center point.
+
+    Center defaults to origin (0,0) unless cx, cy are specified.
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to scale
+        factor: Scale factor (>1 enlarges, <1 shrinks, must be non-zero)
+        cx: X coordinate of scale center (default 0)
+        cy: Y coordinate of scale center (default 0)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def mirror_entity_fn(
+    handle: str,
+    axis: typing.Literal["x", "y"],
+    value: float | None = None,
+) -> dict:
+    """Mirror an entity across an axis line.
+
+    axis='x' mirrors across horizontal line y=value.
+    axis='y' mirrors across vertical line x=value.
+    Cannot target entities on protected layers.
+
+    Args:
+        handle: Handle of the entity to mirror
+        axis: Mirror axis: 'x' for horizontal, 'y' for vertical
+        value: Position of the mirror line (default 0)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_line_fn(
+    start: ToolPoint2D,
+    end: ToolPoint2D,
+    layer: str | None = None,
+) -> dict:
+    """Draw a new line between two points.
+
+    Cannot create on protected layers.
+
+    Args:
+        start: Start point {x, y}
+        end: End point {x, y}
+        layer: Target layer name (optional)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_polyline_fn(
+    points: list[ToolPoint2D],
+    closed: bool = False,
+    layer: str | None = None,
+) -> dict:
+    """Draw a new polyline through a series of points.
+
+    Set closed=true to close the shape.
+    Cannot create on protected layers.
+
+    Args:
+        points: List of {x, y} points defining the polyline (minimum 2)
+        closed: Whether to close the polyline (default false)
+        layer: Target layer name (optional)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_circle_fn(
+    center: ToolPoint2D,
+    radius: float,
+    layer: str | None = None,
+) -> dict:
+    """Draw a new circle at a center point with a given radius.
+
+    Cannot create on protected layers.
+
+    Args:
+        center: Center point {x, y}
+        radius: Circle radius in drawing units
+        layer: Target layer name (optional)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_arc_fn(
+    center: ToolPoint2D,
+    radius: float,
+    start_angle: float,
+    end_angle: float,
+    layer: str | None = None,
+) -> dict:
+    """Draw a new arc (portion of a circle) defined by center, radius, start angle, and end angle.
+
+    Angles are in degrees. Cannot create on protected layers.
+
+    Args:
+        center: Center point {x, y}
+        radius: Arc radius in drawing units
+        start_angle: Start angle in degrees (0 = east/right)
+        end_angle: End angle in degrees (counter-clockwise from start)
+        layer: Target layer name (optional)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def add_text_fn(
+    text: str,
+    insert: ToolPoint2D,
+    height: float | None = None,
+    rotation: float | None = None,
+    layer: str | None = None,
+    text_type: typing.Literal["TEXT", "MTEXT"] | None = None,
+) -> dict:
+    """Add a new text annotation at a specified point.
+
+    Use text_type='MTEXT' for multi-line text. Cannot create on protected layers.
+
+    Args:
+        text: The text content to add
+        insert: Insertion point {x, y}
+        height: Text height in drawing units (default 2.5)
+        rotation: Text rotation in degrees (default 0)
+        layer: Target layer name (optional)
+        text_type: TEXT (single line) or MTEXT (multi-line). Default TEXT.
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def batch_move_fn(
+    dx: float,
+    dy: float,
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    center_x: float | None = None,
+    center_y: float | None = None,
+    radius: float | None = None,
+) -> dict:
+    """Move all entities matching the filter criteria by a displacement vector (dx, dy).
+
+    At least one filter (layer, entity_type, text_contains, or radius) is required.
+
+    Args:
+        dx: Displacement in X direction (drawing units)
+        dy: Displacement in Y direction (drawing units)
+        layer: Filter: only entities on this layer
+        entity_type: Filter: only entities of this type (LINE, LWPOLYLINE, TEXT, MTEXT,
+            INSERT, CIRCLE, ARC)
+        text_contains: Filter: only TEXT/MTEXT containing this substring
+        center_x: Filter: center X for radius search
+        center_y: Filter: center Y for radius search
+        radius: Filter: search radius from (center_x, center_y)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def batch_rotate_fn(
+    angle: float,
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    center_x: float | None = None,
+    center_y: float | None = None,
+    radius: float | None = None,
+    cx: float | None = None,
+    cy: float | None = None,
+) -> dict:
+    """Rotate all entities matching the filter criteria by a given angle.
+
+    At least one filter is required.
+
+    Args:
+        angle: Rotation angle in degrees (counter-clockwise)
+        layer: Filter: only entities on this layer
+        entity_type: Filter: only entities of this type (LINE, LWPOLYLINE, TEXT, MTEXT,
+            INSERT, CIRCLE, ARC)
+        text_contains: Filter: only TEXT/MTEXT containing this substring
+        center_x: Filter: center X for radius search
+        center_y: Filter: center Y for radius search
+        radius: Filter: search radius from (center_x, center_y)
+        cx: Rotation center X (default: each entity's own center)
+        cy: Rotation center Y (default: each entity's own center)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def batch_scale_fn(
+    factor: float,
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    center_x: float | None = None,
+    center_y: float | None = None,
+    radius: float | None = None,
+    cx: float | None = None,
+    cy: float | None = None,
+) -> dict:
+    """Scale all entities matching the filter criteria by a uniform factor.
+
+    At least one filter is required.
+
+    Args:
+        factor: Scale factor (>1 enlarges, <1 shrinks)
+        layer: Filter: only entities on this layer
+        entity_type: Filter: only entities of this type (LINE, LWPOLYLINE, TEXT, MTEXT,
+            INSERT, CIRCLE, ARC)
+        text_contains: Filter: only TEXT/MTEXT containing this substring
+        center_x: Filter: center X for radius search
+        center_y: Filter: center Y for radius search
+        radius: Filter: search radius from (center_x, center_y)
+        cx: Scale center X (default: each entity's own center)
+        cy: Scale center Y (default: each entity's own center)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def batch_delete_fn(
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    center_x: float | None = None,
+    center_y: float | None = None,
+    radius: float | None = None,
+) -> dict:
+    """Delete all entities matching the filter criteria.
+
+    At least one filter is required. Use with caution.
+
+    Args:
+        layer: Filter: only entities on this layer
+        entity_type: Filter: only entities of this type (LINE, LWPOLYLINE, TEXT, MTEXT,
+            INSERT, CIRCLE, ARC)
+        text_contains: Filter: only TEXT/MTEXT containing this substring
+        center_x: Filter: center X for radius search
+        center_y: Filter: center Y for radius search
+        radius: Filter: search radius from (center_x, center_y)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def batch_edit_text_fn(
+    find: str,
+    replace: str,
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    center_x: float | None = None,
+    center_y: float | None = None,
+    radius: float | None = None,
+) -> dict:
+    """Find-and-replace text content across all TEXT/MTEXT entities matching the filter criteria.
+
+    Args:
+        find: Text substring to find
+        replace: Replacement text
+        layer: Filter: only entities on this layer
+        entity_type: Filter: only entities of this type (LINE, LWPOLYLINE, TEXT, MTEXT,
+            INSERT, CIRCLE, ARC)
+        text_contains: Filter: only TEXT/MTEXT containing this substring
+        center_x: Filter: center X for radius search
+        center_y: Filter: center Y for radius search
+        radius: Filter: search radius from (center_x, center_y)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+EDIT_TOOL_FUNCTIONS: list[Callable] = [
+    move_entity_fn,
+    edit_text_fn,
+    delete_entity_fn,
+    add_block_fn,
+    rotate_entity_fn,
+    copy_entity_fn,
+    scale_entity_fn,
+    mirror_entity_fn,
+    add_line_fn,
+    add_polyline_fn,
+    add_circle_fn,
+    add_arc_fn,
+    add_text_fn,
+    batch_move_fn,
+    batch_rotate_fn,
+    batch_scale_fn,
+    batch_delete_fn,
+    batch_edit_text_fn,
+]
 
 # ---------------------------------------------------------------------------
 # Schema generation from typed functions
@@ -866,7 +1256,9 @@ def _hint_to_json_schema(hint: Any) -> dict[str, Any]:
     """Convert a Python type hint to a JSON Schema type dict.
 
     Handles Optional (``X | None``), primitives (str, int, float, bool),
-    and falls back to ``{"type": "string"}`` for anything unrecognised.
+    ``typing.Literal`` (→ enum), dataclasses (→ object with properties),
+    ``list[X]`` (→ array with items), and falls back to ``{"type": "string"}``
+    for anything unrecognised.
     """
     origin = getattr(hint, "__origin__", None)
 
@@ -881,6 +1273,41 @@ def _hint_to_json_schema(hint: Any) -> dict[str, Any]:
         non_none = [a for a in hint.__args__ if a is not type(None)]
         if len(non_none) == 1:
             return _hint_to_json_schema(non_none[0])
+
+    # typing.Literal["x", "y"] → {"type": "string", "enum": ["x", "y"]}
+    if origin is typing.Literal:
+        args = typing.get_args(hint)
+        if args:
+            # Infer JSON type from the first literal value
+            first = args[0]
+            if isinstance(first, bool):
+                json_type = "boolean"
+            elif isinstance(first, int):
+                json_type = "integer"
+            elif isinstance(first, float):
+                json_type = "number"
+            else:
+                json_type = "string"
+            return {"type": json_type, "enum": list(args)}
+
+    # list[X] → {"type": "array", "items": <schema for X>}
+    if origin is list:
+        args = typing.get_args(hint)
+        if args:
+            return {"type": "array", "items": _hint_to_json_schema(args[0])}
+        return {"type": "array"}
+
+    # dataclass → {"type": "object", "properties": {...}, "required": [...]}
+    if dataclasses.is_dataclass(hint) and isinstance(hint, type):
+        props: dict[str, Any] = {}
+        req: list[str] = []
+        for field in dataclasses.fields(hint):
+            props[field.name] = _hint_to_json_schema(field.type)
+            no_default = field.default is dataclasses.MISSING
+            no_factory = field.default_factory is dataclasses.MISSING  # type: ignore[misc]
+            if no_default and no_factory:
+                req.append(field.name)
+        return {"type": "object", "properties": props, "required": req}
 
     if hint is str:
         return {"type": "string"}
@@ -908,7 +1335,8 @@ def _fn_to_tool_schema(fn: Callable) -> dict[str, Any]:
     The function name must end with ``_fn``; that suffix is stripped to
     derive the tool name (e.g. ``find_entities_fn`` → ``find_entities``).
     """
-    hints = typing.get_type_hints(fn)
+    # Exclude "return" from hints before the loop to avoid processing it
+    hints = {k: v for k, v in typing.get_type_hints(fn).items() if k != "return"}
     sig = inspect.signature(fn)
     doc = inspect.getdoc(fn) or ""
 
@@ -917,31 +1345,36 @@ def _fn_to_tool_schema(fn: Callable) -> dict[str, Any]:
     description = desc_parts[0].strip()
 
     # Parse the "Args:" section for per-parameter descriptions.
-    # Handles multi-line descriptions: continuation lines (indented without
-    # a leading "name:") are appended to the current parameter.
+    # A line is treated as a new parameter only when the text before the first
+    # colon is a single valid Python identifier that matches a parameter name.
+    # Any other colon-containing line is treated as a continuation of the
+    # current parameter description (e.g. "Note: case-insensitive").
     param_descs: dict[str, str] = {}
+    param_names = set(sig.parameters.keys())
     if len(desc_parts) > 1:
         current_pname: str | None = None
         for line in desc_parts[1].strip().splitlines():
             stripped = line.strip()
             if not stripped:
                 continue
-            # Continuation line: indented and no new param name
-            if line.startswith("    ") and current_pname and ":" not in stripped.split()[0]:
+            # Check whether this line starts a new parameter entry:
+            # the token before the first colon must be a plain identifier
+            # that exists in the function's parameter list.
+            if ":" in stripped:
+                before_colon, after_colon = stripped.split(":", 1)
+                before_colon = before_colon.strip()
+                if before_colon.isidentifier() and before_colon in param_names:
+                    current_pname = before_colon
+                    param_descs[current_pname] = after_colon.strip()
+                    continue
+            # Continuation line (indented or no valid param name before colon)
+            if current_pname is not None:
                 param_descs[current_pname] += " " + stripped
-            elif ":" in stripped:
-                pname, pdesc = stripped.split(":", 1)
-                current_pname = pname.strip()
-                param_descs[current_pname] = pdesc.strip()
-            else:
-                current_pname = None
 
     # Build JSON Schema properties and required list.
     properties: dict[str, Any] = {}
     required: list[str] = []
     for pname, param in sig.parameters.items():
-        if pname == "return":
-            continue
         hint = hints.get(pname)
         prop = _hint_to_json_schema(hint)
         if pname in param_descs:
@@ -967,4 +1400,4 @@ def _tools_as_schemas() -> list[dict[str, Any]]:
     Used for validation and future ADK migration. The dict-based
     definitions above remain canonical for now.
     """
-    return [_fn_to_tool_schema(fn) for fn in QUERY_TOOL_FUNCTIONS]
+    return [_fn_to_tool_schema(fn) for fn in QUERY_TOOL_FUNCTIONS + EDIT_TOOL_FUNCTIONS]

--- a/src/cad_dxf_agent/llm/tool_definitions.py
+++ b/src/cad_dxf_agent/llm/tool_definitions.py
@@ -8,6 +8,11 @@ and the host code executes them against the validated pipeline.
 
 from __future__ import annotations
 
+import inspect
+import types
+import typing
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -755,3 +760,201 @@ def get_tools_for_request_class(request_class: str) -> list[dict[str, Any]]:
     if request_class == "modify":
         return ALL_TOOLS
     return QUERY_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# ADK-pattern typed tool functions
+# ---------------------------------------------------------------------------
+# Plain Python functions with type hints and docstrings.
+# ADK auto-generates JSON Schema from these. These coexist with the
+# dict-based definitions above — the dicts remain canonical for now.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Point2D:
+    """A 2D point in drawing units."""
+
+    x: float
+    y: float
+
+
+def find_entities_fn(
+    layer: str | None = None,
+    entity_type: str | None = None,
+    text_contains: str | None = None,
+    limit: int = 50,
+) -> dict:
+    """Search for entities in the drawing by layer, type, and/or text content.
+
+    Returns a list of matching entities with handle, type, layer, position, and text.
+    Results are limited to the first `limit` matches.
+
+    Args:
+        layer: Filter by layer name (case-insensitive). Example: 'STRUCTURAL'
+        entity_type: Filter by entity type. Supported: LINE, LWPOLYLINE, TEXT, MTEXT, INSERT,
+            CIRCLE, ARC, DIMENSION, HATCH, SPLINE, POLYLINE, ELLIPSE, MLEADER, SOLID, LEADER
+        text_contains: Search for entities whose text contains this string (case-insensitive)
+        limit: Maximum number of entities to return (default 50)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def get_entity_fn(handle: str) -> dict:
+    """Get full details of a single entity by its handle (unique ID).
+
+    Returns handle, type, layer, position, text content, and block name.
+
+    Args:
+        handle: The DXF entity handle (unique identifier)
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def find_nearest_fn(
+    x: float,
+    y: float,
+    entity_type: str | None = None,
+    layer: str | None = None,
+    radius: float | None = None,
+) -> dict:
+    """Find the nearest entity to a given point.
+
+    Useful for locating entities at grid intersections or near specific coordinates.
+    Use `radius` to limit the search to a spatial window.
+
+    Args:
+        x: X coordinate in drawing units
+        y: Y coordinate in drawing units
+        entity_type: Optional type filter
+        layer: Optional layer filter (case-insensitive)
+        radius: Optional search radius in drawing units. Only entities within this distance
+            are considered.
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def list_layers_fn() -> dict:
+    """List all layers in the drawing with their protection status and entity counts."""
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+def is_protected_fn(layer: str) -> dict:
+    """Check whether a layer is protected from editing.
+
+    Args:
+        layer: The layer name to check
+    """
+    raise NotImplementedError("Dispatch via ToolExecutor")
+
+
+QUERY_TOOL_FUNCTIONS: list[Callable] = [
+    find_entities_fn,
+    get_entity_fn,
+    find_nearest_fn,
+    list_layers_fn,
+    is_protected_fn,
+]
+
+
+# ---------------------------------------------------------------------------
+# Schema generation from typed functions
+# ---------------------------------------------------------------------------
+
+
+def _hint_to_json_schema(hint: Any) -> dict[str, Any]:
+    """Convert a Python type hint to a JSON Schema type dict.
+
+    Handles Optional (``X | None``), primitives (str, int, float, bool),
+    and falls back to ``{"type": "string"}`` for anything unrecognised.
+    """
+    origin = getattr(hint, "__origin__", None)
+
+    # PEP 604 union: ``str | None`` → types.UnionType (Python 3.10+)
+    if isinstance(hint, types.UnionType):
+        non_none = [a for a in hint.__args__ if a is not type(None)]
+        if len(non_none) == 1:
+            return _hint_to_json_schema(non_none[0])
+
+    # typing.Union / typing.Optional (older style)
+    if origin is typing.Union:
+        non_none = [a for a in hint.__args__ if a is not type(None)]
+        if len(non_none) == 1:
+            return _hint_to_json_schema(non_none[0])
+
+    if hint is str:
+        return {"type": "string"}
+    if hint is int:
+        return {"type": "integer"}
+    if hint is float:
+        return {"type": "number"}
+    if hint is bool:
+        return {"type": "boolean"}
+    if hint is dict:
+        return {"type": "object"}
+    if hint is list:
+        return {"type": "array"}
+
+    return {"type": "string"}  # safe fallback
+
+
+def _fn_to_tool_schema(fn: Callable) -> dict[str, Any]:
+    """Convert a typed Python function to a Gemini FunctionDeclaration-compatible dict.
+
+    Extracts name, description (from docstring body before ``Args:``), and
+    parameters (from type hints + docstring ``Args:`` section) to produce
+    the same format as the hand-written dicts above.
+
+    The function name must end with ``_fn``; that suffix is stripped to
+    derive the tool name (e.g. ``find_entities_fn`` → ``find_entities``).
+    """
+    hints = typing.get_type_hints(fn)
+    sig = inspect.signature(fn)
+    doc = inspect.getdoc(fn) or ""
+
+    # Description = everything before "Args:"
+    desc_parts = doc.split("Args:")
+    description = desc_parts[0].strip()
+
+    # Parse the "Args:" section for per-parameter descriptions.
+    # Format expected: "    param_name: description text"
+    param_descs: dict[str, str] = {}
+    if len(desc_parts) > 1:
+        for line in desc_parts[1].strip().splitlines():
+            line = line.strip()
+            if ":" in line:
+                pname, pdesc = line.split(":", 1)
+                param_descs[pname.strip()] = pdesc.strip()
+
+    # Build JSON Schema properties and required list.
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for pname, param in sig.parameters.items():
+        if pname == "return":
+            continue
+        hint = hints.get(pname)
+        prop = _hint_to_json_schema(hint)
+        if pname in param_descs:
+            prop["description"] = param_descs[pname]
+        properties[pname] = prop
+        if param.default is inspect.Parameter.empty:
+            required.append(pname)
+
+    return {
+        "name": fn.__name__.removesuffix("_fn"),
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        },
+    }
+
+
+def _tools_as_schemas() -> list[dict[str, Any]]:
+    """Generate tool schemas from the typed function definitions.
+
+    Used for validation and future ADK migration. The dict-based
+    definitions above remain canonical for now.
+    """
+    return [_fn_to_tool_schema(fn) for fn in QUERY_TOOL_FUNCTIONS]

--- a/src/cad_dxf_agent/otel.py
+++ b/src/cad_dxf_agent/otel.py
@@ -1,7 +1,8 @@
-"""OpenTelemetry bootstrap — initializes tracing when OTEL_ENABLED is set.
+"""OpenTelemetry bootstrap — initializes tracing and metrics when OTEL_ENABLED is set.
 
 All imports are guarded so the app works fine without OTel installed.
-When disabled, get_tracer() returns a no-op tracer and span() is a passthrough.
+When disabled, get_tracer() returns a no-op tracer, get_meter() returns a no-op
+meter, and span() is a passthrough.
 """
 
 from __future__ import annotations
@@ -14,10 +15,16 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Internal provider reference — avoids the global set_tracer_provider limitation
+# Internal provider references — avoids the global set_*_provider limitation
 _provider: Any = None
+_meter_provider: Any = None
 
 try:
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import (
+        ConsoleMetricExporter,
+        PeriodicExportingMetricReader,
+    )
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
@@ -28,18 +35,18 @@ except ImportError:
 
 
 def init_otel(service_name: str = "cad-dxf-agent") -> None:
-    """Initialize OpenTelemetry tracing.
+    """Initialize OpenTelemetry tracing and metrics.
 
     No-op if OTEL_ENABLED env var is not truthy or if OTel is not installed.
     Safe to call multiple times — only the first call takes effect.
     """
-    global _provider
+    global _provider, _meter_provider
 
     if _provider is not None:
         return
 
     if not _HAS_OTEL:
-        logger.debug("OpenTelemetry packages not installed, tracing disabled")
+        logger.debug("OpenTelemetry packages not installed, tracing/metrics disabled")
         return
 
     from .settings import settings
@@ -49,48 +56,83 @@ def init_otel(service_name: str = "cad-dxf-agent") -> None:
         return
 
     resource = Resource.create({"service.name": service_name})
+
+    # --- Tracer provider ---
     provider = TracerProvider(resource=resource)
 
     if settings.otel_exporter == "gcp-trace":
         try:
             from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
 
-            exporter = CloudTraceSpanExporter()
+            span_exporter = CloudTraceSpanExporter()
             logger.info("OTel: using Google Cloud Trace exporter")
         except ImportError:
             logger.warning("OTel: gcp-trace exporter not installed, falling back to console")
-            exporter = ConsoleSpanExporter()
+            span_exporter = ConsoleSpanExporter()
     elif settings.otel_endpoint:
         try:
             from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
                 OTLPSpanExporter,
             )
 
-            exporter = OTLPSpanExporter(endpoint=settings.otel_endpoint)
+            span_exporter = OTLPSpanExporter(endpoint=settings.otel_endpoint)
             logger.info("OTel: using OTLP exporter → %s", settings.otel_endpoint)
         except ImportError:
             logger.warning("OTel: OTLP exporter not installed, falling back to console")
-            exporter = ConsoleSpanExporter()
+            span_exporter = ConsoleSpanExporter()
     else:
-        exporter = ConsoleSpanExporter()
+        span_exporter = ConsoleSpanExporter()
         logger.info("OTel: using console exporter")
 
-    provider.add_span_processor(BatchSpanProcessor(exporter))
+    provider.add_span_processor(BatchSpanProcessor(span_exporter))
     _provider = provider
+
+    # --- Meter provider ---
+    if settings.otel_exporter == "gcp-trace":
+        try:
+            from opentelemetry.exporter.cloud_monitoring import CloudMonitoringMetricsExporter
+
+            metric_exporter: Any = CloudMonitoringMetricsExporter()
+            logger.info("OTel: using Cloud Monitoring metrics exporter")
+        except ImportError:
+            logger.warning(
+                "OTel: cloud_monitoring exporter not installed, falling back to console metrics"
+            )
+            metric_exporter = ConsoleMetricExporter()
+    elif settings.otel_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
+            metric_exporter = OTLPMetricExporter(endpoint=settings.otel_endpoint)
+            logger.info("OTel: using OTLP metrics exporter → %s", settings.otel_endpoint)
+        except ImportError:
+            logger.warning(
+                "OTel: OTLP metrics exporter not installed, falling back to console metrics"
+            )
+            metric_exporter = ConsoleMetricExporter()
+    else:
+        metric_exporter = ConsoleMetricExporter()
+        logger.info("OTel: using console metrics exporter")
+
+    reader = PeriodicExportingMetricReader(metric_exporter)
+    meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+    _meter_provider = meter_provider
 
     import atexit
 
     atexit.register(provider.shutdown)
+    atexit.register(meter_provider.shutdown)
 
-    logger.info("OpenTelemetry tracing initialized (service=%s)", service_name)
+    logger.info("OpenTelemetry initialized (service=%s)", service_name)
 
 
-def init_otel_testing(exporter: Any) -> None:
-    """Initialize OTel with a caller-supplied exporter (for tests).
+def init_otel_testing(exporter: Any, metric_exporter: Any | None = None) -> None:
+    """Initialize OTel with caller-supplied exporters (for tests).
 
-    Uses a SimpleSpanProcessor for immediate export.
+    Uses a SimpleSpanProcessor for immediate span export.
+    When metric_exporter is None, a ConsoleMetricExporter is used as a stand-in.
     """
-    global _provider
+    global _provider, _meter_provider
 
     if not _HAS_OTEL:
         return
@@ -98,20 +140,31 @@ def init_otel_testing(exporter: Any) -> None:
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
     resource = Resource.create({"service.name": "cad-dxf-agent-test"})
+
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     _provider = provider
 
+    chosen_metric_exporter = (
+        metric_exporter if metric_exporter is not None else ConsoleMetricExporter()
+    )
+    reader = PeriodicExportingMetricReader(chosen_metric_exporter)
+    _meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+
 
 def reset_otel() -> None:
     """Reset OTel state (for test teardown)."""
-    global _provider
+    global _provider, _meter_provider
 
     if _provider is not None and hasattr(_provider, "shutdown"):
         with contextlib.suppress(Exception):
             _provider.shutdown()
-
     _provider = None
+
+    if _meter_provider is not None and hasattr(_meter_provider, "shutdown"):
+        with contextlib.suppress(Exception):
+            _meter_provider.shutdown()
+    _meter_provider = None
 
 
 def get_tracer(name: str = "cad-dxf-agent") -> Any:
@@ -126,6 +179,58 @@ def get_tracer(name: str = "cad-dxf-agent") -> Any:
     return _LazyTracer(name)
 
 
+def get_meter(name: str = "cad-dxf-agent") -> Any:
+    """Return a lazy meter that delegates to the current meter provider.
+
+    Returns a no-op meter if OTel is not installed. If OTel is installed but
+    not yet initialized, the meter will return no-op instruments until init is called.
+    """
+    if not _HAS_OTEL:
+        return _NoOpMeter()
+
+    return _LazyMeter(name)
+
+
+def create_metrics(meter_name: str = "cad-dxf-agent") -> dict[str, Any]:
+    """Create and return the standard set of cad-dxf-agent instruments.
+
+    Call once at application startup and share the returned dict across modules.
+    All instruments are no-ops when OTel is not installed or not initialized.
+
+    Returns:
+        dict with keys:
+            - ``request_count`` — Counter, total requests processed
+            - ``request_latency`` — Histogram, request latency in milliseconds
+            - ``agent_turns`` — Histogram, agent turns per request
+            - ``tool_call_success`` — Counter, successful tool calls
+            - ``tool_call_failure`` — Counter, failed tool calls
+    """
+    meter = get_meter(meter_name)
+    return {
+        "request_count": meter.create_counter(
+            "cad.request.count",
+            description="Total requests processed",
+        ),
+        "request_latency": meter.create_histogram(
+            "cad.request.latency_ms",
+            description="Request latency in milliseconds",
+            unit="ms",
+        ),
+        "agent_turns": meter.create_histogram(
+            "cad.agent.turns",
+            description="Agent turns per request",
+        ),
+        "tool_call_success": meter.create_counter(
+            "cad.tool.success",
+            description="Successful tool calls",
+        ),
+        "tool_call_failure": meter.create_counter(
+            "cad.tool.failure",
+            description="Failed tool calls",
+        ),
+    }
+
+
 @contextmanager
 def span(name: str, attributes: dict[str, Any] | None = None) -> Generator[Any, None, None]:
     """Context manager wrapper for ergonomic span usage.
@@ -138,6 +243,11 @@ def span(name: str, attributes: dict[str, Any] | None = None) -> Generator[Any, 
             for k, v in attributes.items():
                 s.set_attribute(k, v)
         yield s
+
+
+# ---------------------------------------------------------------------------
+# Lazy delegates
+# ---------------------------------------------------------------------------
 
 
 class _LazyTracer:
@@ -158,6 +268,33 @@ class _LazyTracer:
                 yield s
         else:
             yield _NoOpSpan()
+
+
+class _LazyMeter:
+    """Meter that delegates to the current _meter_provider at call time.
+
+    This ensures module-level ``meter = get_meter(__name__)`` works correctly
+    even if OTel is initialized after import.
+    """
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def _real_meter(self) -> Any:
+        if _meter_provider is not None:
+            return _meter_provider.get_meter(self._name)
+        return _NoOpMeter()
+
+    def create_counter(self, name: str, **kwargs: Any) -> Any:
+        return self._real_meter().create_counter(name, **kwargs)
+
+    def create_histogram(self, name: str, **kwargs: Any) -> Any:
+        return self._real_meter().create_histogram(name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# No-op stand-ins
+# ---------------------------------------------------------------------------
 
 
 class _NoOpSpan:
@@ -184,3 +321,27 @@ class _NoOpTracer:
     @contextmanager
     def start_as_current_span(self, name: str, **kwargs: Any) -> Generator[_NoOpSpan, None, None]:
         yield _NoOpSpan()
+
+
+class _NoOpCounter:
+    """No-op counter instrument."""
+
+    def add(self, amount: int | float, attributes: dict[str, Any] | None = None) -> None:
+        pass
+
+
+class _NoOpHistogram:
+    """No-op histogram instrument."""
+
+    def record(self, amount: int | float, attributes: dict[str, Any] | None = None) -> None:
+        pass
+
+
+class _NoOpMeter:
+    """Minimal stand-in meter when OTel is not installed or not initialized."""
+
+    def create_counter(self, name: str, **kwargs: Any) -> _NoOpCounter:
+        return _NoOpCounter()
+
+    def create_histogram(self, name: str, **kwargs: Any) -> _NoOpHistogram:
+        return _NoOpHistogram()

--- a/src/cad_dxf_agent/settings.py
+++ b/src/cad_dxf_agent/settings.py
@@ -93,6 +93,15 @@ class Settings:
         # Edit history
         self.max_undo_snapshots: int = int(os.getenv("CAD_MAX_UNDO_SNAPSHOTS", "50"))
 
+        # Agent backend (EPIC-CAD-31: Phase 0+1 only, Phase 2+ deferred)
+        agent_backend = os.getenv("CAD_AGENT_BACKEND", "cloud_run")
+        if agent_backend not in ("cloud_run", "agent_engine"):
+            raise ValueError(
+                f"CAD_AGENT_BACKEND must be 'cloud_run' or 'agent_engine', got '{agent_backend}'"
+            )
+        self.agent_backend: str = agent_backend
+        self.agent_engine_url: str | None = os.getenv("CAD_AGENT_ENGINE_URL") or None
+
     def get_api_key(self, provider: str) -> str | None:
         """Retrieve API key for a provider. Never logs the key."""
         key_map = {

--- a/tests/unit/test_drift_detection.py
+++ b/tests/unit/test_drift_detection.py
@@ -1,0 +1,475 @@
+"""Tests for architectural drift detection (scripts/ci/check_nodrift.sh).
+
+The test suite has two layers:
+
+1. Script-level integration tests — run the real bash script against the
+   actual repo tree via subprocess.  ``test_clean_repo_passes`` is the
+   primary gate: it confirms zero violations on the current working tree.
+
+2. Pattern-unit tests — verify the exact regexes the script uses so that
+   regressions in the patterns are caught without a full shell round-trip.
+   These are fast, hermetic, and cover both positive (violation detected)
+   and negative (approved code not flagged) cases.
+
+Note on subprocess injection: the script resolves REPO_ROOT from its own
+``$(dirname "$0")`` location, so it always scans the actual repo tree
+regardless of the ``cwd`` passed to subprocess.run.  We therefore do not
+attempt to inject temporary violations into a fake tree; instead the
+pattern tests cover the detection logic, and the clean-repo test proves
+the script runs correctly end-to-end.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "check_nodrift.sh"
+
+# ---------------------------------------------------------------------------
+# Compiled patterns — mirror what check_nodrift.sh uses
+# ---------------------------------------------------------------------------
+
+# Check 1
+_FORBIDDEN_FRAMEWORK_RE = re.compile(
+    r"^(import |from )(langchain|crewai|autogen|llamaindex|llama_index)",
+    re.MULTILINE,
+)
+
+# Check 2
+_MSP_ADD_RE = re.compile(r"msp\.add_")
+_SAVEAS_RE = re.compile(r"\.saveas\(")
+_ENTITY_ATTR_WRITE_RE = re.compile(r"entity\.dxf\.\w+\s*=[^=]")
+
+# Check 5 & 6
+_ADK_IMPORT_RE = re.compile(r"^(import |from )google\.adk", re.MULTILINE)
+
+# ---------------------------------------------------------------------------
+# Script-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestScriptExists:
+    """Basic sanity checks that the script is present and accessible."""
+
+    def test_script_exists(self) -> None:
+        """The drift detection script is present in the repo."""
+        assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+
+    def test_script_starts_with_bash_shebang(self) -> None:
+        """The script has a recognisable shell shebang on the first line."""
+        first_line = SCRIPT.read_text().splitlines()[0]
+        assert first_line.startswith("#!/"), f"Unexpected first line: {first_line!r}"
+        assert "bash" in first_line or "env" in first_line
+
+
+class TestCleanRepoPasses:
+    """The script must exit 0 on the current unmodified repository."""
+
+    def test_clean_repo_passes(self) -> None:
+        """Running the script on the actual repo exits 0 (no violations)."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            "Drift detected in the repo — fix violations before merging.\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+    def test_clean_repo_output_contains_all_check_headers(self) -> None:
+        """Every check emits its header and a PASS line when the repo is clean."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=30,
+        )
+        assert result.returncode == 0
+        for check_number in range(1, 7):
+            assert f"Check {check_number}" in result.stdout, (
+                f"Check {check_number} header missing from script output"
+            )
+        assert "ALL CLEAR" in result.stdout
+
+    def test_clean_repo_has_no_pass_failures(self) -> None:
+        """The word FAIL does not appear in the output on a clean run."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=30,
+        )
+        assert "FAIL:" not in result.stdout, (
+            f"Unexpected FAIL in clean-repo output:\n{result.stdout}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check 1: Forbidden framework imports
+# ---------------------------------------------------------------------------
+
+
+class TestCheck1ForbiddenImports:
+    """Regex used by Check 1 correctly matches and rejects the right lines."""
+
+    @pytest.mark.parametrize(
+        "bad_line",
+        [
+            "from langchain import chains",
+            "import langchain",
+            "from crewai import Agent",
+            "import crewai",
+            "from autogen import AssistantAgent",
+            "import autogen",
+            "from llamaindex import VectorIndex",
+            "import llamaindex",
+            "from llama_index.core import Document",
+            "import llama_index",
+        ],
+    )
+    def test_forbidden_import_pattern_matches(self, bad_line: str) -> None:
+        """Pattern flags every top-level import of a forbidden framework."""
+        assert _FORBIDDEN_FRAMEWORK_RE.search(bad_line), (
+            f"Pattern should have matched: {bad_line!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "good_line",
+        [
+            "from vertexai import generative_models",
+            "import google.cloud.aiplatform",
+            "from google.adk import Agent",  # ADK is caught by check 5, not check 1
+            "import google.generativeai",
+            "# from langchain import chains",  # comment — no match expected
+            "    from langchain import chains",  # indented — regex anchors to ^ with MULTILINE
+        ],
+    )
+    def test_approved_import_not_flagged(self, good_line: str) -> None:
+        """Lines that are not top-level forbidden imports do not match."""
+        assert not _FORBIDDEN_FRAMEWORK_RE.search(good_line), (
+            f"Pattern should NOT have matched: {good_line!r}"
+        )
+
+    def test_check1_passes_on_real_src(self) -> None:
+        """No forbidden framework imports exist anywhere in src/."""
+        violations: list[str] = []
+        for py_file in (REPO_ROOT / "src").rglob("*.py"):
+            content = py_file.read_text(errors="replace")
+            if _FORBIDDEN_FRAMEWORK_RE.search(content):
+                violations.append(str(py_file.relative_to(REPO_ROOT)))
+        assert violations == [], "Forbidden framework imports found in src/:\n" + "\n".join(
+            violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check 2: DXF mutation confined to approved modules
+# ---------------------------------------------------------------------------
+
+APPROVED_MUTATION_FILES: frozenset[str] = frozenset(
+    [
+        "src/cad_dxf_agent/core/edit_engine.py",
+        "src/cad_dxf_agent/core/dxf_reader.py",
+        "src/cad_dxf_agent/core/dxf_writer.py",
+        "src/cad_dxf_agent/core/revision_notes.py",
+        "src/cad_dxf_agent/core/converter.py",
+        "src/cad_dxf_agent/core/comparison/applier.py",
+        "src/cad_dxf_agent/core/comparison/diff_overlay.py",
+        "src/cad_dxf_agent/core/comparison/bundle.py",
+        "src/cad_dxf_agent/cli/commands.py",
+    ]
+)
+
+
+class TestCheck2DxfMutation:
+    """Check 2 verifies DXF mutations do not appear outside approved files."""
+
+    def test_approved_files_list_contains_edit_engine(self) -> None:
+        """edit_engine.py is always in the approved mutation file list."""
+        assert "src/cad_dxf_agent/core/edit_engine.py" in APPROVED_MUTATION_FILES
+
+    # --- msp.add_* ---
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "msp.add_line((0, 0), (10, 0))",
+            "msp.add_circle(center=(0, 0), radius=5)",
+            "msp.add_lwpolyline(points)",
+            "msp.add_text('hello')",
+        ],
+    )
+    def test_msp_add_pattern_matches(self, line: str) -> None:
+        """msp.add_* pattern catches entity-creation calls."""
+        assert _MSP_ADD_RE.search(line), f"Pattern should match: {line!r}"
+
+    def test_msp_add_not_in_unapproved_files(self) -> None:
+        """No unapproved Python file contains a msp.add_* call."""
+        violations = _find_pattern_outside_approved(_MSP_ADD_RE)
+        assert violations == [], "msp.add_* found outside approved modules:\n" + "\n".join(
+            violations
+        )
+
+    # --- .saveas() ---
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'doc.saveas("output.dxf")',
+            "drawing.saveas(output_path)",
+        ],
+    )
+    def test_saveas_pattern_matches(self, line: str) -> None:
+        """.saveas() pattern catches DXF file-save calls."""
+        assert _SAVEAS_RE.search(line), f"Pattern should match: {line!r}"
+
+    def test_saveas_not_in_unapproved_files(self) -> None:
+        """No unapproved Python file contains a .saveas() call."""
+        violations = _find_pattern_outside_approved(_SAVEAS_RE)
+        assert violations == [], ".saveas() found outside approved modules:\n" + "\n".join(
+            violations
+        )
+
+    # --- entity.dxf.X = ... ---
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "entity.dxf.color = 1",
+            "entity.dxf.layer = 'WALLS'",
+            "entity.dxf.insert = (0, 0, 0)",
+        ],
+    )
+    def test_entity_attr_write_pattern_matches(self, line: str) -> None:
+        """entity.dxf.X = ... pattern catches attribute-mutation writes."""
+        assert _ENTITY_ATTR_WRITE_RE.search(line), f"Pattern should match: {line!r}"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "if entity.dxf.color == 1:",
+            "assert entity.dxf.layer == 'WALLS'",
+            "entity.dxf.color != 0",
+        ],
+    )
+    def test_entity_attr_comparison_not_flagged(self, line: str) -> None:
+        """Comparison operators (== !=) are reads, not mutations — must not match."""
+        assert not _ENTITY_ATTR_WRITE_RE.search(line), (
+            f"Pattern should NOT match comparison: {line!r}"
+        )
+
+    def test_entity_attr_mutation_not_in_unapproved_files(self) -> None:
+        """No unapproved Python file mutates entity.dxf attributes."""
+        violations = _find_pattern_outside_approved(_ENTITY_ATTR_WRITE_RE)
+        assert violations == [], "entity.dxf.X = ... found outside approved modules:\n" + "\n".join(
+            violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check 3: Protected layer dual-enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestCheck3ProtectedLayers:
+    """Check 3 verifies protected-layer enforcement exists in the right modules."""
+
+    def test_validators_py_references_protected_layers(self) -> None:
+        """validators.py contains the string 'protected_layers'."""
+        validators = REPO_ROOT / "src/cad_dxf_agent/core/validators.py"
+        assert validators.exists(), "validators.py missing"
+        assert "protected_layers" in validators.read_text(), (
+            "validators.py must reference 'protected_layers'"
+        )
+
+    def test_tool_executor_py_references_protected(self) -> None:
+        """tool_executor.py contains the string 'protected'."""
+        tool_executor = REPO_ROOT / "src/cad_dxf_agent/llm/tool_executor.py"
+        assert tool_executor.exists(), "tool_executor.py missing"
+        assert "protected" in tool_executor.read_text(), (
+            "tool_executor.py must reference 'protected'"
+        )
+
+    @pytest.mark.parametrize("layer", ["TITLE", "TITLEBLOCK", "SEAL", "REVISION"])
+    def test_config_schema_defines_each_protected_layer(self, layer: str) -> None:
+        """config_schema.py declares each canonical protected layer by name."""
+        config_schema = REPO_ROOT / "src/cad_dxf_agent/models/config_schema.py"
+        assert config_schema.exists(), "config_schema.py missing"
+        assert layer in config_schema.read_text(), (
+            f"Canonical protected layer '{layer}' missing from config_schema.py"
+        )
+
+    def test_config_schema_layers_appear_on_one_line(self) -> None:
+        """All four layers appear on a single line (the script's regex requirement).
+
+        The script uses the pattern ``TITLE.*TITLEBLOCK.*SEAL.*REVISION`` as a
+        single-line grep, so all four names must co-exist on one line in
+        config_schema.py (the default-factory list).
+        """
+        config_schema = REPO_ROOT / "src/cad_dxf_agent/models/config_schema.py"
+        script_pattern = re.compile(r"TITLE.*TITLEBLOCK.*SEAL.*REVISION")
+        assert script_pattern.search(config_schema.read_text()), (
+            "config_schema.py must have all four protected layers on one line; "
+            "the script grep uses: TITLE.*TITLEBLOCK.*SEAL.*REVISION"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check 4: No .env files committed
+# ---------------------------------------------------------------------------
+
+
+class TestCheck4NoEnvFiles:
+    """Check 4 ensures no .env files are tracked by git."""
+
+    def test_no_env_files_tracked_by_git(self) -> None:
+        """git ls-files reports no .env files (excluding .env.example)."""
+        result = subprocess.run(
+            ["git", "ls-files", "*.env", ".env*", "web/.env*"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=10,
+        )
+        tracked = [
+            f for f in result.stdout.strip().splitlines() if f and not f.endswith(".env.example")
+        ]
+        assert tracked == [], (
+            "Found tracked .env files — remove with git rm --cached:\n" + "\n".join(tracked)
+        )
+
+    def test_env_example_exclusion_logic(self) -> None:
+        r"""Files ending in .env.example are permitted; bare .env files are not.
+
+        This mirrors the ``grep -v '\.env\.example$'`` exclusion in the script.
+        """
+        candidates = [".env.example", "web/.env.example", ".env", "web/.env", "secrets.env"]
+        violations = [f for f in candidates if not f.endswith(".env.example")]
+        assert ".env.example" not in violations
+        assert "web/.env.example" not in violations
+        assert ".env" in violations
+        assert "web/.env" in violations
+        assert "secrets.env" in violations
+
+
+# ---------------------------------------------------------------------------
+# Check 5: No google.adk imports outside the adk/ module
+# ---------------------------------------------------------------------------
+
+
+class TestCheck5AdkImports:
+    """Check 5 ensures google.adk usage is confined to src/cad_dxf_agent/adk/."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "from google.adk import Agent",
+            "from google.adk.agents import LlmAgent",
+            "import google.adk",
+        ],
+    )
+    def test_adk_import_pattern_matches(self, line: str) -> None:
+        """Pattern correctly identifies google.adk import statements."""
+        assert _ADK_IMPORT_RE.search(line), f"Pattern should match: {line!r}"
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "from google.cloud import storage",
+            "import google.cloud.aiplatform",
+            "from google.generativeai import GenerativeModel",
+            "# from google.adk import Agent",  # comment
+            "    from google.adk import Agent",  # indented — not top-level
+        ],
+    )
+    def test_non_adk_google_import_not_flagged(self, line: str) -> None:
+        """Other google.* imports are not mistaken for google.adk."""
+        assert not _ADK_IMPORT_RE.search(line), f"Pattern should NOT match: {line!r}"
+
+    def test_no_rogue_adk_imports_in_src(self) -> None:
+        """No google.adk imports exist outside src/cad_dxf_agent/adk/ right now."""
+        src_root = REPO_ROOT / "src"
+        adk_dir = src_root / "cad_dxf_agent" / "adk"
+        violations: list[str] = []
+        for py_file in src_root.rglob("*.py"):
+            try:
+                py_file.relative_to(adk_dir)
+                continue  # file is inside the approved adk/ module
+            except ValueError:
+                pass
+            if _ADK_IMPORT_RE.search(py_file.read_text(errors="replace")):
+                violations.append(str(py_file.relative_to(REPO_ROOT)))
+        assert violations == [], "google.adk imported outside approved adk/ module:\n" + "\n".join(
+            violations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Check 6: Gateway must not import google.adk
+# ---------------------------------------------------------------------------
+
+
+class TestCheck6GatewayNoAdk:
+    """Check 6 enforces the gateway-as-pure-proxy rule (no ADK coupling)."""
+
+    def test_gateway_file_exists(self) -> None:
+        """The gateway file web/backend/main.py is present."""
+        main_py = REPO_ROOT / "web" / "backend" / "main.py"
+        assert main_py.exists(), "web/backend/main.py not found"
+
+    def test_gateway_does_not_import_google_adk(self) -> None:
+        """web/backend/main.py contains no google.adk import."""
+        main_py = REPO_ROOT / "web" / "backend" / "main.py"
+        content = main_py.read_text()
+        assert not _ADK_IMPORT_RE.search(content), (
+            "web/backend/main.py must not import google.adk — "
+            "the gateway is a pure proxy with no ADK dependency."
+        )
+
+    def test_adk_detection_distinguishes_from_google_cloud(self) -> None:
+        """ADK pattern does not accidentally flag other google.* modules."""
+        gateway_like_approved = (
+            "from google.cloud import storage\n"
+            "import google.auth\n"
+            "from google.oauth2 import credentials\n"
+        )
+        assert not _ADK_IMPORT_RE.search(gateway_like_approved), (
+            "Pattern incorrectly flagged approved google.* imports"
+        )
+
+    def test_adk_detection_catches_gateway_violation(self) -> None:
+        """Pattern matches when google.adk appears as it would in a violation."""
+        gateway_violation = (
+            "from fastapi import FastAPI\nfrom google.adk import Agent\napp = FastAPI()\n"
+        )
+        assert _ADK_IMPORT_RE.search(gateway_violation), (
+            "Pattern should have matched google.adk import in gateway code"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_pattern_outside_approved(pattern: re.Pattern[str]) -> list[str]:
+    """Return relative paths of src/ files that match *pattern* and are not approved."""
+    src_root = REPO_ROOT / "src"
+    violations: list[str] = []
+    for py_file in src_root.rglob("*.py"):
+        relative = str(py_file.relative_to(REPO_ROOT))
+        if relative in APPROVED_MUTATION_FILES:
+            continue
+        if pattern.search(py_file.read_text(errors="replace")):
+            violations.append(relative)
+    return violations

--- a/tests/unit/test_tool_definitions.py
+++ b/tests/unit/test_tool_definitions.py
@@ -109,8 +109,15 @@ class TestToolNarrowing:
         assert tools == ALL_TOOLS
 
     def test_non_modify_gets_query_only(self):
-        for rc in ("understand", "estimate", "recommend", "optimize",
-                    "summarize", "compare", "validate"):
+        for rc in (
+            "understand",
+            "estimate",
+            "recommend",
+            "optimize",
+            "summarize",
+            "compare",
+            "validate",
+        ):
             tools = get_tools_for_request_class(rc)
             assert tools == QUERY_TOOLS, f"{rc} should get QUERY_TOOLS only"
             # Verify no edit tools leak through
@@ -120,8 +127,16 @@ class TestToolNarrowing:
 
     def test_query_tools_always_present(self):
         """Every request class gets at least the query tools."""
-        for rc in ("modify", "understand", "estimate", "recommend",
-                    "optimize", "summarize", "compare", "validate"):
+        for rc in (
+            "modify",
+            "understand",
+            "estimate",
+            "recommend",
+            "optimize",
+            "summarize",
+            "compare",
+            "validate",
+        ):
             tools = get_tools_for_request_class(rc)
             tool_names = {t["name"] for t in tools}
             query_names = {t["name"] for t in QUERY_TOOLS}

--- a/tests/unit/test_tool_functions.py
+++ b/tests/unit/test_tool_functions.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 import pytest
 
 from cad_dxf_agent.llm.tool_definitions import (
+    ALL_TOOLS,
+    EDIT_TOOL_FUNCTIONS,
+    EDIT_TOOLS,
     QUERY_TOOL_FUNCTIONS,
     QUERY_TOOLS,
+    ToolPoint2D,
     _fn_to_tool_schema,
     _hint_to_json_schema,
     _tools_as_schemas,
@@ -57,10 +61,10 @@ class TestToolFunctionSchemas:
             assert fn.__doc__, f"{fn.__name__} missing docstring"
 
     def test_tools_as_schemas_returns_list(self):
-        """_tools_as_schemas returns a list of well-formed dicts."""
+        """_tools_as_schemas returns a list of well-formed dicts covering all tool functions."""
         schemas = _tools_as_schemas()
         assert isinstance(schemas, list)
-        assert len(schemas) == len(QUERY_TOOL_FUNCTIONS)
+        assert len(schemas) == len(QUERY_TOOL_FUNCTIONS) + len(EDIT_TOOL_FUNCTIONS)
         for s in schemas:
             assert "name" in s
             assert "description" in s
@@ -202,3 +206,196 @@ class TestHintToJsonSchema:
 
         result = _hint_to_json_schema(_Custom)
         assert result == {"type": "string"}
+
+
+class TestEditToolFunctionSchemas:
+    """Verify edit typed functions produce equivalent schemas to hand-written dicts."""
+
+    def test_edit_tool_count_matches(self):
+        """Same number of edit tool functions and edit tool dicts (should be 18)."""
+        assert len(EDIT_TOOL_FUNCTIONS) == len(EDIT_TOOLS)
+        assert len(EDIT_TOOL_FUNCTIONS) == 18
+
+    def test_edit_tool_names_match(self):
+        """Function names (minus _fn suffix) match dict names for edit tools."""
+        fn_names = {fn.__name__.removesuffix("_fn") for fn in EDIT_TOOL_FUNCTIONS}
+        dict_names = {t["name"] for t in EDIT_TOOLS}
+        assert fn_names == dict_names
+
+    def test_edit_required_params_match(self):
+        """Required parameters match between typed edit functions and dicts."""
+        for fn in EDIT_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            name = schema["name"]
+            dict_schema = next(t for t in EDIT_TOOLS if t["name"] == name)
+            assert set(schema["parameters"]["required"]) == set(
+                dict_schema["parameters"]["required"]
+            ), f"Required params mismatch for {name}"
+
+    def test_edit_parameter_names_match(self):
+        """Parameter names match between typed edit functions and dicts."""
+        for fn in EDIT_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            name = schema["name"]
+            dict_schema = next(t for t in EDIT_TOOLS if t["name"] == name)
+            fn_params = set(schema["parameters"]["properties"].keys())
+            dict_params = set(dict_schema["parameters"]["properties"].keys())
+            assert fn_params == dict_params, f"Param names mismatch for {name}"
+
+    def test_all_edit_functions_have_docstrings(self):
+        """Every edit tool function has a docstring."""
+        for fn in EDIT_TOOL_FUNCTIONS:
+            assert fn.__doc__, f"{fn.__name__} missing docstring"
+
+    def test_edit_schema_descriptions_not_empty(self):
+        """All auto-generated edit tool descriptions are non-trivially long."""
+        for fn in EDIT_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            assert len(schema["description"]) > 10, (
+                f"{schema['name']} has a suspiciously short description"
+            )
+
+    def test_edit_functions_raise_not_implemented(self):
+        """All 18 edit stub functions raise NotImplementedError."""
+        from cad_dxf_agent.llm.tool_definitions import (
+            add_arc_fn,
+            add_block_fn,
+            add_circle_fn,
+            add_line_fn,
+            add_polyline_fn,
+            add_text_fn,
+            batch_delete_fn,
+            batch_edit_text_fn,
+            batch_move_fn,
+            batch_rotate_fn,
+            batch_scale_fn,
+            copy_entity_fn,
+            delete_entity_fn,
+            edit_text_fn,
+            mirror_entity_fn,
+            move_entity_fn,
+            rotate_entity_fn,
+            scale_entity_fn,
+        )
+
+        stubs_and_args: list[tuple] = [
+            (move_entity_fn, ("abc", 1.0, 2.0)),
+            (edit_text_fn, ("abc", "new")),
+            (delete_entity_fn, ("abc",)),
+            (add_block_fn, ("DOOR", 0.0, 0.0)),
+            (rotate_entity_fn, ("abc", 90.0)),
+            (copy_entity_fn, ("abc", 5.0, 0.0)),
+            (scale_entity_fn, ("abc", 2.0)),
+            (mirror_entity_fn, ("abc", "x")),
+            (add_line_fn, (ToolPoint2D(0, 0), ToolPoint2D(10, 0))),
+            (add_polyline_fn, ([ToolPoint2D(0, 0), ToolPoint2D(5, 5)],)),
+            (add_circle_fn, (ToolPoint2D(0, 0), 5.0)),
+            (add_arc_fn, (ToolPoint2D(0, 0), 5.0, 0.0, 90.0)),
+            (add_text_fn, ("hello", ToolPoint2D(0, 0))),
+            (batch_move_fn, (1.0, 2.0)),
+            (batch_rotate_fn, (45.0,)),
+            (batch_scale_fn, (2.0,)),
+            (batch_delete_fn, ()),
+            (batch_edit_text_fn, ("old", "new")),
+        ]
+
+        for fn, args in stubs_and_args:
+            with pytest.raises(NotImplementedError):
+                fn(*args)
+
+    def test_all_tools_typed(self):
+        """Critical CI gate: every tool in ALL_TOOLS has a corresponding typed stub.
+
+        len(EDIT_TOOL_FUNCTIONS) + len(QUERY_TOOL_FUNCTIONS) must equal len(ALL_TOOLS).
+        This ensures that as new tools are added to the hand-written dicts, typed
+        stubs are added as well.
+        """
+        assert len(EDIT_TOOL_FUNCTIONS) + len(QUERY_TOOL_FUNCTIONS) == len(ALL_TOOLS)
+
+
+class TestSchemaEdgeCases:
+    """Edge-case coverage for _hint_to_json_schema and _fn_to_tool_schema."""
+
+    def test_literal_type_produces_enum(self):
+        """typing.Literal['x', 'y'] produces a string enum schema."""
+        from typing import Literal
+
+        hint = Literal["x", "y"]
+        result = _hint_to_json_schema(hint)
+        assert result["type"] == "string"
+        assert result["enum"] == ["x", "y"]
+
+    def test_literal_entity_types(self):
+        """A full entity-type Literal produces the correct enum list."""
+        from typing import Literal
+
+        hint = Literal["LINE", "LWPOLYLINE", "TEXT", "MTEXT", "INSERT", "CIRCLE", "ARC"]
+        result = _hint_to_json_schema(hint)
+        assert "enum" in result
+        assert "LINE" in result["enum"]
+        assert len(result["enum"]) == 7
+
+    def test_dataclass_produces_object_schema(self):
+        """ToolPoint2D dataclass produces a nested object schema with x and y."""
+        result = _hint_to_json_schema(ToolPoint2D)
+        assert result["type"] == "object"
+        assert "x" in result["properties"]
+        assert "y" in result["properties"]
+        assert result["properties"]["x"]["type"] == "number"
+        assert result["properties"]["y"]["type"] == "number"
+
+    def test_list_str_produces_array_schema(self):
+        """list[str] produces an array schema with string items."""
+        result = _hint_to_json_schema(list[str])
+        assert result == {"type": "array", "items": {"type": "string"}}
+
+    def test_list_dataclass_produces_array_of_objects(self):
+        """list[ToolPoint2D] produces an array-of-objects schema."""
+        result = _hint_to_json_schema(list[ToolPoint2D])
+        assert result["type"] == "array"
+        assert result["items"]["type"] == "object"
+        assert "x" in result["items"]["properties"]
+        assert "y" in result["items"]["properties"]
+
+    def test_colon_in_description_edge_case(self):
+        """A colon inside a param description line is not treated as a new parameter."""
+
+        def _colon_test_fn(mode: str) -> dict:
+            """Test function.
+
+            Args:
+                mode: The mode to use. Note: case-insensitive matching is applied
+            """
+            raise NotImplementedError
+
+        schema = _fn_to_tool_schema(_colon_test_fn)
+        desc = schema["parameters"]["properties"]["mode"]["description"]
+        assert "Note:" in desc  # The colon should not split the description
+
+    def test_function_with_no_args_section(self):
+        """A function with a docstring but no Args: section produces empty properties."""
+
+        def _no_args_fn() -> dict:
+            """A function with no parameters."""
+            raise NotImplementedError
+
+        schema = _fn_to_tool_schema(_no_args_fn)
+        assert schema["parameters"]["properties"] == {}
+        assert schema["parameters"]["required"] == []
+
+    def test_list_str_type_hint(self):
+        """A list[str] parameter in a function generates an array schema."""
+
+        def _list_fn(tags: list[str]) -> dict:
+            """A function with a list param.
+
+            Args:
+                tags: Tag strings to apply
+            """
+            raise NotImplementedError
+
+        schema = _fn_to_tool_schema(_list_fn)
+        tags_prop = schema["parameters"]["properties"]["tags"]
+        assert tags_prop["type"] == "array"
+        assert tags_prop["items"] == {"type": "string"}
+        assert "tags" in schema["parameters"]["required"]

--- a/tests/unit/test_tool_functions.py
+++ b/tests/unit/test_tool_functions.py
@@ -1,0 +1,204 @@
+"""Tests for ADK-pattern typed tool functions.
+
+Validates that the auto-generated schemas from typed Python functions
+match the hand-written dict schemas, ensuring the two representations
+stay in sync as we migrate toward ADK.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.tool_definitions import (
+    QUERY_TOOL_FUNCTIONS,
+    QUERY_TOOLS,
+    _fn_to_tool_schema,
+    _hint_to_json_schema,
+    _tools_as_schemas,
+)
+
+
+class TestToolFunctionSchemas:
+    """Verify typed functions produce equivalent schemas to hand-written dicts."""
+
+    def test_query_tool_count_matches(self):
+        """Same number of query tools in both representations."""
+        assert len(QUERY_TOOL_FUNCTIONS) == len(QUERY_TOOLS)
+
+    def test_tool_names_match(self):
+        """Function names (minus _fn suffix) match dict names."""
+        fn_names = {fn.__name__.removesuffix("_fn") for fn in QUERY_TOOL_FUNCTIONS}
+        dict_names = {t["name"] for t in QUERY_TOOLS}
+        assert fn_names == dict_names
+
+    def test_required_params_match(self):
+        """Required parameters match between typed functions and dicts."""
+        for fn in QUERY_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            name = schema["name"]
+            dict_schema = next(t for t in QUERY_TOOLS if t["name"] == name)
+            assert set(schema["parameters"]["required"]) == set(
+                dict_schema["parameters"]["required"]
+            ), f"Required params mismatch for {name}"
+
+    def test_parameter_names_match(self):
+        """Parameter names match between typed functions and dicts."""
+        for fn in QUERY_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            name = schema["name"]
+            dict_schema = next(t for t in QUERY_TOOLS if t["name"] == name)
+            fn_params = set(schema["parameters"]["properties"].keys())
+            dict_params = set(dict_schema["parameters"]["properties"].keys())
+            assert fn_params == dict_params, f"Param names mismatch for {name}"
+
+    def test_all_functions_have_docstrings(self):
+        """Every tool function has a docstring."""
+        for fn in QUERY_TOOL_FUNCTIONS:
+            assert fn.__doc__, f"{fn.__name__} missing docstring"
+
+    def test_tools_as_schemas_returns_list(self):
+        """_tools_as_schemas returns a list of well-formed dicts."""
+        schemas = _tools_as_schemas()
+        assert isinstance(schemas, list)
+        assert len(schemas) == len(QUERY_TOOL_FUNCTIONS)
+        for s in schemas:
+            assert "name" in s
+            assert "description" in s
+            assert "parameters" in s
+
+    def test_schema_description_not_empty(self):
+        """Auto-generated descriptions are non-trivially long."""
+        for fn in QUERY_TOOL_FUNCTIONS:
+            schema = _fn_to_tool_schema(fn)
+            assert len(schema["description"]) > 10, (
+                f"{schema['name']} has a suspiciously short description"
+            )
+
+    def test_schemas_have_type_object_parameters(self):
+        """Every generated schema has parameters.type == 'object'."""
+        for schema in _tools_as_schemas():
+            assert schema["parameters"]["type"] == "object", (
+                f"{schema['name']} parameters.type is not 'object'"
+            )
+
+    def test_functions_raise_not_implemented(self):
+        """Stub functions raise NotImplementedError — dispatch stays in ToolExecutor."""
+        from cad_dxf_agent.llm.tool_definitions import (
+            find_entities_fn,
+            find_nearest_fn,
+            get_entity_fn,
+            is_protected_fn,
+            list_layers_fn,
+        )
+
+        with pytest.raises(NotImplementedError):
+            find_entities_fn()
+        with pytest.raises(NotImplementedError):
+            get_entity_fn("somehandle")
+        with pytest.raises(NotImplementedError):
+            find_nearest_fn(0.0, 0.0)
+        with pytest.raises(NotImplementedError):
+            list_layers_fn()
+        with pytest.raises(NotImplementedError):
+            is_protected_fn("STRUCTURAL")
+
+    def test_fn_name_suffix_stripped(self):
+        """_fn suffix is stripped when deriving the tool name."""
+        from cad_dxf_agent.llm.tool_definitions import find_entities_fn
+
+        schema = _fn_to_tool_schema(find_entities_fn)
+        assert schema["name"] == "find_entities"
+        assert not schema["name"].endswith("_fn")
+
+    def test_optional_params_are_not_required(self):
+        """Optional parameters (default=None) are absent from required list."""
+        from cad_dxf_agent.llm.tool_definitions import find_entities_fn
+
+        schema = _fn_to_tool_schema(find_entities_fn)
+        # All four params of find_entities_fn have defaults, so required must be empty.
+        assert schema["parameters"]["required"] == []
+
+    def test_positional_params_are_required(self):
+        """Params without defaults appear in the required list."""
+        from cad_dxf_agent.llm.tool_definitions import get_entity_fn, is_protected_fn
+
+        for fn, expected_required in [
+            (get_entity_fn, {"handle"}),
+            (is_protected_fn, {"layer"}),
+        ]:
+            schema = _fn_to_tool_schema(fn)
+            assert set(schema["parameters"]["required"]) == expected_required, (
+                f"{fn.__name__}: required mismatch"
+            )
+
+    def test_find_nearest_required_coords(self):
+        """find_nearest requires x and y, the rest are optional."""
+        from cad_dxf_agent.llm.tool_definitions import find_nearest_fn
+
+        schema = _fn_to_tool_schema(find_nearest_fn)
+        assert set(schema["parameters"]["required"]) == {"x", "y"}
+
+    def test_list_layers_has_no_parameters(self):
+        """list_layers has no parameters and empty required list."""
+        from cad_dxf_agent.llm.tool_definitions import list_layers_fn
+
+        schema = _fn_to_tool_schema(list_layers_fn)
+        assert schema["parameters"]["properties"] == {}
+        assert schema["parameters"]["required"] == []
+
+    def test_param_descriptions_populated(self):
+        """Parameters documented in Args: section have description fields."""
+        from cad_dxf_agent.llm.tool_definitions import find_entities_fn, get_entity_fn
+
+        for fn in (find_entities_fn, get_entity_fn):
+            schema = _fn_to_tool_schema(fn)
+            for pname, prop in schema["parameters"]["properties"].items():
+                assert "description" in prop, (
+                    f"{fn.__name__}.{pname} missing description in generated schema"
+                )
+
+
+class TestHintToJsonSchema:
+    """Unit tests for the _hint_to_json_schema helper."""
+
+    def test_str(self):
+        assert _hint_to_json_schema(str) == {"type": "string"}
+
+    def test_int(self):
+        assert _hint_to_json_schema(int) == {"type": "integer"}
+
+    def test_float(self):
+        assert _hint_to_json_schema(float) == {"type": "number"}
+
+    def test_bool(self):
+        assert _hint_to_json_schema(bool) == {"type": "boolean"}
+
+    def test_dict(self):
+        assert _hint_to_json_schema(dict) == {"type": "object"}
+
+    def test_list(self):
+        assert _hint_to_json_schema(list) == {"type": "array"}
+
+    def test_optional_str(self):
+        """str | None collapses to string schema."""
+        hint = str | None
+        assert _hint_to_json_schema(hint) == {"type": "string"}
+
+    def test_optional_float(self):
+        """float | None collapses to number schema."""
+        hint = float | None
+        assert _hint_to_json_schema(hint) == {"type": "number"}
+
+    def test_optional_int(self):
+        """int | None collapses to integer schema."""
+        hint = int | None
+        assert _hint_to_json_schema(hint) == {"type": "integer"}
+
+    def test_unknown_falls_back_to_string(self):
+        """Unrecognised types fall back to string schema without raising."""
+
+        class _Custom:
+            pass
+
+        result = _hint_to_json_schema(_Custom)
+        assert result == {"type": "string"}

--- a/tests/unit/test_zone_detector.py
+++ b/tests/unit/test_zone_detector.py
@@ -507,3 +507,80 @@ class TestAspectRatio:
 
     def test_single_point(self):
         assert _aspect_ratio([Point2D(x=0, y=0)]) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Geometry helper reference-value tests
+# ---------------------------------------------------------------------------
+
+
+class TestGeometryHelpers:
+    """Reference-value assertions for geometry functions.
+
+    These serve as regression tests with exact expected values,
+    and as Shapely-equivalent reference tests for future migration.
+    """
+
+    def test_square_10x10_area(self):
+        """10x10 square: area = 100.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=10), Point2D(x=0, y=10)]
+        assert _shoelace_area(points) == pytest.approx(100.0)
+
+    def test_square_10x10_perimeter(self):
+        """10x10 square: perimeter = 40.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=10), Point2D(x=0, y=10)]
+        assert _polygon_perimeter(points) == pytest.approx(40.0)
+
+    def test_square_10x10_centroid(self):
+        """10x10 square: centroid = (5.0, 5.0)"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=10), Point2D(x=0, y=10)]
+        c = _polygon_centroid(points)
+        assert c.x == pytest.approx(5.0)
+        assert c.y == pytest.approx(5.0)
+
+    def test_square_10x10_aspect_ratio(self):
+        """10x10 square: aspect_ratio = 1.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=10), Point2D(x=0, y=10)]
+        assert _aspect_ratio(points) == pytest.approx(1.0)
+
+    def test_rectangle_10x5_aspect_ratio(self):
+        """10x5 rectangle: aspect_ratio = 2.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=5), Point2D(x=0, y=5)]
+        assert _aspect_ratio(points) == pytest.approx(2.0)
+
+    def test_rectangle_10x5_area(self):
+        """10x5 rectangle: area = 50.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=10, y=5), Point2D(x=0, y=5)]
+        assert _shoelace_area(points) == pytest.approx(50.0)
+
+    def test_rectangle_20x15_area(self):
+        """20x15 rectangle: area = 300.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=20, y=0), Point2D(x=20, y=15), Point2D(x=0, y=15)]
+        assert _shoelace_area(points) == pytest.approx(300.0)
+
+    def test_degenerate_polygon_two_vertices(self):
+        """Degenerate polygon (< 3 vertices): area = 0.0 without raising."""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0)]
+        assert _shoelace_area(points) == pytest.approx(0.0)
+
+    def test_degenerate_polygon_single_vertex(self):
+        """Single vertex: area = 0.0 without raising."""
+        points = [Point2D(x=5, y=5)]
+        assert _shoelace_area(points) == pytest.approx(0.0)
+
+    def test_degenerate_polygon_empty(self):
+        """Empty polygon: area = 0.0 without raising."""
+        points: list[Point2D] = []
+        assert _shoelace_area(points) == pytest.approx(0.0)
+
+    def test_triangle_area(self):
+        """Right triangle (0,0)-(10,0)-(0,10): area = 50.0"""
+        points = [Point2D(x=0, y=0), Point2D(x=10, y=0), Point2D(x=0, y=10)]
+        assert _shoelace_area(points) == pytest.approx(50.0)
+
+    def test_offset_rectangle_centroid(self):
+        """Rectangle at (20,0)-(40,15): centroid = (30.0, 7.5)"""
+        points = [Point2D(x=20, y=0), Point2D(x=40, y=0), Point2D(x=40, y=15), Point2D(x=20, y=15)]
+        c = _polygon_centroid(points)
+        assert c.x == pytest.approx(30.0)
+        assert c.y == pytest.approx(7.5)

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -398,3 +398,68 @@ class TestAllowlist:
         os.environ["CAD_WEB_DEV_MODE"] = "1"
         user = {"uid": "any-user"}
         await check_license(user)  # should not raise
+
+
+@pytest.mark.web
+class TestIsDevMode:
+    """Tests for the consolidated is_dev_mode() helper."""
+
+    def test_dev_mode_with_1(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "1")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_with_true(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "true")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_with_yes(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "yes")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_with_true_uppercase(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "TRUE")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_with_yes_uppercase(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "YES")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_with_true_mixed_case(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "True")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True
+
+    def test_dev_mode_disabled_empty(self, monkeypatch):
+        monkeypatch.delenv("CAD_WEB_DEV_MODE", raising=False)
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is False
+
+    def test_dev_mode_disabled_zero(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "0")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is False
+
+    def test_dev_mode_disabled_false(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "false")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is False
+
+    def test_dev_mode_with_whitespace(self, monkeypatch):
+        monkeypatch.setenv("CAD_WEB_DEV_MODE", "  true  ")
+        from web.backend.auth import is_dev_mode
+
+        assert is_dev_mode() is True

--- a/web/backend/api_v1.py
+++ b/web/backend/api_v1.py
@@ -54,6 +54,8 @@ class _RateLimiter:
         self.window_seconds = window_seconds
         self._store: dict[str, list[float]] = {}
         self._lock = threading.Lock()
+        self._call_count = 0
+        self._cleanup_interval = 500  # prune stale IPs every N calls
 
     def is_allowed(self, ip: str) -> bool:
         """Return True if the request should be allowed; False if rate-limited."""
@@ -71,6 +73,15 @@ class _RateLimiter:
 
             timestamps.append(now)
             self._store[ip] = timestamps
+
+            # Periodically prune stale IPs to prevent unbounded memory growth
+            self._call_count += 1
+            if self._call_count >= self._cleanup_interval:
+                self._call_count = 0
+                stale = [k for k, v in self._store.items() if not v or v[-1] <= cutoff]
+                for k in stale:
+                    del self._store[k]
+
             return True
 
 

--- a/web/backend/api_v1.py
+++ b/web/backend/api_v1.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import logging
 import tempfile
+import threading
+import time
 from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
 
 from cad_dxf_agent.core.compliance_rules import check_compliance
 from cad_dxf_agent.core.design_ops import TakeoffGenerator
@@ -34,7 +36,66 @@ from cad_dxf_agent.otel import span as otel_span
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1", tags=["v1-agent"])
+
+# ---------------------------------------------------------------------------
+# Per-IP rate limiter
+# ---------------------------------------------------------------------------
+
+
+class _RateLimiter:
+    """Sliding-window per-IP rate limiter backed by an in-memory dict.
+
+    Not distributed — effective for single-instance Cloud Run deployments.
+    For multi-instance deployments, replace with Redis-backed counting.
+    """
+
+    def __init__(self, max_requests: int = 60, window_seconds: float = 60.0) -> None:
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._store: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def is_allowed(self, ip: str) -> bool:
+        """Return True if the request should be allowed; False if rate-limited."""
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+
+        with self._lock:
+            timestamps = self._store.get(ip, [])
+            # Prune timestamps outside the current window.
+            timestamps = [ts for ts in timestamps if ts > cutoff]
+
+            if len(timestamps) >= self.max_requests:
+                self._store[ip] = timestamps
+                return False
+
+            timestamps.append(now)
+            self._store[ip] = timestamps
+            return True
+
+
+_rate_limiter = _RateLimiter(max_requests=60, window_seconds=60.0)
+
+
+async def _check_rate_limit(request: Request) -> None:
+    """FastAPI dependency that enforces per-IP rate limiting.
+
+    Raises HTTP 429 with a Retry-After header when the limit is exceeded.
+    """
+    ip = request.client.host if request.client else "unknown"
+    if not _rate_limiter.is_allowed(ip):
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded. Max 60 requests per 60 seconds per IP.",
+            headers={"Retry-After": str(int(_rate_limiter.window_seconds))},
+        )
+
+
+router = APIRouter(
+    prefix="/api/v1",
+    tags=["v1-agent"],
+    dependencies=[Depends(_check_rate_limit)],
+)
 
 
 def _save_upload(file: UploadFile) -> Path:

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -12,6 +12,15 @@ from fastapi import HTTPException, Request
 
 logger = logging.getLogger(__name__)
 
+
+def is_dev_mode() -> bool:
+    """Check if the backend is running in development mode.
+
+    Consolidates the CAD_WEB_DEV_MODE check into a single function
+    so all callers agree on which values are truthy.
+    """
+    return os.getenv("CAD_WEB_DEV_MODE", "").strip().lower() in ("1", "true", "yes")
+
 # License cache: {uid: (active: bool, timestamp: float)}
 _license_cache: dict[str, tuple[bool, float]] = {}
 _LICENSE_CACHE_TTL = 300  # 5 minutes
@@ -56,7 +65,7 @@ async def verify_token(request: Request) -> dict:
     Raises HTTPException 401 if missing or invalid.
     """
     # Skip auth in development mode
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         return {"uid": "dev-user", "email": "dev@localhost"}
 
     auth_header = request.headers.get("Authorization", "")
@@ -88,7 +97,7 @@ async def check_license(user: dict) -> None:
     Raises HTTPException 403 if the license is missing or inactive.
     """
     # Skip in dev mode (same as auth skip)
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         return
 
     # Reject anonymous users — Google sign-in required
@@ -237,7 +246,7 @@ async def ensure_user_profile(user: dict) -> dict:
     Subsequent calls hit the in-process cache (5 min TTL).
     In dev mode, returns a synthetic profile without touching Firestore.
     """
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         user["tenant_id"] = "dev-tenant"
         user["display_name"] = user.get("name", user.get("email", "dev"))
         return user

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -58,7 +58,13 @@ from cad_dxf_agent.otel import span as otel_span  # noqa: E402
 from cad_dxf_agent.settings import settings as cad_settings  # noqa: E402
 
 from .api_v1 import router as v1_router  # noqa: E402
-from .auth import _get_profile, _get_tenant, _update_profile, get_licensed_user  # noqa: E402
+from .auth import (  # noqa: E402
+    _get_profile,
+    _get_tenant,
+    _update_profile,
+    get_licensed_user,
+    is_dev_mode,
+)
 from .session import Session, SessionManager  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -107,7 +113,7 @@ async def _session_cleanup_loop():
 async def lifespan(app: FastAPI):
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-    dev_mode = os.getenv("CAD_WEB_DEV_MODE", "").strip() in ("1", "true", "yes")
+    dev_mode = is_dev_mode()
     otel_enabled = os.getenv("OTEL_ENABLED", "").strip() in ("1", "true", "yes")
 
     if dev_mode and otel_enabled:
@@ -527,7 +533,7 @@ def _get_document_store():
             InMemoryDocumentStore,
         )
 
-        if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+        if is_dev_mode():
             _document_store = InMemoryDocumentStore()
             logger.info("Using InMemory document store (dev mode)")
         else:
@@ -604,7 +610,7 @@ class ProfileUpdateRequest(BaseModel):
 @app.get("/api/profile")
 async def get_profile(user: dict = Depends(get_user)):
     """Get the current user's profile."""
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         return {
             "profile": {
                 "uid": user["uid"],
@@ -626,7 +632,7 @@ async def get_profile(user: dict = Depends(get_user)):
 @app.put("/api/profile")
 async def update_profile(body: ProfileUpdateRequest, user: dict = Depends(get_user)):
     """Update the current user's display name and/or company."""
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         profile = {"uid": user["uid"], "display_name": body.display_name or ""}
         if body.company is not None:
             profile["company"] = body.company
@@ -652,7 +658,7 @@ async def update_profile(body: ProfileUpdateRequest, user: dict = Depends(get_us
 async def get_workspace(user: dict = Depends(get_user)):
     """Get the current user's workspace/tenant info."""
     tenant_id = user.get("tenant_id", "")
-    if os.getenv("CAD_WEB_DEV_MODE", "").lower() in ("1", "true"):
+    if is_dev_mode():
         return {
             "workspace": {"tenant_id": "dev-tenant", "name": "Dev Workspace", "plan": "personal"}
         }

--- a/web/backend/session.py
+++ b/web/backend/session.py
@@ -191,8 +191,8 @@ class SessionManager:
 
         return session
 
-    def get_by_id(self, session_id: str) -> Session:
-        """Get a session by ID without ownership check."""
+    def _get_by_id_internal(self, session_id: str) -> Session:
+        """Get a session by ID without ownership check (internal use only)."""
         with self._lock:
             session = self._sessions.get(session_id)
 


### PR DESCRIPTION
## Epic
EPIC-CAD-31: System Design Pattern Adoption

## Bead(s)
- cad-dxf-agent-ees (parent epic — Phase 0+1 scope)
- cad-dxf-agent-vk8 (typed tool stubs)
- cad-dxf-agent-2hc (drift detection)

## Summary

A 12-specialist engineer review (ADK, security, database, performance, backend architecture, Python, cloud, DevOps, testing, architecture review, DX, observability) evaluated the full EPIC-CAD-31 rollout. The critical finding: **tools cannot run inside Agent Engine** (ezdxf C library, R-tree, local file I/O). Decision: ship Phase 0+1 now, defer Phase 2+ until user growth demands the HTTP-Client FunctionTool pattern.

### Phase 0 — Pre-Migration Prerequisites
- **Dead code cleanup:** Removed `from __future__ import annotations` (latent `get_type_hints()` bug), dead `Point2D` dataclass (name collision with models), dead `pname == "return"` guard, loop-body imports in agent_provider
- **Dev mode fix:** Created `is_dev_mode()` helper consolidating inconsistent `CAD_WEB_DEV_MODE` parsing (lifespan accepted "yes", auth didn't)
- **Session security:** Renamed `SessionManager.get_by_id()` → `_get_by_id_internal()` to prevent ownership bypass
- **Feature flag:** Added `CAD_AGENT_BACKEND` (`cloud_run` | `agent_engine`) with startup validation — plumbing ready for future Agent Engine routing
- **Rate limiting:** Added per-IP rate limiting (60 req/min) on all `/api/v1/` endpoints (previously zero auth)
- **Dependencies:** Added `pyyaml` to core deps, `google-adk` to optional `[adk]` group

### Phase 1 — Complete Foundation
- **All 23 tools typed:** Added 18 edit tool `_fn` stub functions (move, delete, rotate, copy, scale, mirror, add_line/polyline/circle/arc/text, 5 batch tools). Schema sync enforced by CI test.
- **Schema generation:** Extended `_hint_to_json_schema()` for `Literal` → `enum`, dataclass → nested object, `list[X]` → array with items
- **Docstring parser fix:** Colons mid-sentence no longer incorrectly split parameter descriptions
- **Drift detection:** Added checks 5-6: no `google.adk` imports outside `adk/` module, gateway must not import `google.adk`
- **Observability:** Added `MeterProvider` + 5 core metrics (`cad.request.count`, `cad.request.latency_ms`, `cad.agent.turns`, `cad.tool.success`, `cad.tool.failure`)
- **Shapely reference tests:** 12 geometry assertions (area, perimeter, centroid, aspect ratio) as regression + migration prep

## Test plan
- [x] `make check` (lint + format + typecheck + tests + smoke): all green
- [x] `make scorecard`: 205 passed, 41 xfailed, no regressions
- [x] Drift detection (`scripts/ci/check_nodrift.sh`): all 6 checks pass
- [x] Smoke test: full pipeline end-to-end pass
- [x] **4325 tests passed** (up from ~4100), 5 skipped, 0 failures
- [x] All 23 tools have typed stubs: `len(EDIT_TOOL_FUNCTIONS) + len(QUERY_TOOL_FUNCTIONS) == len(ALL_TOOLS)`
- [x] Feature flag: `CAD_AGENT_BACKEND=invalid` raises `ValueError`
- [x] Dev mode: `is_dev_mode()` consistent for "1", "true", "yes", "True", "YES"
- [x] Rate limiter: returns 429 after threshold
- [x] Literal/enum: `mirror_entity_fn` axis → `{"enum": ["x", "y"]}`
- [x] Nested objects: `add_line_fn` start → `{"type": "object", "properties": {"x": ..., "y": ...}}`
- [x] Degenerate polygons: area 0.0 without raising

## Docs
- `CLAUDE.md` updated: EPIC-CAD-31 review outcome, tool function architecture section, config table, epic registry, observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)