### PR TITLE
fix: add tooltip explaining why Apply button is disabled

### DIFF
--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -635,19 +635,30 @@ export default function PreviewPanel({
                 const approved = revisionOps.filter((o) => isOpApproved(o)).length;
                 const pending = revisionOps.filter((o) => o.status === 'pending').length;
                 const canApply = approved > 0 && pending === 0;
+                const disabledTitle = approved === 0
+                  ? 'Approve at least one change to apply'
+                  : 'Review all changes before applying';
                 return (
-                  <button
-                    className="btn btn--primary btn--full"
-                    onClick={onRevisionApply}
-                    disabled={loading || !canApply}
-                    style={{ marginTop: 'var(--space-2)' }}
-                  >
-                    {loading
-                      ? <span className="spinner" aria-hidden="true" />
-                      : canApply
-                        ? `Apply ${approved} Approved Change${approved !== 1 ? 's' : ''}`
-                        : 'Review all changes before applying'}
-                  </button>
+                  <>
+                    <button
+                      className="btn btn--primary btn--full"
+                      onClick={onRevisionApply}
+                      disabled={loading || !canApply}
+                      title={!loading && !canApply ? disabledTitle : undefined}
+                      style={{ marginTop: 'var(--space-2)' }}
+                    >
+                      {loading
+                        ? <span className="spinner" aria-hidden="true" />
+                        : canApply
+                          ? `Apply ${approved} Approved Change${approved !== 1 ? 's' : ''}`
+                          : 'Apply Changes'}
+                    </button>
+                    {!loading && !canApply && (
+                      <p style={{ marginTop: 'var(--space-1)', fontSize: '0.75rem', color: 'var(--color-text-muted)', textAlign: 'center' }}>
+                        {disabledTitle}
+                      </p>
+                    )}
+                  </>
                 );
               })()}
             </div>

--- a/web/frontend/src/components/PreviewPanel.jsx
+++ b/web/frontend/src/components/PreviewPanel.jsx
@@ -635,9 +635,9 @@ export default function PreviewPanel({
                 const approved = revisionOps.filter((o) => isOpApproved(o)).length;
                 const pending = revisionOps.filter((o) => o.status === 'pending').length;
                 const canApply = approved > 0 && pending === 0;
-                const disabledTitle = approved === 0
-                  ? 'Approve at least one change to apply'
-                  : 'Review all changes before applying';
+                const disabledTitle = pending > 0
+                  ? 'Review all changes before applying'
+                  : 'Approve at least one change to apply';
                 return (
                   <>
                     <button


### PR DESCRIPTION
## Summary
- Add `title` attribute to disabled Apply button explaining what action is needed
- Show a small helper message below the button when it is disabled
- Two distinct messages: "Approve at least one change to apply" (zero approved ops) vs "Review all changes before applying" (pending ops remain)

## Test plan
- [x] `npx vite build` passes with no errors
- [ ] Manual: reject all ops → hover Apply button → verify tooltip reads "Approve at least one change to apply"
- [ ] Manual: leave some ops pending → hover Apply → verify tooltip reads "Review all changes before applying"

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)