### PR TITLE
feat: add email/password sign-in to login page

### DIFF
--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -64,6 +64,7 @@ function AuthGate({ user, loading, authState }) {
     return (
       <LoginPage
         onSignInWithGoogle={authState.signInWithGoogle}
+        onSignInWithEmail={authState.signInWithEmail}
         error={authState.error}
         clearError={authState.clearError}
       />

--- a/web/frontend/src/components/LoginPage.jsx
+++ b/web/frontend/src/components/LoginPage.jsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export default function LoginPage({ onSignInWithGoogle, error, clearError }) {
+export default function LoginPage({ onSignInWithGoogle, onSignInWithEmail, error, clearError }) {
   const gistRef = useRef(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   useEffect(() => {
     if (!gistRef.current) return;
@@ -94,6 +96,37 @@ export default function LoginPage({ onSignInWithGoogle, error, clearError }) {
           </svg>
           Sign in with Google
         </button>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', margin: 'var(--space-4) 0' }}>
+          <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border-default)' }} />
+          <span className="text-sm text-muted">or</span>
+          <hr style={{ flex: 1, border: 'none', borderTop: '1px solid var(--border-default)' }} />
+        </div>
+
+        <form onSubmit={(e) => { e.preventDefault(); onSignInWithEmail(email, password); }}
+              style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="input"
+            style={{ width: '100%', padding: 'var(--space-2) var(--space-3)', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-default)', fontSize: 'var(--text-sm)' }}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="input"
+            style={{ width: '100%', padding: 'var(--space-2) var(--space-3)', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-default)', fontSize: 'var(--text-sm)' }}
+          />
+          <button type="submit" className="btn btn--secondary btn--lg" style={{ width: '100%' }}>
+            Sign in with Email
+          </button>
+        </form>
 
         <details style={{ marginTop: 'var(--space-5)', textAlign: 'left' }}>
           <summary className="text-sm text-muted" style={{ cursor: 'pointer', textAlign: 'center' }}>


### PR DESCRIPTION
## Summary
- Add email + password login form below Google Sign-In button
- Sign-in only — no self-registration (Jeremy creates accounts via Firebase API)
- `engineer@gmail.com` / `engineer123!@#` account already created in Firebase Auth + Firestore allowlist

## Test plan
- [x] `npx vite build` passes
- [ ] Manual: go to login page → verify email/password form visible below Google button
- [ ] Manual: sign in with `engineer@gmail.com` / `engineer123!@#` → verify access
- [ ] Manual: try wrong password → verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)