### PR TITLE
fix(test): repair real-world persona fixtures

### DIFF
--- a/000-docs/072-TQ-TEST-realworld-user-profiles.md
+++ b/000-docs/072-TQ-TEST-realworld-user-profiles.md
@@ -12,7 +12,7 @@
 
 The existing E2E test suite uses the same `r2000_blocks.dxf` for all 15 conversations and 20 canary prompts. Real users upload wildly different drawings. This profile system simulates 25 different AEC professionals, each with their own documents, workflows, multi-turn conversations, and expected responses.
 
-**Document variety:** 17 unique DXF files + 5 unique PDFs = 22 distinct documents
+**Document variety:** 19 unique DXF files + 4 unique PDFs = 23 distinct documents. Profile 15 intentionally reuses the Profile 3 floor-plan fixture, and Profiles 12 and 18 intentionally reuse the sawcut plan, so the same drawings are exercised through distinct professional workflows.
 **Format coverage:** 20 DXF uploads + 5 PDF uploads = 25% PDF coverage (vs current: 0%)
 
 Each profile defines:
@@ -38,10 +38,10 @@ Each profile defines:
 | 9 | Fire Protection Eng. | Circle/arc layout | `tests/fixtures/dxf_zoo/sourced/jscad-2Dcircles.dxf` | DXF | add_circle, compliance, Q&A |
 | 10 | GC Superintendent | Structural plan (PDF) | `tests/fixtures/test_pdfs/structural_plan.pdf` | PDF | summary, Q&A, health |
 | 11 | Estimator | Foundation detail (PDF) | `tests/fixtures/test_pdfs/foundation_detail.pdf` | PDF | takeoff, Q&A, summary |
-| 12 | Code Compliance Officer | Stamped plan set (PDF) | `000-docs/aMULBERRYdsn01.1-STAMPED-SEALED.pdf` | PDF | compliance, RFI, health |
+| 12 | Code Compliance Officer | Site plan (PDF) | `000-docs/032-TQ-TEST-sawcuts-sample-drawing.pdf` | PDF | compliance, RFI, health |
 | 13 | Interior Designer | Text-heavy drawing | `tests/fixtures/dxf_zoo/sourced/jscad-texts.dxf` | DXF | edit_text, summary, zone, add_text |
 | 14 | Civil Engineer | Polyline site plan | `tests/fixtures/dxf_zoo/sourced/jscad-2Dpolylines.dxf` | DXF | add_polyline, move, scale, Q&A |
-| 15 | Landscape Designer | Landscape site plan | `tests/fixtures/dxf_zoo/sourced/jscad-floorplan.dxf` | DXF | compliance (MWELO), takeoff, summary, edit, Q&A, health |
+| 15 | Landscape Designer (HeyFlora.ai) | Landscape site plan | `tests/fixtures/dxf_zoo/sourced/jscad-floorplan.dxf` | DXF | compliance (MWELO), takeoff, summary, edit, Q&A, health |
 | 16 | Construction Manager | Revision pair | `tests/fixtures/revision/clean_realworld/master.dxf` + `revision.dxf` | DXF | compare, summary, Q&A |
 | 17 | Project Manager | Simple geometry (PDF) | `tests/fixtures/test_pdfs/simple_geometry.pdf` | PDF | summary, Q&A (non-technical) |
 | 18 | Plan Reviewer (City) | Sawcut drawing (PDF) | `000-docs/032-TQ-TEST-sawcuts-sample-drawing.pdf` | PDF | compliance, RFI, health |
@@ -51,7 +51,7 @@ Each profile defines:
 | 22 | Solar Installer | Rectangle layout | `tests/fixtures/dxf_zoo/sourced/jscad-2Drectangles.dxf` | DXF | add_block (panels), copy, batch, takeoff |
 | 23 | BIM Coordinator | Modern polylines | `tests/fixtures/dxf_zoo/r2018_polylines.dxf` | DXF | health, compare, Q&A, summary |
 | 24 | Junior Drafter/Intern | Layers + empty | `tests/fixtures/dxf_zoo/sourced/jscad-layers.dxf` | DXF | Q&A (learning), move, edit_text, summary |
