### PR TITLE
chore(ci): delete parked cron blocks from canary-monitoring and security workflows

### DIFF
--- a/.github/workflows/canary-monitoring.yml
+++ b/.github/workflows/canary-monitoring.yml
@@ -2,10 +2,7 @@ name: Production Canary Monitoring
 
 on:
   # Manual-only. The hosted demo instance this canary tested was retired, so the
-  # daily run only produced guaranteed failures. Re-add the schedule below if a
-  # public instance is ever restood:
-  #   schedule:
-  #     - cron: '0 8 * * *'   # daily at 8am UTC
+  # daily run only produced guaranteed failures.
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # schedule disabled — burns Actions minutes
-  # schedule:
-  #   - cron: '0 6 * * 1'  # Weekly Monday 6 AM UTC
 
 permissions:
   contents: read


### PR DESCRIPTION
**What:** Delete the commented-out `schedule:`/`cron:` blocks from `canary-monitoring.yml` (also drops the "re-add the schedule" pointer while keeping the still-true manual-only/demo-retired context) and `security.yml` (plus its orphaned "schedule disabled" header). Live `workflow_dispatch`/`push`/`pull_request` triggers untouched.

**Why:** 2026-07-10 estate automation remediation — a commented cron block is a zombie: it looks like an automation, shows up in audits, and tempts silent re-enable. Git history preserves it; revival is a reviewed PR away.

**Refs:** intent-solutions-io/intent-os#42

- Jeremy Longshore
intentsolutions.io