### PR TITLE
ci: wire vendored audit-harness into CI, Makefile, and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,33 @@ jobs:
       - name: Mypy
         run: mypy src/
 
+  audit-harness:
+    runs-on: ubuntu-latest
+    needs: [drift-check]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify harness hash-pin (tamper check)
+        # Blocking: exit 2 = HARNESS_TAMPERED (a pinned harness script changed
+        # without a fresh `audit-harness init`). Keeps the quality gates honest.
+        run: bash scripts/audit-harness verify
+      - name: Escape-scan the PR diff for test-weakening
+        # Blocking on PRs: REFUSE (exit 2) = coverage floor lowered / tests
+        # deleted / pinned artifact touched; CHALLENGE (exit 1) = skip marker /
+        # mutation bypass / trivially-true assertion added. Floor read from
+        # tests/TESTING.md (coverage.line: 65).
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --prune origin \
+            "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          git diff "origin/${{ github.base_ref }}...HEAD" > /tmp/scan.diff
+          bash scripts/audit-harness escape-scan /tmp/scan.diff
+      - name: Test-bias scan (advisory)
+        run: bash scripts/audit-harness bias || true
+      - name: Architecture rules (advisory — no rule config yet)
+        run: bash scripts/audit-harness arch || true
+
   test:
     runs-on: ${{ matrix.os }}
     needs: [drift-check]

--- a/.harness-hash
+++ b/.harness-hash
@@ -1,0 +1,8 @@
+f5bb89ef74bffa018a92df6abbfeb66b3d2264daf6b365bc8cafdbad00065f9d  .audit-harness/scripts/arch-check.sh
+93173d353a7820a6484519329a16ea8795b9658d79e682af0557158b18a6ebdf  .audit-harness/scripts/bias-count.sh
+83da2309e20151aeb14afe5625c14a67ebf8a6a5e78330861fcf3e1444bebc40  .audit-harness/scripts/crap-score.py
+add245f35fb0dbd63d5ab475020bb367b53be4c611eb509d614c8a1f5ca8ea32  .audit-harness/scripts/emit-evidence.sh
+0ffea346a8c310677f2176e9f367370c8b308f82633bf62ccd00a95985e09469  .audit-harness/scripts/escape-scan.sh
+d29a2e9b94f7fd94f4f8953314323f96ca424cbaa6a985f6783b48ee2feae0f8  .audit-harness/scripts/gherkin-lint.sh
+9c588a980e89dbc9ea2bcf0992daff51ec72b926ecb1644e21838b9fc5c2883d  .audit-harness/scripts/harness-hash.sh
+6342f5b91dca3736912c7a388527e388ed964676efd9ecb9dd8090845aa48970  scripts/audit-harness