-| 25 | Landscape Field Crew Lead | Arc/curve plan | `tests/fixtures/dxf_zoo/sourced/jscad-2Darcs.dxf` | DXF | Q&A, summary, health, takeoff |
+| 25 | Landscape Field Crew Lead (HeyFlora.ai) | Arc/curve plan | `tests/fixtures/dxf_zoo/sourced/jscad-2Darcs.dxf` | DXF | Q&A, summary, health, takeoff |
 
 ---
 
@@ -416,7 +416,7 @@ Verification that all platform capabilities appear in at least two profiles:
 ### Profile 12 — Code Compliance Officer
 
 **Who:** Officer Patricia Nelson, senior plan reviewer at the City of Mulberry Building Department. 18 years of plan review experience. Processes 15-20 permit applications per week across residential and commercial projects.
-**Document:** `000-docs/aMULBERRYdsn01.1-STAMPED-SEALED.pdf` (PDF)
+**Document:** `000-docs/032-TQ-TEST-sawcuts-sample-drawing.pdf` (PDF)
 **Business context:** The plan review queue is backed up. Patricia needs to quickly check submitted plans for code compliance, flag deficiencies, and generate RFIs (Requests for Information) for anything that doesn't meet code. Her department has a 10-business-day turnaround requirement.
 
 #### Capabilities exercised
@@ -502,7 +502,7 @@ Verification that all platform capabilities appear in at least two profiles:
 
 ---
 
-### Profile 15 — Landscape Designer
+### Profile 15 — Landscape Designer (HeyFlora.ai workflow)
 
 **Who:** Maya Greenfield, RLA (Registered Landscape Architect) at GreenEdge Design-Build, specializing in water-efficient landscape design. 9 years of experience in drought-tolerant commercial landscapes in Southern California. Currently designing a 2-acre water-efficient landscape for a new corporate campus in Irvine.
 **Document:** `tests/fixtures/dxf_zoo/sourced/jscad-floorplan.dxf` (DXF)
@@ -536,7 +536,7 @@ Verification that all platform capabilities appear in at least two profiles:
 
 #### Landscape management integration context
 
-This profile models the landscape management vertical — a $150B professional sector that relies on drawing analysis for compliance, bidding, and field operations. Landscape design firms need to:
+This profile models a HeyFlora.ai landscape-design workflow in the landscape management vertical — a $150B professional sector that relies on drawing analysis for compliance, bidding, and field operations. Landscape design firms need to:
 - Read DXF/PDF site plans and extract plant counts for bid pricing
 - Check spatial compliance against water-efficiency ordinances (MWELO, LEED)
 - Generate client-facing summaries for proposals and reports
@@ -814,7 +814,7 @@ This profile models the landscape management vertical — a $150B professional s
 
 ---
 
-### Profile 25 — Landscape Field Crew Lead
+### Profile 25 — Landscape Field Crew Lead (HeyFlora.ai workflow)
 
 **Who:** Marcus Thompson, landscape crew lead at Green Valley Landscapes. 8 years of hands-on landscape installation experience. Reviews plans on a ruggedized tablet at the job site. Prefers short, direct answers — voice-first interaction style.
 **Document:** `tests/fixtures/dxf_zoo/sourced/jscad-2Darcs.dxf` (DXF)
@@ -844,7 +844,7 @@ This profile models the landscape management vertical — a $150B professional s
 
 #### Landscape field operations context
 
-This profile models the field crew use case for landscape management — the person who reads plans on a tablet at the job site. Voice-first interaction style: short, direct questions about what's where and what to build. Field crews need:
+This profile models a HeyFlora.ai field-crew workflow for landscape management — the person who reads plans on a tablet at the job site. Voice-first interaction style: short, direct questions about what's where and what to build. Field crews need:
 - Spatial Q&A ("what's in the northeast corner?") routed through drawing analysis
 - Quick field briefs summarizing scope for crew huddles
 - Health checks that flag drawing issues before concrete pours or installations

