### PR TITLE
feat: open self-registration — remove allowlist gate

### DIFF
--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -152,7 +152,7 @@ class TestCheckLicense:
         with pytest.raises(HTTPException) as exc_info:
             await check_license(user)
         assert exc_info.value.status_code == 403
-        assert "Google sign-in required" in exc_info.value.detail
+        assert "Sign-in required" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_user_without_email_rejected(self):
@@ -162,7 +162,7 @@ class TestCheckLicense:
         with pytest.raises(HTTPException) as exc_info:
             await check_license(user)
         assert exc_info.value.status_code == 403
-        assert "Google sign-in required" in exc_info.value.detail
+        assert "Sign-in required" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_existing_active_license_passes(self):
@@ -179,7 +179,7 @@ class TestCheckLicense:
             await check_license(user)  # should not raise
 
     @pytest.mark.asyncio
-    async def test_new_user_auto_provisioned_when_on_allowlist(self):
+    async def test_new_user_auto_provisioned(self):
         from unittest.mock import MagicMock, patch
 
         from web.backend.auth import check_license
@@ -193,7 +193,6 @@ class TestCheckLicense:
         mock_provision = MagicMock()
         with (
             patch("web.backend.auth._fetch_license", return_value=False),
-            patch("web.backend.auth._check_email_allowed", return_value=True),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)  # should not raise
@@ -254,9 +253,9 @@ class TestAllowlist:
             os.environ.pop("CAD_ALLOWED_EMAILS", None)
 
     @pytest.mark.asyncio
-    async def test_unlisted_email_rejected_with_403(self):
-        """A new user not on the allowlist gets 403, not auto-provisioned."""
-        from unittest.mock import patch
+    async def test_unlisted_email_auto_provisioned(self):
+        """Any new authenticated user is auto-provisioned (no allowlist gate)."""
+        from unittest.mock import MagicMock, patch
 
         from web.backend.auth import check_license
 
@@ -265,23 +264,21 @@ class TestAllowlist:
             "email": "stranger@gmail.com",
             "firebase": {"sign_in_provider": "google.com"},
         }
+        mock_provision = MagicMock()
         with (
             patch("web.backend.auth._fetch_license", return_value=False),
-            patch("web.backend.auth._check_email_allowed", return_value=False),
-            pytest.raises(HTTPException) as exc_info,
+            patch("web.backend.auth._provision_license", mock_provision),
         ):
-            await check_license(user)
-        assert exc_info.value.status_code == 403
-        assert "Access restricted" in exc_info.value.detail
+            await check_license(user)  # should not raise
+        mock_provision.assert_called_once_with("stranger", "stranger@gmail.com")
 
     @pytest.mark.asyncio
-    async def test_env_var_allows_email(self):
-        """Email listed in CAD_ALLOWED_EMAILS is auto-provisioned."""
+    async def test_any_email_auto_provisioned(self):
+        """Any authenticated user is auto-provisioned regardless of allowlist."""
         from unittest.mock import MagicMock, patch
 
         from web.backend.auth import check_license
 
-        os.environ["CAD_ALLOWED_EMAILS"] = "beta@test.com,vip@corp.com"
         user = {
             "uid": "beta-user",
             "email": "beta@test.com",
@@ -296,16 +293,15 @@ class TestAllowlist:
         mock_provision.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_env_var_semicolon_separator(self):
-        """Semicolons work as separators (avoids gcloud delimiter conflicts)."""
+    async def test_email_lowercased_before_provision(self):
+        """Email is lowercased before being passed to _provision_license."""
         from unittest.mock import MagicMock, patch
 
         from web.backend.auth import check_license
 
-        os.environ["CAD_ALLOWED_EMAILS"] = "alpha@test.com;beta@test.com"
         user = {
-            "uid": "beta-user",
-            "email": "beta@test.com",
+            "uid": "mixed-case-user",
+            "email": "BETA@Test.COM",
             "firebase": {"sign_in_provider": "google.com"},
         }
         mock_provision = MagicMock()
@@ -314,53 +310,11 @@ class TestAllowlist:
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)
-        mock_provision.assert_called_once()
+        mock_provision.assert_called_once_with("mixed-case-user", "beta@test.com")
 
     @pytest.mark.asyncio
