### PR TITLE
feat(llm): make the planner genuinely bring-your-own-provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,18 +2,17 @@
 # Copy to .env and fill in values as needed
 
 # LLM Provider
-#   mock        — keyword matching, no API key (pipeline testing only, NOT real AI)
-#   gemini-key  — your own free Gemini API key; no GCP project needed (recommended)
-#   gemini      — Vertex AI via gcloud ADC; requires your own GCP project
+#   mock  — keyword matching, no API key (pipeline testing only, NOT real AI)
+#   <dotted path>  — your own provider: "package.module:YourProvider"
 CAD_LLM_PROVIDER=mock
 
-# Real AI — bring your own free Gemini key from https://aistudio.google.com/apikey
-# Set CAD_LLM_PROVIDER=gemini-key, then uncomment:
-# CAD_GEMINI_API_KEY=
-# CAD_GEMINI_MODEL=gemini-2.5-flash      # optional model override
-
-# Vertex AI path instead (CAD_LLM_PROVIDER=gemini) — set your OWN GCP project:
-# CAD_GCP_PROJECT=your-gcp-project-id
+# Bring your own provider for real AI: implement PlannerProvider
+# (src/cad_dxf_agent/llm/providers.py), then set the dotted import path, e.g.
+# CAD_LLM_PROVIDER=my_providers:MyProvider
+#
+# Your provider reads its own config (API key, endpoint, model) from the
+# environment in __init__ — add those vars here, e.g.:
+# MY_PROVIDER_API_KEY=
 
 # Protected layers (comma-separated, case-insensitive)
 CAD_PROTECTED_LAYERS=TITLE,TITLEBLOCK,SEAL,REVISION

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,23 +69,25 @@ cad-revision bundle master.dxf revision.dxf --output-dir ./bundle --approve-all
 make build
 ```
 
-### Dev Environment
+### Dev Environment + LLM provider
 
-Local dev uses a bring-your-own Gemini API key (free, no GCP project) — not mock mode. Get a key at https://aistudio.google.com/apikey.
+Local dev and CI default to `CAD_LLM_PROVIDER=mock` (keyword matching, no key).
+The LLM is **pluggable** — `get_provider()` (`llm/planner.py`) loads any
+`PlannerProvider` (`llm/providers.py`) from a dotted import path. For real-AI
+dev, implement one and point the env var at it:
 
 ```bash
 # .env (gitignored):
-CAD_LLM_PROVIDER=gemini-key
-CAD_GEMINI_API_KEY=your-key-here
+CAD_LLM_PROVIDER=my_providers:MyProvider   # package.module:ClassName
 ```
 
-CI tests use mock mode for determinism and speed. The `tests/live/` suite hits the real Gemini API — run it locally with your key:
+A bad path or non-`PlannerProvider` class raises at startup (no silent mock
+fallback). Bare unknown names (no `:`/`.`) still fall back to mock.
 
-```bash
-CAD_LLM_PROVIDER=gemini-key CAD_GEMINI_API_KEY=your-key pytest tests/live/ -v -m live_api -s
-```
-
-> Vertex AI (`CAD_LLM_PROVIDER=gemini` + `CAD_GCP_PROJECT=<your-project>`) is still supported for BYO-GCP setups. The `deploy-web.yml` / WIF live-test plumbing targets a specific GCP project — repoint it at your own before relying on it.
+> The repo still ships Gemini/Vertex provider implementations under `llm/`
+> (`gemini`, `gemini-key`, `agent`, `proxy`), but they are **not** the
+> documented path and not maintained as the default. The `tests/live/` suite +
+> the `live-test` CI job target those and are gated to manual (`workflow_dispatch`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Upload a DXF, PDF, or DWG — describe what you need in plain English, and get s
 | Revision comparison (CLI + web) | |
 | Web app (Firebase + Cloud Run, auto-deploy) | |
 | Desktop app (Windows + Linux) | |
-| Gemini vision pipeline (free API key or Vertex AI) | |
+| Pluggable LLM provider (bring your own) | |
 | OpenTelemetry tracing (console, OTLP, GCP Trace) | |
 
 For full details see:
@@ -148,7 +148,7 @@ cd web/frontend && npm run dev    # http://localhost:3000
 CAD_WEB_DEV_MODE=1 uvicorn web.backend.main:app --port 8322
 ```
 
