### PR TITLE
ci: gate live-test job to manual-only (workflow_dispatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:   # enables manual runs (e.g. the live-test job)
 
 permissions:
   contents: read
@@ -118,7 +119,12 @@ jobs:
   live-test:
     runs-on: ubuntu-latest
     needs: [drift-check, test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Manual-only. This job authenticates to GCP via WIF and runs tests/live/
+    # against Vertex AI, which is no longer in use — on a normal push it only
+    # fails. Trigger it by hand (Actions → CI → Run workflow) when a working
+    # GCP project is configured. Original auto-trigger:
+    #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Problem
The `live-test` job in `ci.yml` ran on every push to `main`: it authenticates to GCP via WIF and runs `tests/live/` against **Vertex AI**, which is no longer in use. Result — a guaranteed failure on every merge to main, same class of problem as the retired canary and deploy jobs.

## Change
Gated to manual-only, mirroring the canary fix:
- Added `workflow_dispatch` to the CI `on:` triggers.
- `live-test` now runs only on a manual **Run workflow** dispatch (`if: github.event_name == 'workflow_dispatch'`).
- The original auto-trigger (`push` + `refs/heads/main`) is preserved as a comment for one-line restoration.

Normal pushes/PRs no longer attempt the live API tests. Run them by hand (Actions → CI → Run workflow) once a working GCP project is configured — or after the live tests are repointed at a `gemini-key` setup.

## Test plan
- `ci.yml` parses; triggers = `push, pull_request, workflow_dispatch`; `live-test` `if` = `workflow_dispatch`.
- Passes the new harness gates: `verify` OK, `escape-scan` on this diff `REFUSE=0 CHALLENGE=0 FLAG=0`.
- `benchmark` (also push/main-gated) is left untouched — it runs local pytest-benchmark, hits no cloud/credits.

## Docs
None (CI config only).