-    async def test_env_var_case_insensitive(self):
-        """Allowlist matching is case-insensitive."""
-        from unittest.mock import MagicMock, patch
-
-        from web.backend.auth import check_license
-
-        os.environ["CAD_ALLOWED_EMAILS"] = "BETA@Test.COM"
-        user = {
-            "uid": "beta-user",
-            "email": "beta@test.com",
-            "firebase": {"sign_in_provider": "google.com"},
-        }
-        mock_provision = MagicMock()
-        with (
-            patch("web.backend.auth._fetch_license", return_value=False),
-            patch("web.backend.auth._provision_license", mock_provision),
-        ):
-            await check_license(user)
-        mock_provision.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_firestore_allowlist_allows_email(self):
-        """Email found in Firestore allowlist collection is auto-provisioned."""
-        from unittest.mock import MagicMock, patch
-
-        from web.backend.auth import check_license
-
-        user = {
-            "uid": "firestore-user",
-            "email": "approved@corp.com",
-            "firebase": {"sign_in_provider": "google.com"},
-        }
-        mock_provision = MagicMock()
-        with (
-            patch("web.backend.auth._fetch_license", return_value=False),
-            patch("web.backend.auth._check_email_allowed", return_value=True),
-            patch("web.backend.auth._provision_license", mock_provision),
-        ):
-            await check_license(user)
-        mock_provision.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_existing_license_skips_allowlist(self):
-        """A user with an active license is not checked against the allowlist."""
+    async def test_existing_license_skips_provisioning(self):
+        """A user with an active license is not re-provisioned."""
         from unittest.mock import patch
 
         from web.backend.auth import check_license
@@ -370,13 +324,12 @@ class TestAllowlist:
             "email": "old@example.com",
             "firebase": {"sign_in_provider": "google.com"},
         }
-        # _check_email_allowed should NOT be called
         with (
             patch("web.backend.auth._fetch_license", return_value=True),
-            patch("web.backend.auth._check_email_allowed") as mock_check,
+            patch("web.backend.auth._provision_license") as mock_provision,
         ):
             await check_license(user)
-        mock_check.assert_not_called()
+        mock_provision.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_allowlist_cached(self):

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -175,7 +175,7 @@ class TestCheckLicense:
             "email": "u@example.com",
             "firebase": {"sign_in_provider": "google.com"},
         }
-        with patch("web.backend.auth._fetch_license", return_value=True):
+        with patch("web.backend.auth._fetch_license_status", return_value="active"):
             await check_license(user)  # should not raise
 
     @pytest.mark.asyncio
@@ -192,7 +192,7 @@ class TestCheckLicense:
 
         mock_provision = MagicMock()
         with (
-            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._fetch_license_status", return_value="missing"),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)  # should not raise
@@ -210,13 +210,13 @@ class TestCheckLicense:
             "email": "u@example.com",
             "firebase": {"sign_in_provider": "google.com"},
         }
-        # _fetch_license returns False for expired licenses
         with (
-            patch("web.backend.auth._fetch_license", return_value=False),
-            patch("web.backend.auth._provision_license", side_effect=Exception("already exists")),
-            pytest.raises(HTTPException),
+            patch("web.backend.auth._fetch_license_status", return_value="inactive"),
+            pytest.raises(HTTPException) as exc_info,
         ):
             await check_license(user)
+        assert exc_info.value.status_code == 403
+        assert "License inactive" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_dev_mode_bypasses_license(self):
@@ -266,7 +266,7 @@ class TestAllowlist:
         }
         mock_provision = MagicMock()
         with (
-            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._fetch_license_status", return_value="missing"),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)  # should not raise
@@ -286,7 +286,7 @@ class TestAllowlist:
         }
         mock_provision = MagicMock()
         with (
-            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._fetch_license_status", return_value="missing"),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)
@@ -306,7 +306,7 @@ class TestAllowlist:
         }
         mock_provision = MagicMock()
         with (
-            patch("web.backend.auth._fetch_license", return_value=False),
+            patch("web.backend.auth._fetch_license_status", return_value="missing"),
             patch("web.backend.auth._provision_license", mock_provision),
         ):
             await check_license(user)