--- a/.harness-hash-extra-patterns
+++ b/.harness-hash-extra-patterns
@@ -1,0 +1,14 @@
+# Extra hash-pin patterns for this repo (consumed by .audit-harness/scripts/harness-hash.sh).
+#
+# This repo has no BDD .feature files or import-linter/dependency-cruiser config yet,
+# so the harness's canonical pin set is empty. The most meaningful thing to pin here
+# is the enforcement surface itself — the vendored harness scripts and the wrapper.
+# With these pinned, `audit-harness verify` (and escape-scan's hash check) will REFUSE
+# any diff that alters the harness without a fresh `audit-harness init`, so the quality
+# gates can't be silently weakened.
+#
+# On a deliberate harness upgrade: review the new scripts, then re-run
+# `scripts/audit-harness init` and commit the updated .harness-hash in the same change.
+.audit-harness/scripts/*.sh
+.audit-harness/scripts/*.py
+scripts/audit-harness

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
         entry: bash -c 'echo "Do not commit .env files!" && exit 1'
         language: system
         files: '^\.env$'
+      - id: audit-harness-verify
+        name: audit-harness verify (hash-pin tamper check)
+        entry: bash scripts/audit-harness verify
+        language: system
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format typecheck test test-unit test-integration test-live test-web test-web-live test-e2e test-cov smoke check run clean build build-clean scorecard scorecard-live
+.PHONY: install lint format typecheck test test-unit test-integration test-live test-web test-web-live test-e2e test-cov smoke check run clean build build-clean scorecard scorecard-live audit-harness
 
 install:
 	pip install -e ".[dev]"
@@ -49,6 +49,14 @@ scorecard-live:
 security:
 	bandit -r src/ -ll
 	pip-audit --local
+
+# Vendored audit-harness gates. `verify` is blocking (hash-pin tamper check);
+# escape-scan/bias/arch are advisory locally (leading `-` ignores their exit).
+audit-harness:
+	bash scripts/audit-harness verify
+	-bash scripts/audit-harness escape-scan --staged
+	-bash scripts/audit-harness bias
+	-bash scripts/audit-harness arch
 
 check: lint format typecheck test smoke
 	@echo "All checks passed."

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,50 @@
+# Testing Policy
+
+Canonical policy thresholds for this repo. The vendored audit-harness reads the
+machine-readable values below (e.g. `escape-scan` uses `coverage.line` as the
+floor it refuses to let a diff drop beneath), so this file is the single source
+of truth for "what bar must a change clear."
+
+## Policy thresholds
+
+```
+coverage.line: 65
+coverage.branch: 0
+mutation.kill_rate: 0
+```
+
+- **`coverage.line: 65`** — enforced in CI via `fail_under = 65` in
+  `[tool.coverage.report]` (`pyproject.toml`). `escape-scan` REFUSES any diff
+  that lowers a coverage threshold below this floor. Raise both together; never
+  ratchet down.
+- **`coverage.branch: 0`** — branch coverage is measured but not gated yet.
+- **`mutation.kill_rate: 0`** — `mutmut` is configured (`[tool.mutmut]` in
+  `pyproject.toml`, three core modules) but not yet gated in CI. Set a real
+  floor here when the mutation run is promoted to a required check.
+
+## Enforcement layers in CI
+
+| Layer | Where | Status |
+|-------|-------|--------|
+| Lint / format (ruff) | `ci.yml` → `lint` | required |
+| Types (mypy) | `ci.yml` → `typecheck` | required |
+| Unit/integration/web tests + coverage floor | `ci.yml` → `test` | required |
+| Architectural drift | `ci.yml` → `drift-check` | required |
+| **Harness hash-pin (`verify`)** | `ci.yml` → `audit-harness` | required |
+| **Escape-scan (diff)** | `ci.yml` → `audit-harness` | required (PRs) |
+| Bias count | `ci.yml` → `audit-harness` | advisory |
+| Architecture rules (`arch`) | `ci.yml` → `audit-harness` | advisory (no rule config yet) |
+
+## Promoting advisory gates
+
+The harness can do more than is gated today. To promote a gate from advisory to
+required:
+
+1. **Architecture rules** — add an `.importlinter` contract (layered:
+   `models` ← `core`/`llm` ← `cli`/`ui`/`web`), then make the `arch` step
+   blocking.
+2. **Mutation** — wire a `mutmut run` step, set `mutation.kill_rate` above, and
+   make it blocking.
+
+After any change to a pinned policy artifact, re-run `scripts/audit-harness init`
+and commit the updated `.harness-hash` in the same change.


### PR DESCRIPTION
## Bead(s)
cad-dxf-agent-7ow

## Problem
The audit-harness was vendored in #171 but **nothing invoked it** — no `.harness-hash` manifest, no CI step, no hook referenced `scripts/audit-harness`. The deterministic quality gates it ships (`verify`, `escape-scan`, `bias`, `arch`) were dead weight. "Enforcement travels with the code" was unmet because nothing ran the enforcement.

## What this wires
A new **`audit-harness`** CI job plus matching local entry points:

| Check | Severity | Notes |
|-------|----------|-------|
| `verify` (hash-pin tamper check) | **blocking** | exit 2 = a pinned harness script changed without a fresh `init` |
| `escape-scan` (PR diff) | **blocking on PRs** | REFUSE = coverage-floor drop / test deletion / pinned-artifact edit; CHALLENGE = skip marker / mutation bypass / trivially-true assertion |
| `bias` | advisory | upstream `bias-count.sh` has a `set -e` + zero-match `grep` bug, so run non-blocking |
| `arch` | advisory | no import-linter/dependency-cruiser config yet → "not configured" |

## Files
- **`.harness-hash` + `.harness-hash-extra-patterns`** — this repo has no `.feature` files or arch-rule config to pin, so the meaningful pin target is the **enforcement surface itself**: the 7 vendored scripts + the `scripts/audit-harness` wrapper (8 files). Tampering with the harness now fails `verify`.
- **`tests/TESTING.md`** — declares the canonical policy floor (`coverage.line: 65`, matching `fail_under` in `pyproject.toml`) that `escape-scan` reads. Without it, escape-scan defaults to **80** and would falsely REFUSE legitimate diffs.
- **`ci.yml`** — the `audit-harness` job (checkout `fetch-depth: 0` for the diff range).
- **`Makefile`** — `make audit-harness` (verify blocking; rest advisory).
- **`.pre-commit-config.yaml`** — local `verify` hook so tampering is caught before commit.

## Test plan
Validated locally before wiring:
- `verify` → pass, 8 files pinned.
- `escape-scan` on this PR's own diff → `REFUSE=0 CHALLENGE=0 FLAG=0` (PASS).
- Negative: a synthetic diff dropping `fail_under` 65→50 → **REFUSE (exit 2)**, message cites the 65 floor read from `TESTING.md`.
- Negative: a synthetic diff adding `@pytest.mark.skip` → **CHALLENGE (exit 1)**.
- `bias` exits 1 (upstream bug) and `arch` exits 2 (not configured) — both confirmed harmless under the advisory `|| true`.
- Pre-commit hook fires: `audit-harness verify (hash-pin tamper check)......Passed`.

## Follow-ups (documented in tests/TESTING.md, not in this PR)
- Add an `.importlinter` layered contract (`models` ← `core`/`llm` ← `cli`/`ui`/`web`) and promote `arch` to blocking.
- Wire a `mutmut run` step, set `mutation.kill_rate`, and gate it.
- Upstream fix for the `bias-count.sh` pipefail-on-zero-match bug, then promote `bias` to a real threshold.