### PR TITLE
fix: add confirmation dialog before clearing workspace

### DIFF
--- a/web/frontend/src/components/Workspace.jsx
+++ b/web/frontend/src/components/Workspace.jsx
@@ -119,7 +119,14 @@ export default function Workspace({ user, onSignOut }) {
           </div>
           <div className="flex items-center gap-3">
             {sessionId && (
-              <button className="btn btn--ghost btn--sm" onClick={session.reset}>
+              <button
+                className="btn btn--ghost btn--sm"
+                onClick={() => {
+                  if (window.confirm('Start a new file? Any unsaved work will be lost.')) {
+                    session.reset();
+                  }
+                }}
+              >
                 New File
               </button>
             )}

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -427,7 +427,11 @@ export function useSession() {
     setError(null);
     try {
       const approvals = revisionOps
-        .filter((op) => op.status === 'pending' || op.status === 'auto_approved' || (action === 'reject' && op.status !== 'rejected'))
+        .filter((op) => {
+          if (action === 'approve') return op.status !== 'approved';
+          if (action === 'reject') return op.status !== 'rejected';
+          return true;
+        })
         .map((op) => ({ op_id: op.op_id, action }));
       if (approvals.length === 0) return;
       const data = await revisionApprove(sessionId, approvals);

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -427,11 +427,7 @@ export function useSession() {
     setError(null);
     try {
       const approvals = revisionOps
-        .filter((op) => {
-          if (action === 'approve') return op.status !== 'approved';
-          if (action === 'reject') return op.status !== 'rejected';
-          return true;
-        })
+        .filter((op) => op.status === 'pending' || op.status === 'auto_approved' || (action === 'reject' && op.status !== 'rejected'))
         .map((op) => ({ op_id: op.op_id, action }));
       if (approvals.length === 0) return;
       const data = await revisionApprove(sessionId, approvals);


### PR DESCRIPTION
## Summary
- Add `window.confirm()` guard before `session.reset()` on the "New File" button
- Prevents accidental loss of unsaved comparison work

## Test plan
- [x] `npx vite build` passes
- [ ] Manual: load a DXF → click "New File" → verify confirmation dialog appears
- [ ] Manual: click Cancel → verify session is preserved
- [ ] Manual: click OK → verify workspace resets

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)