### PR TITLE
fix: canary CI auth + manual alignment confidence floor

### DIFF
--- a/.github/workflows/canary-monitoring.yml
+++ b/.github/workflows/canary-monitoring.yml
@@ -54,9 +54,14 @@ jobs:
       - name: Check for failures
         working-directory: web/frontend
         run: |
-          FAILED=$(find test-results/canary-results -name '*.json' -exec grep -l '"outcome":"error"\|"outcome":"timeout"' {} \; | wc -l)
+          RESULTS=$(find test-results/canary-results -name '*.json' 2>/dev/null | wc -l)
+          if [ "$RESULTS" -eq "0" ]; then
+            echo "::error::No canary result files found — tests may not have run"
+            exit 1
+          fi
+          FAILED=$(find test-results/canary-results -name '*.json' -exec grep -lE '"outcome"\s*:\s*"(error|timeout)"' {} \; | wc -l)
           if [ "$FAILED" -gt "0" ]; then
             echo "::error::$FAILED canary test(s) failed"
             exit 1
           fi
-          echo "All canary tests passed"
+          echo "All canary tests passed ($RESULTS result files checked)"

--- a/.github/workflows/canary-monitoring.yml
+++ b/.github/workflows/canary-monitoring.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # WIF for GCP auth
 
 jobs:
   canary:
@@ -33,16 +32,12 @@ jobs:
         working-directory: web/frontend
         run: npx playwright install --with-deps chromium
 
-      - name: Authenticate to Google Cloud (WIF)
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: 'projects/604022301876/locations/global/workloadIdentityPools/github-actions/providers/github-provider'
-          service_account: 'github-actions-ci@cad-dxf-agent.iam.gserviceaccount.com'
-
       - name: Run canary tests against production
         working-directory: web/frontend
         env:
           TARGET: production
+          E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
         run: npx playwright test -c playwright.config.js --grep "canary" --reporter=list
         continue-on-error: true
 

--- a/src/cad_dxf_agent/core/comparison/alignment.py
+++ b/src/cad_dxf_agent/core/comparison/alignment.py
@@ -578,6 +578,17 @@ def try_manual_alignment(
     diag = score_alignment(m_pts, r_pts, R, t, master_snaps, revision_snaps, config.max_residual)
     confidence = compute_confidence(diag, config.max_residual)
 
+    # Manual control points: trust the user's correspondence assertion.
+    # Confidence floor based on control-point fit quality, not full-drawing overlap.
+    if len(pairs) >= 2:
+        transformed = (R @ r_pts.T).T + t
+        cp_residuals = np.linalg.norm(m_pts - transformed, axis=1)
+        cp_rms = float(np.sqrt(np.mean(cp_residuals**2)))
+        cp_score = max(0.0, 1.0 - cp_rms / config.max_residual)
+        confidence = max(confidence, 0.5 * cp_score + 0.2)
+    elif len(pairs) == 1:
+        confidence = max(confidence, 0.7)
+
     return AlignmentResult(
         method=AlignmentMethod.manual,
         confidence=confidence,

--- a/src/cad_dxf_agent/core/comparison/alignment.py
+++ b/src/cad_dxf_agent/core/comparison/alignment.py
@@ -587,7 +587,8 @@ def try_manual_alignment(
         cp_score = max(0.0, 1.0 - cp_rms / config.max_residual)
         confidence = max(confidence, 0.5 * cp_score + 0.2)
     elif len(pairs) == 1:
-        confidence = max(confidence, 0.7)
+        # Single point = translation only, no rotation constraint
+        confidence = max(confidence, 0.5)
 
     return AlignmentResult(
         method=AlignmentMethod.manual,

--- a/tests/unit/test_alignment.py
+++ b/tests/unit/test_alignment.py
@@ -759,8 +759,8 @@ class TestManualAlignment:
         )
         result = try_manual_alignment(m, r, cfg)
         assert result.method == AlignmentMethod.manual
-        # Single control point → confidence floor of 0.7
-        assert result.confidence >= 0.7
+        # Single control point → confidence floor of 0.5 (translation only)
+        assert result.confidence >= 0.5
         # Overlap is still zero (drawings don't actually match)
         assert result.diagnostics.overlap_ratio == 0.0
 

--- a/tests/unit/test_alignment.py
+++ b/tests/unit/test_alignment.py
@@ -748,7 +748,7 @@ class TestManualAlignment:
         assert result.diagnostics.attempts[0].method == "manual"
 
     def test_manual_bad_points_still_returns(self):
-        """Wrong control points → result still returned, low confidence."""
+        """Wrong control points → result still returned, confidence from floor."""
         m = [_make_snap(0, 0), _make_snap(10, 10)]
         r = [_make_snap(500, 500), _make_snap(600, 600)]
         cfg = AlignmentConfig(
@@ -759,5 +759,22 @@ class TestManualAlignment:
         )
         result = try_manual_alignment(m, r, cfg)
         assert result.method == AlignmentMethod.manual
-        # Result is returned (not None) but overlap should be zero
+        # Single control point → confidence floor of 0.7
+        assert result.confidence >= 0.7
+        # Overlap is still zero (drawings don't actually match)
         assert result.diagnostics.overlap_ratio == 0.0
+
+    def test_manual_correct_points_high_confidence(self):
+        """Correct control points → confidence > 0.5 from control-point fit."""
+        m = [_make_snap(0, 0), _make_snap(10, 0), _make_snap(10, 10)]
+        r = [_make_snap(5, 0), _make_snap(15, 0), _make_snap(15, 10)]
+        # Correct correspondence: revision is shifted +5 in x
+        cfg = AlignmentConfig(
+            enabled=True,
+            confidence_threshold=0.3,
+            max_residual=1.0,
+            control_points=[((0.0, 0.0), (5.0, 0.0)), ((10.0, 0.0), (15.0, 0.0))],
+        )
+        result = try_manual_alignment(m, r, cfg)
+        assert result.method == AlignmentMethod.manual
+        assert result.confidence > 0.5


### PR DESCRIPTION
## Summary
- **Canary CI**: Removed WIF auth step that only trusts push/PR OIDC claims (canary runs on `schedule`). Canary tests authenticate via Firebase REST API using `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD` secrets — no GCP auth needed.
- **#136 fix**: Manual control point alignment was reporting 0% confidence because it scored the transform against full-drawing overlap. Added a confidence floor based on control-point fit quality, trusting the user's asserted correspondence.
- **Closed 6 issues** (#112, #133, #140, #142, #145, #153) with detailed explanations.

## Files Changed
| File | Change |
|------|--------|
| `.github/workflows/canary-monitoring.yml` | Remove WIF auth step, add E2E credential env vars |
| `src/cad_dxf_agent/core/comparison/alignment.py` | Confidence floor for manual control points |
| `tests/unit/test_alignment.py` | Updated + new test for manual alignment confidence |

## Test plan
- [x] All 4317 tests pass (unit + integration + web)
- [x] 6 manual alignment tests pass including new `test_manual_correct_points_high_confidence`
- [ ] **Manual step required**: Set `E2E_TEST_EMAIL` and `E2E_TEST_PASSWORD` GitHub secrets
- [ ] Trigger canary via `workflow_dispatch` to verify it runs without WIF

## Issues Addressed
- Fixes #136 (control point refinement at 0%)
- Closes #112 (stale, no actionable content)
- Closes #133 (library IS visible; explained)
- Closes #140 (needs reproduction data)
- Closes #142 (standalone sessions are ephemeral by design)
- Closes #145 (feature request, not a bug)
- Closes #153 (standard CAD pan/zoom behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)