--- a/tests/fixtures/realworld_profile_conversations.json
+++ b/tests/fixtures/realworld_profile_conversations.json
@@ -356,7 +356,7 @@
   {
     "id": "profile-12",
     "title": "Profile 12 — Code Compliance Officer — plan check review",
-    "drawing_fixture": "000-docs/aMULBERRYdsn01.1-STAMPED-SEALED.pdf",
+    "drawing_fixture": "000-docs/032-TQ-TEST-sawcuts-sample-drawing.pdf",
     "profile": {
       "id": "12",
       "role": "Code Compliance Officer",
@@ -456,12 +456,12 @@
   },
   {
     "id": "profile-15",
-    "title": "Profile 15 — Landscape Designer — water-efficient landscape proposal",
+    "title": "Profile 15 — Landscape Designer (HeyFlora.ai) — water-efficient landscape proposal",
     "drawing_fixture": "tests/fixtures/dxf_zoo/sourced/jscad-floorplan.dxf",
     "profile": {
       "id": "15",
       "role": "Landscape Designer",
-      "context": "Water-efficient commercial landscape design, client proposal due next week"
+      "context": "HeyFlora.ai water-efficient commercial landscape design, client proposal due next week"
     },
     "turns": [
       {
@@ -784,12 +784,12 @@
   },
   {
     "id": "profile-25",
-    "title": "Profile 25 — Landscape Field Crew Lead — hardscape installation brief",
+    "title": "Profile 25 — Landscape Field Crew Lead (HeyFlora.ai) — hardscape installation brief",
     "drawing_fixture": "tests/fixtures/dxf_zoo/sourced/jscad-2Darcs.dxf",
     "profile": {
       "id": "25",
       "role": "Landscape Field Crew Lead",
-      "context": "On-site for hardscape installation, using tablet"
+      "context": "HeyFlora.ai on-site hardscape installation workflow, using tablet"
     },
     "turns": [
       {

--- a/tests/unit/test_realworld_profile_fixtures.py
+++ b/tests/unit/test_realworld_profile_fixtures.py
@@ -1,0 +1,38 @@
+"""Integrity checks for the real-world AEC persona E2E corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CORPUS_PATH = ROOT / "tests/fixtures/realworld_profile_conversations.json"
+
+
+def _profiles() -> list[dict[str, object]]:
+    return json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def test_realworld_profile_corpus_has_expected_document_coverage() -> None:
+    profiles = _profiles()
+    fixtures = [profile["drawing_fixture"] for profile in profiles]
+
+    assert len(profiles) == 25
+    assert len(set(fixtures)) == 23
+    assert sum(path.endswith(".dxf") for path in fixtures) == 20
+    assert sum(path.endswith(".pdf") for path in fixtures) == 5
+    assert len({path for path in fixtures if path.endswith(".pdf")}) == 4
+    assert all((ROOT / path).is_file() for path in fixtures)
+
+
+def test_realworld_profile_corpus_identifies_two_heyflora_workflows() -> None:
+    profiles = _profiles()
+    heyflora = [
+        profile
+        for profile in profiles
+        if "HeyFlora.ai" in profile["title"]
+        and "HeyFlora.ai" in profile["profile"]["context"]
+    ]
+
+    assert [profile["id"] for profile in heyflora] == ["profile-15", "profile-25"]


### PR DESCRIPTION
Repairs the missing profile-12 fixture reference, aligns documented corpus counts with the committed files, identifies the two HeyFlora.ai workflows, and adds deterministic corpus-integrity coverage.\n\nValidation: `uv run --with pytest --with ezdxf pytest tests/unit/test_realworld_profile_fixtures.py -q`.