-The backend reuses the same pipeline as the CLI and desktop app, so configure `CAD_LLM_PROVIDER` / `CAD_GEMINI_API_KEY` the same way (see [Using Real AI](#using-real-ai-bring-your-own-key)). A `deploy-web.yml` workflow exists for deploying to Cloud Run + Firebase Hosting, but it is wired to its operator's GCP project — repoint it at your own project and Firebase app before using it.
+The backend reuses the same pipeline as the CLI and desktop app, so configure `CAD_LLM_PROVIDER` the same way (see [Bring Your Own LLM Provider](#bring-your-own-llm-provider)). A `deploy-web.yml` workflow exists for deploying to Cloud Run + Firebase Hosting, but it is wired to its operator's cloud project — repoint it at your own before using it.
 
 ## Testing Without an API Key (Mock Mode)
 
@@ -164,38 +164,51 @@ python scripts/smoke_test.py
 
 The mock provider responds to keywords like "move", "delete", "text", "rename" in your prompt.
 
-## Using Real AI (bring your own key)
+## Bring Your Own LLM Provider
 
-The default `mock` provider only keyword-matches — it's for exercising the pipeline offline, not for real results. To get actual AI planning, bring your own Gemini API key. **No GCP project, billing setup, or `gcloud` required.**
+The default `mock` provider only keyword-matches — it's for exercising the pipeline offline, not for real results. The LLM is **fully pluggable**: the planner never sees raw DXF, it only returns a structured `ChangeSet`, so any model that can follow that contract works. Point `CAD_LLM_PROVIDER` at your own provider — no fork required.
 
-### Quickest path — free Gemini API key
+### 1. Implement the provider interface
+
+Subclass `PlannerProvider` (`src/cad_dxf_agent/llm/providers.py`):
+
+```python
+# my_providers.py
+from cad_dxf_agent.llm.providers import PlannerProvider
+from cad_dxf_agent.models.ops_schema import ChangeSet
+
+class MyProvider(PlannerProvider):
+    @property
+    def name(self) -> str:
+        return "my-provider"
+
+    def plan(
+        self,
+        prompt: str,
+        drawing_context: dict,
+        conversation_history: list[dict] | None = None,
+    ) -> ChangeSet:
+        # Call your model and return a validated ChangeSet of structured
+        # operations. The engine validates and applies them — the model never
+        # touches DXF. Read your own keys / endpoint / model from the
+        # environment in __init__.
+        ...
+```
+
+The contract is small (`plan()` + a `name`) and the provider must be constructible with no arguments.
+
+### 2. Point the app at it
+
+`CAD_LLM_PROVIDER` accepts a dotted import path — `package.module:ClassName`:
 
 ```bash
-# 1. Get a free key at https://aistudio.google.com/apikey
-# 2. Install the lightweight Gemini client
-pip install -e ".[gemini-key]"
-
-# 3. Point the app at your key
-export CAD_LLM_PROVIDER=gemini-key
-export CAD_GEMINI_API_KEY=your-key-here
-
-# 4. Run
+export CAD_LLM_PROVIDER=my_providers:MyProvider
 python -m cad_dxf_agent.app
 ```
 
-That's it — every capability (edit, compliance, takeoff, agent mode) runs on **your** key. Model defaults to `gemini-2.5-flash` (override with `CAD_GEMINI_MODEL`).
+The class is imported and validated as a `PlannerProvider` at startup. A bad path, or a class that isn't a `PlannerProvider`, **fails loudly** — it never silently degrades to mock and produces keyword-matched nonsense.
 
-### Advanced — Vertex AI (bring your own GCP project)
-
-If you already run on Google Cloud and prefer Vertex AI with Application Default Credentials:
-
-```bash
-gcloud auth application-default login
-pip install -e ".[gemini]"
-export CAD_LLM_PROVIDER=gemini
-export CAD_GCP_PROJECT=your-gcp-project-id   # your own project — not a shared one
-python -m cad_dxf_agent.app
-```
+> The `src/cad_dxf_agent/llm/` package contains existing provider implementations you can copy as a starting point.
 
 Both paths use tool-use with vision — the planner analyzes DXF renders and, for complex multi-step requests, runs an iterative agent loop (up to 10 turns) over 20+ query/edit tools. The `mock` provider remains available for offline pipeline testing.
 
@@ -361,10 +374,10 @@ The `StrategyRegistry` maps each (RequestClass, ObjectiveTag) pair to a `StagePi
 
 For complex requests, the `AgentProvider` runs an iterative tool-use loop:
 
-1. Sends prompt + drawing context + tool definitions to Gemini
-2. Gemini returns tool calls (query tools: list entities, find by layer; edit tools: move, delete, add)
+1. Sends prompt + drawing context + tool definitions to the LLM provider
+2. The provider returns tool calls (query tools: list entities, find by layer; edit tools: move, delete, add)
 3. `ToolExecutor` dispatches each call, enforcing protected-layer rules
-4. Results feed back to Gemini for next iteration (max 10 turns)
+4. Results feed back to the provider for the next iteration (max 10 turns)
 5. Final ChangeSet extracted from accumulated tool calls
 
 20+ tools split into query (read-only) and edit (state-changing) categories.

--- a/src/cad_dxf_agent/llm/planner.py
+++ b/src/cad_dxf_agent/llm/planner.py
@@ -23,6 +23,80 @@ logger = logging.getLogger(__name__)
 tracer = get_tracer(__name__)
 
 
+def _is_import_path(spec: str) -> bool:
+    """True if ``spec`` looks like a dotted import path to a custom provider.
+
+    Accepts ``package.module:Attr`` (canonical) or ``package.module.Attr``.
+    Bare names like ``openai`` or ``totally-unknown-xyz`` are NOT import paths
+    and fall through to the mock fallback, preserving existing behaviour.
+    """
+    return ":" in spec or "." in spec
+
+
+def _load_custom_provider(spec: str) -> PlannerProvider:
+    """Dynamically load a user-supplied :class:`PlannerProvider` (bring-your-own).
+
+    ``spec`` is ``package.module:Attr`` (preferred) or ``package.module.Attr``.
+    ``Attr`` may be a ``PlannerProvider`` subclass (instantiated with no
+    arguments) or an already-constructed ``PlannerProvider`` instance. A custom
+    provider reads its own configuration (keys, endpoints, model) from the
+    environment in its constructor.
+
+    Misconfiguration is a hard error — a broken custom provider never silently
+    falls back to mock, so failures surface immediately instead of producing
+    keyword-matched nonsense.
+
+    Raises:
+        ValueError: spec malformed, module/attribute unimportable, the attribute
+            is not constructible with no arguments, or the loaded object is not a
+            ``PlannerProvider``.
+    """
+    import importlib
+
+    if ":" in spec:
+        module_path, _, attr = spec.partition(":")
+    else:
+        module_path, _, attr = spec.rpartition(".")
+    if not module_path or not attr:
+        raise ValueError(
+            f"CAD_LLM_PROVIDER='{spec}' is not a valid provider import path. "
+            "Use 'your_package.module:YourProvider'."
+        )
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise ValueError(
+            f"CAD_LLM_PROVIDER='{spec}': could not import module '{module_path}' ({exc})."
+        ) from exc
+    try:
+        obj = getattr(module, attr)
+    except AttributeError as exc:
+        raise ValueError(
+            f"CAD_LLM_PROVIDER='{spec}': module '{module_path}' has no attribute '{attr}'."
+        ) from exc
+
+    if isinstance(obj, type):
+        try:
+            provider: object = obj()
+        except Exception as exc:
+            raise ValueError(
+                f"CAD_LLM_PROVIDER='{spec}': could not instantiate {attr}() — a custom "
+                "provider must be constructible with no arguments and read its config "
+                f"from the environment ({exc})."
+            ) from exc
+    else:
+        provider = obj
+
+    if not isinstance(provider, PlannerProvider):
+        raise ValueError(
+            f"CAD_LLM_PROVIDER='{spec}': {attr} must be a PlannerProvider subclass or "
+            f"instance, got {type(provider).__name__}."
+        )
+    logger.info("Loaded custom planner provider: %s", provider.name)
+    return provider
+
+
 def get_provider(
     provider_name: str | None = None,
     image_path: Path | None = None,
@@ -37,7 +111,8 @@ def get_provider(
         image_path: Optional path to a rendered PNG for vision-augmented planning.
         request_class: RequestClass value for tool narrowing (default "modify").
     """
-    name = (provider_name or settings.llm_provider).lower()
+    raw = provider_name or settings.llm_provider
+    name = raw.lower()
 
     if name == "mock":
         return MockProvider()
@@ -96,6 +171,11 @@ def get_provider(
 
             return MockAgentProvider()
 
+    # Bring-your-own-provider: an unknown name shaped like a dotted import path
+    # ("your_pkg.module:YourProvider") is loaded dynamically and validated as a
+    # PlannerProvider. Bare unknown names fall back to mock.
+    if _is_import_path(raw):
+        return _load_custom_provider(raw)
     logger.warning("Unknown provider '%s', falling back to mock", name)
     return MockProvider()
 

--- a/tests/unit/test_provider_byo.py
+++ b/tests/unit/test_provider_byo.py
@@ -1,0 +1,91 @@
+"""Bring-your-own-provider: dynamic loading of a custom PlannerProvider.
+
+`get_provider()` accepts a dotted import path ("package.module:Attr" or
+"package.module.Attr") and loads any PlannerProvider — no fork of the planner
+dispatch required. Misconfiguration is a hard error, never a silent mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cad_dxf_agent.llm.planner import get_provider
+from cad_dxf_agent.llm.providers import PlannerProvider
+
+# This test module is already imported by pytest, so it is importable by name —
+# we reference the providers defined below via "<this module>:<Attr>".
+MOD = __name__
+
+
+class GoodProvider(PlannerProvider):
+    """A minimal valid custom provider, constructible with no arguments."""
+
+    @property
+    def name(self) -> str:
+        return "byo-good"
+
+    def plan(self, prompt, drawing_context, conversation_history=None):  # noqa: D102
+        raise NotImplementedError("not exercised — these tests cover loading only")
+
+
+# A module-level, already-constructed instance (loading an instance, not a class).
+good_instance = GoodProvider()
+
+
+class NotAProvider:
+    """Deliberately NOT a PlannerProvider."""
+
+
+class NeedsArgs(PlannerProvider):
+    """Custom provider with a required constructor arg — must fail to load."""
+
+    def __init__(self, required):  # no default → not no-arg constructible
+        self._required = required
+
+    @property
+    def name(self) -> str:
+        return "needs-args"
+
+    def plan(self, prompt, drawing_context, conversation_history=None):  # noqa: D102
+        raise NotImplementedError
+
+
+class TestBringYourOwnProvider:
+    def test_loads_class_via_colon(self):
+        provider = get_provider(f"{MOD}:GoodProvider")
+        assert isinstance(provider, PlannerProvider)
+        assert provider.name == "byo-good"
+
+    def test_loads_class_via_dotted_real_module(self):
+        # Stable dotted path: the shipped MockProvider, loaded as a custom path.
+        provider = get_provider("cad_dxf_agent.llm.mock_provider.MockProvider")
+        assert isinstance(provider, PlannerProvider)
+        assert provider.name == "mock"
+
+    def test_loads_an_already_constructed_instance(self):
+        provider = get_provider(f"{MOD}:good_instance")
+        assert provider is good_instance
+
+    def test_bad_module_raises_value_error(self):
+        with pytest.raises(ValueError, match="could not import module"):
+            get_provider("no.such.module_xyz:Whatever")
+
+    def test_missing_attribute_raises_value_error(self):
+        with pytest.raises(ValueError, match="no attribute"):
+            get_provider(f"{MOD}:DoesNotExist")
+
+    def test_attribute_not_a_provider_raises(self):
+        with pytest.raises(ValueError, match="must be a PlannerProvider"):
+            get_provider(f"{MOD}:NotAProvider")
+
+    def test_constructor_requiring_args_raises_clear_error(self):
+        with pytest.raises(ValueError, match="no arguments"):
+            get_provider(f"{MOD}:NeedsArgs")
+
+    def test_bare_unknown_name_still_falls_back_to_mock(self):
+        # Regression: names without ':' or '.' are NOT import paths.
+        provider = get_provider("totally-unknown-xyz")
+        assert provider.name == "mock"
+
+    def test_builtin_names_unaffected(self):
+        assert get_provider("mock").name == "mock"


### PR DESCRIPTION
## Bead(s)
cad-dxf-agent-jvc

## Problem
The project was *documented* as bring-your-own-provider, but it wasn't **built** for it. `get_provider()` hardcoded a closed list of names (`mock`, `gemini`/`vertex`, `gemini-key`, `agent`, `proxy`) — every real one Gemini-based — so an outsider could not plug in their own LLM without forking the dispatch. (Compounding it: the prior onboarding headlined a "free Gemini key," which is wrong on both counts — that engine is retired and not free.)

## Change
`CAD_LLM_PROVIDER` now also accepts a **dotted import path** — `package.module:YourProvider` (or `package.module.YourProvider`). It's dynamically imported, instantiated with no args, and validated as a `PlannerProvider`. The only contract is `plan()` + a `name` property.

**Fails loudly, never silently:**
- bad module / missing attribute / not-a-`PlannerProvider` / constructor that needs args → clear `ValueError`
- bare unknown names (no `:`/`.`) still fall back to mock — **prior behaviour preserved**

Docs rewritten **vendor-neutral**: `mock` is the offline try-it path; real use = implement `PlannerProvider` and point the env var at it. No provider is recommended or named as "the" path; the bundled implementations under `llm/` are noted as copyable references only.

## Files
- `src/cad_dxf_agent/llm/planner.py` — `_is_import_path()` + `_load_custom_provider()`
- `tests/unit/test_provider_byo.py` — 9 tests
- `README.md` — new "Bring Your Own LLM Provider" section; neutralized scope row, web-app note, agent-loop prose
- `.env.example` — provider-neutral
- `CLAUDE.md` — dev section documents the pluggable provider

## Test plan
- `pytest tests/unit/test_provider_byo.py` → 9 pass (colon + dotted load, instance load, bad-module / missing-attr / not-a-provider / needs-args errors, bare-name → mock fallback).
- `test_planner_providers.py` + `test_agent_provider.py` + `test_proxy_client.py` + `test_gemini_provider.py` → 95 pass (no regression in built-in routing).
- `scripts/smoke_test.py` → exit 0. `ruff` / `ruff format --check` / `mypy src/` (124 files) → clean.
- Harness gates on this diff: `verify` OK, `escape-scan` `REFUSE=0 CHALLENGE=0 FLAG=0`.

## Note
The bundled Gemini/Vertex providers (`gemini_provider.py`, `gemini_key_provider.py`, `agent_provider.py`, `proxy_client.py`) are **kept** as optional/built-in, just no longer the documented or default path. Deleting them is a larger, separate demolition (their own tests, the agent loop, ToolExecutor) — out of scope here unless you want it.