### PR TITLE
fix: allow toggling rejected ops back to approved

### DIFF
--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -427,7 +427,11 @@ export function useSession() {
     setError(null);
     try {
       const approvals = revisionOps
-        .filter((op) => op.status === 'pending' || op.status === 'auto_approved' || (action === 'reject' && op.status !== 'rejected'))
+        .filter((op) => {
+          if (action === 'approve') return op.status !== 'approved';
+          if (action === 'reject') return op.status !== 'rejected';
+          return true;
+        })
         .map((op) => ({ op_id: op.op_id, action }));
       if (approvals.length === 0) return;
       const data = await revisionApprove(sessionId, approvals);

--- a/web/frontend/src/hooks/useSession.js
+++ b/web/frontend/src/hooks/useSession.js
@@ -430,7 +430,7 @@ export function useSession() {
         .filter((op) => {
           if (action === 'approve') return op.status !== 'approved';
           if (action === 'reject') return op.status !== 'rejected';
-          return true;
+          return false;
         })
         .map((op) => ({ op_id: op.op_id, action }));
       if (approvals.length === 0) return;


### PR DESCRIPTION
## Summary
- Fix bulk approve/reject filter that prevented rejected→approved state transitions
- Users can now freely toggle between approve and reject states

## Root Cause
The filter in `handleRevisionBulkApprove` only included `pending` and `auto_approved` ops for approval, excluding already-rejected ops.

## Test plan
- [x] `npx vite build` passes
- [ ] Manual: reject all ops → click Approve All → verify all switch to approved
- [ ] Manual: approve an op → reject it → approve again → verify it works

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)