### PR TITLE
ci: gate web deploy + canary to manual-only after retiring hosted instance

### DIFF
--- a/.github/workflows/canary-monitoring.yml
+++ b/.github/workflows/canary-monitoring.yml
@@ -1,9 +1,11 @@
 name: Production Canary Monitoring
 
 on:
-  schedule:
-    # Daily at 8am UTC
-    - cron: '0 8 * * *'
+  # Manual-only. The hosted demo instance this canary tested was retired, so the
+  # daily run only produced guaranteed failures. Re-add the schedule below if a
+  # public instance is ever restood:
+  #   schedule:
+  #     - cron: '0 8 * * *'   # daily at 8am UTC
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,12 +1,15 @@
 name: Deploy Web
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'web/**'
-      - 'src/**'
-      - '.github/workflows/deploy-web.yml'
+  # Manual-only. Auto-deploy on push was disabled when the hosted instance was
+  # retired, so merges no longer push to anyone's Cloud Run / Firebase project.
+  # Re-add the push trigger below to resume continuous deployment to your own GCP:
+  #   push:
+  #     branches: [main]
+  #     paths:
+  #       - 'web/**'
+  #       - 'src/**'
+  #       - '.github/workflows/deploy-web.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem
The hosted demo instance was retired, but two workflows still reached for it automatically:

- **`canary-monitoring.yml`** ran a daily (8am UTC) Playwright suite against the live demo site. With the site gone, every run is a **guaranteed failure** — a permanent red ❌ on the Actions tab plus daily failure noise and wasted runner minutes.
- **`deploy-web.yml`** auto-deployed to Cloud Run + Firebase on every push to `main` touching `web/**` or `src/**`, re-spinning infra on the retired GCP project.

## Change
Both workflows are now **`workflow_dispatch`-only** (manual trigger). The original `schedule:` / `push:` triggers are preserved as inline comments so a maintainer can restore continuous deployment or scheduled canaries in a one-line edit if a public instance is ever stood back up.

## Test plan
- No application code touched — workflow triggers only.
- Both files parse as valid YAML; each now exposes exactly one trigger: `workflow_dispatch`.
- Neither workflow can auto-fire on push/schedule after this change.

## Docs
None (CI config only). Note: `CLAUDE.md` still documents the old auto-deploy path in its "Commands" section — left as-is here; can be updated separately if the deploy story is being retired for good.