@@ -325,7 +325,7 @@ class TestAllowlist:
             "firebase": {"sign_in_provider": "google.com"},
         }
         with (
-            patch("web.backend.auth._fetch_license", return_value=True),
+            patch("web.backend.auth._fetch_license_status", return_value="active"),
             patch("web.backend.auth._provision_license") as mock_provision,
         ):
             await check_license(user)

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -125,17 +125,20 @@ async def check_license(user: dict) -> None:
     try:
         from starlette.concurrency import run_in_threadpool
 
-        active = await run_in_threadpool(_fetch_license, uid)
+        status = await run_in_threadpool(_fetch_license_status, uid)
 
-        if not active:
-            # Open self-registration: any authenticated user gets a trial
+        if status == "active":
+            _license_cache[uid] = (True, now)
+        elif status == "missing":
+            # Open self-registration: first-time user gets a trial
             email = user.get("email", "").lower()
             await run_in_threadpool(_provision_license, uid, email)
             _license_cache[uid] = (True, now)
             logger.info("Auto-provisioned 30-day trial for %s", email)
-            return
-
-        _license_cache[uid] = (active, now)
+        else:
+            # Expired or revoked — do not re-provision
+            _license_cache[uid] = (False, now)
+            raise HTTPException(status_code=403, detail="License inactive")
 
     except HTTPException:
         raise
@@ -145,8 +148,14 @@ async def check_license(user: dict) -> None:
         raise HTTPException(status_code=403, detail="License check unavailable") from e
 
 
-def _fetch_license(uid: str) -> bool:
-    """Synchronous Firestore lookup — called via run_in_threadpool."""
+def _fetch_license_status(uid: str) -> str:
+    """Synchronous Firestore lookup — called via run_in_threadpool.
+
+    Returns:
+        "active" — license exists and is valid
+        "missing" — no license document (first-time user)
+        "inactive" — license exists but expired or revoked
+    """
     import datetime
 
     from google.cloud import firestore
@@ -154,12 +163,14 @@ def _fetch_license(uid: str) -> bool:
     db = firestore.Client()
     doc = db.collection("licenses").document(uid).get()
     if not doc.exists:
-        return False
+        return "missing"
     data = doc.to_dict()
     if not data.get("active", False):
-        return False
+        return "inactive"
     expires_at = data.get("expires_at")
-    return not (expires_at and expires_at < datetime.datetime.now(datetime.UTC))
+    if expires_at and expires_at < datetime.datetime.now(datetime.UTC):
+        return "inactive"
+    return "active"
 
 
 def _provision_license(uid: str, email: str) -> None:

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -103,7 +103,7 @@ async def check_license(user: dict) -> None:
     # Reject anonymous users — Google sign-in required
     provider = user.get("firebase", {}).get("sign_in_provider", "")
     if provider == "anonymous" or not user.get("email"):
-        raise HTTPException(status_code=403, detail="Google sign-in required")
+        raise HTTPException(status_code=403, detail="Sign-in required")
 
     uid = user.get("uid")
     if not uid:
@@ -128,16 +128,8 @@ async def check_license(user: dict) -> None:
         active = await run_in_threadpool(_fetch_license, uid)
 
         if not active:
-            # Only auto-provision if the email is on the allowlist
+            # Open self-registration: any authenticated user gets a trial
             email = user.get("email", "").lower()
-            allowed = await run_in_threadpool(_check_email_allowed, email)
-            if not allowed:
-                _license_cache[uid] = (False, now)
-                logger.info("Rejected unlisted email %s", email)
-                raise HTTPException(
-                    status_code=403,
-                    detail="Access restricted — contact admin for an invitation",
-                )
             await run_in_threadpool(_provision_license, uid, email)
             _license_cache[uid] = (True, now)
             logger.info("Auto-provisioned 30-day trial for %s", email)


### PR DESCRIPTION
## Summary
- Remove allowlist gate from `check_license()` — any authenticated user now gets auto-provisioned with a 30-day trial on first API call
- Fix "Google sign-in required" → "Sign-in required" error message (email/password auth is now supported)
- Allowlist infrastructure preserved but unused — available for future premium tiers/admin roles

## Test plan
- [x] `tests/web/test_auth.py` — all 28 tests pass (updated to reflect open registration)
- [x] `tests/web/` — all 455 web tests pass
- [x] `tests/unit/` + `tests/integration/` — 3861 tests pass
- [ ] Manual: create new email/password account at site → auto-provisions, lands in Workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)